### PR TITLE
Fix whitespace to properly align pseudographic charts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Container vulnerabilities are a top attack vector. Most base images ship with do
 
 ```
 Traditional images:     Your containers:
-┌──────────────────┐    ┌──────────────────┐
-│ debian:latest    │    │ minimal-python   │
-│ 127 CVEs         │    │ 0-5 CVEs         │
-│ Patched: ~30 days│    │ Patched: <48 hrs │
-└──────────────────┘    └──────────────────┘
+┌───────────────────┐    ┌──────────────────┐
+│ debian:latest     │    │ minimal-python   │
+│ 127 CVEs          │    │ 0-5 CVEs         │
+│ Patched: ~30 days │    │ Patched: <48 hrs │
+└───────────────────┘    └──────────────────┘
 ```
 
 **Impact:**
@@ -92,18 +92,18 @@ docker run -d -p 5432:5432 -v pgdata:/var/lib/postgresql/data ghcr.io/rtvkiz/min
 │  Package Source            Image Assembly           Verification    │
 │  ──────────────           ──────────────           ──────────────   │
 │                                                                     │
-│  ┌─────────────┐          ┌────────────┐          ┌────────────┐   │
-│  │   Wolfi     │─────────▶│    apko    │─────────▶│   Trivy    │   │
-│  │ (pre-built) │  install │ (OCI image)│  scan    │ (CVE gate) │   │
-│  │ Python, Go, │          │            │          │            │   │
-│  │ Node, etc.  │          │            │          │            │   │
-│  └─────────────┘          └─────┬──────┘          └─────┬──────┘   │
-│                                 │                       │          │
-│  ┌─────────────┐                │                       ▼          │
-│  │   melange   │────────────────┘              ┌────────────────┐  │
-│  │ (Jenkins,   │  build from                   │ cosign + SBOM  │  │
-│  │  Redis)     │  source                       │ (sign & publish│  │
-│  └─────────────┘                               └────────────────┘  │
+│  ┌─────────────┐          ┌────────────┐          ┌─────────────┐   │
+│  │   Wolfi     │─────────▶│    apko    │─────────▶│   Trivy     │   │
+│  │ (pre-built) │  install │ (OCI image)│  scan    │ (CVE gate)  │   │
+│  │ Python, Go, │          │            │          │             │   │
+│  │ Node, etc.  │          │            │          │             │   │
+│  └─────────────┘          └─────┬──────┘          └─────┬───────┘   │
+│                                 │                       │           │
+│  ┌─────────────┐                │                       ▼           │
+│  │   melange   │────────────────┘              ┌─────────────────┐  │
+│  │ (Jenkins,   │  build from                   │ cosign + SBOM   │  │
+│  │  Redis)     │  source                       │ (sign & publish │  │
+│  └─────────────┘                               └─────────────────┘  │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
* Make the build diagram's right border align.
* Make the image comparison diagram have consistent whitespace padding.