### PR TITLE
fix(opensearch): update build.yml primary_grep to match version 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
             primary_grep: "openjdk-[0-9].*-jre"
           - name: opensearch
             apko_config: opensearch/apko/opensearch.yaml
-            primary_grep: "opensearch-2"
+            primary_grep: "opensearch-3"
           - name: deno
             apko_config: deno/apko/deno.yaml
             primary_grep: "deno"


### PR DESCRIPTION
Fixes the recently introduced build failure on main where opensearch-3 package was not being correctly identified in build.yml.