### PR TITLE
chore(opensearch): upgrade to major version 3.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VICTORIA_METRICS_VERSION ?= 1.138.0
 JAEGER_VERSION ?= 2.17.0
 OTELCOL_VERSION ?= 0.149.0
 QDRANT_VERSION ?= 1.17.1
-OPENSEARCH_VERSION ?= 2.19.5
+OPENSEARCH_VERSION ?= 3.5.0
 
 .PHONY: all build scan clean help
 .PHONY: python jenkins jenkins-melange go node-slim nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet java php php-melange rails rails-melange kafka kafka-melange keygen opensearch

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Patch updates are auto-PR'd and validated by CI. Minor/major version bumps (e.g.
 | Kafka | 4.2.x | kafka (65532) | `/usr/bin/kafka-entrypoint.sh` | `/` |
 | RabbitMQ | 4.2.x | rabbitmq (65532) | `/opt/rabbitmq/sbin/rabbitmq-server` | `/` |
 | MinIO | RELEASE.2025-10-15T17-29-55Z | minio (65532) | `/usr/bin/minio server --console-address :9001 /data` | `/data` |
-| OpenSearch | 2.19.5 | opensearch (65532) | `/usr/share/opensearch/opensearch-docker-entrypoint.sh` | `/usr/share/opensearch/data` |
+| OpenSearch | 3.5.x | opensearch (65532) | `/usr/share/opensearch/opensearch-docker-entrypoint.sh` | `/usr/share/opensearch/data` |
 | etcd | 3.6.x | nonroot (65532) | `/usr/bin/etcd` | `/var/lib/etcd` |
 | VictoriaMetrics | 1.138.x | nonroot (65532) | `/usr/bin/victoria-metrics` | `/` |
 | Jaeger | 2.17.x | nonroot (65532) | `/usr/bin/jaeger` | `/` |

--- a/opensearch/apko/opensearch.yaml
+++ b/opensearch/apko/opensearch.yaml
@@ -1,5 +1,5 @@
-# Minimal OpenSearch image - using Wolfi's pre-built opensearch-2 package
-# OpenSearch 2.x with OpenJDK 17 JRE
+# Minimal OpenSearch image - using Wolfi's pre-built opensearch-3 package
+# OpenSearch 3.x with OpenJDK 21 JRE
 # CVE patching via daily Wolfi package rebuilds
 
 contents:
@@ -11,8 +11,8 @@ contents:
     # Base filesystem
     - wolfi-baselayout
 
-    # OpenSearch 2.x from Wolfi (pulls openjdk-17-jre, bash, busybox, curl)
-    - opensearch-2
+    # OpenSearch 3.x from Wolfi (pulls openjdk-21-jre, bash, busybox, curl)
+    - opensearch-3
 
     # Core runtime libraries
     - glibc
@@ -38,8 +38,8 @@ entrypoint:
 environment:
   OPENSEARCH_HOME: /usr/share/opensearch
   OPENSEARCH_PATH_CONF: /usr/share/opensearch/config
-  # Point entrypoint to Wolfi's openjdk-17-jre (no bundled JDK in Wolfi package)
-  OPENSEARCH_JAVA_HOME: /usr/lib/jvm/java-17-openjdk
+  # Point entrypoint to Wolfi's openjdk-21-jre (no bundled JDK in Wolfi package)
+  OPENSEARCH_JAVA_HOME: /usr/lib/jvm/java-21-openjdk
   # Disable security plugin demo config — users configure TLS for production
   DISABLE_INSTALL_DEMO_CONFIG: "true"
   # Disable security plugin entirely for simple single-node dev usage
@@ -75,7 +75,7 @@ paths:
 
 annotations:
   org.opencontainers.image.title: "minimal-opensearch"
-  org.opencontainers.image.description: "Hardened OpenSearch 2.x image on Wolfi with OpenJDK 17, daily CVE patches"
+  org.opencontainers.image.description: "Hardened OpenSearch 3.x image on Wolfi with OpenJDK 21, daily CVE patches"
   org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
   org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/opensearch"
   org.opencontainers.image.licenses: "Apache-2.0"


### PR DESCRIPTION
## Summary

Updates OpenSearch to major version **3.x** (latest: 3.5.0).

## Changes

- opensearch/apko/opensearch.yaml: switched to opensearch-3 Wolfi package and updated to OpenJDK 21.
- Makefile: updated OPENSEARCH_VERSION to 3.5.0.
- README.md: updated image version table.

Closes #43