### PR TITLE
add minimal-envoy container image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,14 @@ jobs:
             melange_config: qdrant/melange.yaml
             arch: aarch64
             runner: ubuntu-24.04-arm
+          - name: envoy
+            melange_config: envoy/melange.yaml
+            arch: x86_64
+            runner: ubuntu-latest
+          - name: envoy
+            melange_config: envoy/melange.yaml
+            arch: aarch64
+            runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -632,6 +640,10 @@ jobs:
           - name: qdrant
             apko_config: qdrant/apko/qdrant.yaml
             melange_config: qdrant/melange.yaml
+            arches: x86_64,aarch64
+          - name: envoy
+            apko_config: envoy/apko/envoy.yaml
+            melange_config: envoy/melange.yaml
             arches: x86_64,aarch64
 
     steps:

--- a/.github/workflows/update-envoy.yml
+++ b/.github/workflows/update-envoy.yml
@@ -1,0 +1,153 @@
+name: Update Envoy Version
+
+on:
+  schedule:
+    # Check daily at 6:30am UTC
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Check for new Envoy stable version
+        id: check
+        run: |
+          # Get latest stable release from GitHub API
+          LATEST=$(curl -sS --retry 3 --retry-delay 5 "https://api.github.com/repos/envoyproxy/envoy/releases" | \
+            python3 -c "
+import sys, json
+releases = json.load(sys.stdin)
+for r in releases:
+    if r.get('prerelease', False):
+        continue
+    print(r['tag_name'].lstrip('v'))
+    break
+" 2>/dev/null)
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::Failed to fetch latest Envoy version from GitHub API"
+            exit 1
+          fi
+
+          # Validate version format (e.g., 1.37.1)
+          if ! [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid Envoy version received: $LATEST"
+            exit 1
+          fi
+
+          # Get current version from melange.yaml
+          CURRENT=$(grep '^  version:' envoy/melange.yaml | awk '{print $2}')
+
+          echo "Current version: $CURRENT"
+          echo "Latest version: $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ]; then
+            echo "update_available=true" >> $GITHUB_OUTPUT
+            echo "new_version=$LATEST" >> $GITHUB_OUTPUT
+            echo "current_version=$CURRENT" >> $GITHUB_OUTPUT
+            echo "Update available: $CURRENT -> $LATEST"
+          else
+            echo "update_available=false" >> $GITHUB_OUTPUT
+            echo "Already up to date"
+          fi
+
+      - name: Update version and checksums in all files
+        if: steps.check.outputs.update_available == 'true'
+        run: |
+          VERSION="${{ steps.check.outputs.new_version }}"
+          echo "Updating to Envoy $VERSION"
+
+          # Download checksums and compute SHA256 for both architectures
+          echo "Fetching checksums for Envoy $VERSION..."
+          CHECKSUMS=$(curl -fsSL --retry 3 --retry-delay 5 "https://github.com/envoyproxy/envoy/releases/download/v${VERSION}/checksums.txt.asc" 2>/dev/null || echo "")
+
+          # For x86_64
+          SHA256_X86=$(echo "$CHECKSUMS" | grep "envoy-${VERSION}-linux-x86_64" | awk '{print $1}')
+          # For aarch64 (note: Envoy uses "aarch_64" not "aarch64")
+          SHA256_ARM=$(echo "$CHECKSUMS" | grep "envoy-${VERSION}-linux-aarch_64" | awk '{print $1}')
+
+          if [ -z "$SHA256_X86" ] || [ -z "$SHA256_ARM" ]; then
+            echo "Warning: Could not fetch checksums from signed file, downloading directly..."
+
+            # Download x86_64 and compute checksum
+            curl -fsSL --retry 3 --retry-delay 5 "https://github.com/envoyproxy/envoy/releases/download/v${VERSION}/envoy-${VERSION}-linux-x86_64" \
+              -o /tmp/envoy-x86_64
+            SHA256_X86=$(sha256sum /tmp/envoy-x86_64 | awk '{print $1}')
+
+            # Download aarch64 and compute checksum
+            curl -fsSL --retry 3 --retry-delay 5 "https://github.com/envoyproxy/envoy/releases/download/v${VERSION}/envoy-${VERSION}-linux-aarch_64" \
+              -o /tmp/envoy-aarch_64
+            SHA256_ARM=$(sha256sum /tmp/envoy-aarch_64 | awk '{print $1}')
+
+            rm -f /tmp/envoy-x86_64 /tmp/envoy-aarch_64
+          fi
+
+          echo "SHA256 x86_64: $SHA256_X86"
+          echo "SHA256 aarch64: $SHA256_ARM"
+
+          # Update envoy/melange.yaml - version
+          sed -i "s/^  version: .*/  version: $VERSION/" envoy/melange.yaml
+
+          # Update envoy/melange.yaml - checksums
+          sed -i "s/^  sha256_x86: .*/  sha256_x86: $SHA256_X86/" envoy/melange.yaml
+          sed -i "s/^  sha256_arm: .*/  sha256_arm: $SHA256_ARM/" envoy/melange.yaml
+
+          # Reset epoch to 0 for new upstream version
+          sed -i "s/^  epoch: .*/  epoch: 0/" envoy/melange.yaml
+
+          # Update Makefile
+          sed -i "s/^ENVOY_VERSION ?= .*/ENVOY_VERSION ?= $VERSION/" Makefile
+
+          # Verify changes
+          echo "=== envoy/melange.yaml ==="
+          grep -E '(version:|sha256_)' envoy/melange.yaml | head -3
+          echo "=== Makefile ==="
+          grep 'ENVOY_VERSION' Makefile
+
+      - name: Create Pull Request
+        if: steps.check.outputs.update_available == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore(envoy): bump to ${{ steps.check.outputs.new_version }}"
+          body: |
+            ## Summary
+
+            Updates Envoy from `${{ steps.check.outputs.current_version }}` to `${{ steps.check.outputs.new_version }}`.
+
+            ## Changes
+
+            - `envoy/melange.yaml` - package version, SHA256 checksums, epoch reset
+            - `Makefile` - ENVOY_VERSION variable
+
+            ## Image Tag
+
+            Once merged, this will publish: `ghcr.io/rtvkiz/minimal-envoy:${{ steps.check.outputs.new_version }}-r0`
+
+            ## Links
+
+            - [Envoy Releases](https://github.com/envoyproxy/envoy/releases)
+            - [Release Notes for ${{ steps.check.outputs.new_version }}](https://github.com/envoyproxy/envoy/releases/tag/v${{ steps.check.outputs.new_version }})
+
+            ---
+
+            This PR was automatically created by the [update-envoy](${{ github.server_url }}/${{ github.repository }}/actions/workflows/update-envoy.yml) workflow.
+          branch: update-envoy-${{ steps.check.outputs.new_version }}
+          commit-message: |
+            chore(envoy): bump to ${{ steps.check.outputs.new_version }}
+
+            Updates Envoy from ${{ steps.check.outputs.current_version }} to ${{ steps.check.outputs.new_version }}.
+          delete-branch: true
+          labels: |
+            dependencies
+            envoy

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ RABBITMQ_VERSION ?= 4.2.5
 CADDY_VERSION ?= 2.11.2
 HAPROXY_VERSION ?= 3.3.0
 TRAEFIK_VERSION ?= 3.6.12
+ENVOY_VERSION ?= 1.37.1
 
 # --- Observability ---
 PROMETHEUS_VERSION ?= 3.11.0
@@ -46,16 +47,16 @@ OPENSEARCH_VERSION ?= 3.5.0
 
 .PHONY: all build scan clean help
 .PHONY: python jenkins jenkins-melange go node-slim nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet java php php-melange rails rails-melange kafka kafka-melange keygen opensearch
-.PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange rabbitmq rabbitmq-melange minio minio-melange
+.PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange grafana grafana-melange mariadb mariadb-melange
 .PHONY: etcd etcd-melange victoria-metrics victoria-metrics-melange jaeger jaeger-melange otelcol otelcol-melange qdrant qdrant-melange deno
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-grafana scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno
-.PHONY: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-php test-rails test-kafka test-valkey test-nats test-traefik test-rabbitmq test-minio test-opensearch test-prometheus test-grafana test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno
+.PHONY: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-grafana test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno
 
 all: build scan
 
 # Build all images
-build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java php rails kafka valkey nats traefik rabbitmq minio opensearch prometheus grafana mariadb etcd victoria-metrics jaeger otelcol qdrant deno
+build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus grafana mariadb etcd victoria-metrics jaeger otelcol qdrant deno
 
 #------------------------------------------------------------------------------
 # SIGNING KEY (required for melange packages)
@@ -408,6 +409,32 @@ traefik: traefik-melange
 		$(REGISTRY)/$(OWNER)/minimal-traefik:latest
 	@rm -f traefik.tar sbom-*.spdx.json
 	@echo "✓ minimal-traefik built (source build)"
+
+#------------------------------------------------------------------------------
+# ENVOY IMAGE (melange official binary release + apko)
+#------------------------------------------------------------------------------
+envoy-melange: keygen
+	@echo "Building Envoy $(ENVOY_VERSION) from upstream releases via melange..."
+	melange build envoy/melange.yaml \
+		--arch x86_64,aarch64 \
+		--signing-key melange.rsa
+	@echo "✓ Envoy package built"
+
+envoy: envoy-melange
+	@echo "Assembling minimal-envoy image with apko..."
+	apko build envoy/apko/envoy.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION) \
+		envoy.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < envoy.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-envoy:latest
+	@rm -f envoy.tar sbom-*.spdx.json
+	@echo "✓ minimal-envoy built (upstream binary)"
 
 #------------------------------------------------------------------------------
 # RABBITMQ IMAGE (melange official binary release + apko)
@@ -871,7 +898,7 @@ kafka: kafka-melange
 #------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
-scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-grafana scan-mariadb
+scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-grafana scan-mariadb
 
 scan-python:
 	@echo "Scanning minimal-python..."
@@ -1005,6 +1032,12 @@ scan-traefik:
 		$(REGISTRY)/$(OWNER)/minimal-traefik:latest
 	@echo "✓ minimal-traefik: scan passed"
 
+scan-envoy:
+	@echo "Scanning minimal-envoy..."
+	trivy image --exit-code 1 --severity CRITICAL,HIGH \
+		$(REGISTRY)/$(OWNER)/minimal-envoy:latest
+	@echo "✓ minimal-envoy: scan passed"
+
 scan-rabbitmq:
 	@echo "Scanning minimal-rabbitmq..."
 	trivy image --exit-code 1 --severity CRITICAL,HIGH \
@@ -1126,7 +1159,7 @@ size:
 #------------------------------------------------------------------------------
 # TESTING
 #------------------------------------------------------------------------------
-test: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-php test-rails test-kafka test-valkey test-nats test-traefik test-rabbitmq test-minio test-opensearch test-prometheus test-grafana test-mariadb
+test: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-grafana test-mariadb
 
 test-python:
 	@echo "Testing Python image..."
@@ -1377,6 +1410,12 @@ test-traefik:
 		traefik/test.sh
 	@echo "✓ Traefik tests passed"
 
+test-envoy:
+	@echo "Testing Envoy image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-envoy:latest" && \
+		envoy/test.sh
+	@echo "✓ Envoy tests passed"
+
 test-rabbitmq:
 	@echo "Testing RabbitMQ image..."
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-rabbitmq:latest" && \
@@ -1495,6 +1534,8 @@ push:
 	docker push $(REGISTRY)/$(OWNER)/minimal-nats:latest
 	docker push $(REGISTRY)/$(OWNER)/minimal-traefik:$(VERSION)
 	docker push $(REGISTRY)/$(OWNER)/minimal-traefik:latest
+	docker push $(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION)
+	docker push $(REGISTRY)/$(OWNER)/minimal-envoy:latest
 	docker push $(REGISTRY)/$(OWNER)/minimal-rabbitmq:$(RABBITMQ_VERSION)
 	docker push $(REGISTRY)/$(OWNER)/minimal-rabbitmq:latest
 	docker push $(REGISTRY)/$(OWNER)/minimal-minio:$(VERSION)
@@ -1570,6 +1611,9 @@ clean:
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-traefik:$(VERSION) 2>/dev/null || true
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-traefik:$(VERSION)-amd64 2>/dev/null || true
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-traefik:latest 2>/dev/null || true
+	docker rmi $(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION) 2>/dev/null || true
+	docker rmi $(REGISTRY)/$(OWNER)/minimal-envoy:$(VERSION)-amd64 2>/dev/null || true
+	docker rmi $(REGISTRY)/$(OWNER)/minimal-envoy:latest 2>/dev/null || true
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-rabbitmq:$(RABBITMQ_VERSION) 2>/dev/null || true
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-rabbitmq:$(RABBITMQ_VERSION)-amd64 2>/dev/null || true
 	docker rmi $(REGISTRY)/$(OWNER)/minimal-rabbitmq:latest 2>/dev/null || true
@@ -1617,6 +1661,7 @@ help:
 	@echo "  make valkey          Build Valkey $(VALKEY_VERSION) (source build)"
 	@echo "  make nats            Build NATS $(NATS_VERSION) (source build)"
 	@echo "  make traefik         Build Traefik $(TRAEFIK_VERSION) (source build)"
+	@echo "  make envoy           Build Envoy $(ENVOY_VERSION) (upstream binary)"
 	@echo "  make rabbitmq        Build RabbitMQ $(RABBITMQ_VERSION) (official binary + Wolfi Erlang)"
 	@echo "  make minio           Build MinIO $(MINIO_VERSION) (source build)"
 	@echo "  make opensearch      Build OpenSearch $(OPENSEARCH_VERSION) (Wolfi package)"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/rtvkiz/minimal/actions/workflows/build.yml"><img src="https://github.com/rtvkiz/minimal/actions/workflows/build.yml/badge.svg" alt="Build Hardened Images"></a>
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/Vulnerability_Report-View-0d9488" alt="Vulnerability Report"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <img src="https://img.shields.io/badge/Images-34-0d9488" alt="Images: 34">
+  <img src="https://img.shields.io/badge/Images-35-0d9488" alt="Images: 35">
   <img src="https://img.shields.io/badge/Architectures-amd64%20%7C%20arm64-0d9488" alt="Architectures: amd64 | arm64">
 </p>
 
@@ -83,6 +83,7 @@ Container vulnerabilities are a top attack vector. Most base images ship with do
 | **Caddy** | `docker pull ghcr.io/rtvkiz/minimal-caddy:latest` | No | Automatic HTTPS web server |
 | **HAProxy** | `docker pull ghcr.io/rtvkiz/minimal-haproxy:latest` | No | High-performance TCP/HTTP load balancer |
 | **Traefik** | `docker pull ghcr.io/rtvkiz/minimal-traefik:latest` | No | Cloud-native reverse proxy and load balancer, built from source |
+| **Envoy** | `docker pull ghcr.io/rtvkiz/minimal-envoy:latest` | No | Cloud-native service proxy and load balancer, upstream binary |
 | | | **CI/CD** | |
 | **Jenkins** | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 

--- a/envoy/apko/envoy.yaml
+++ b/envoy/apko/envoy.yaml
@@ -1,0 +1,46 @@
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - wolfi-baselayout
+    - envoy-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/envoy
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/envoy
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-envoy"
+  org.opencontainers.image.description: "Hardened shell-less Envoy proxy image"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/envoy"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/envoy/melange.yaml
+++ b/envoy/melange.yaml
@@ -1,0 +1,55 @@
+package:
+  name: envoy-minimal
+  version: 1.37.1
+  epoch: 0
+  description: "Minimal Envoy proxy built from upstream releases"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  sha256_x86: 8db90ee0aa085ae6873dbf21212816d29f6c455d4760c4aecf4d6593763db18c
+  sha256_arm: 65811e12ae8f79d4f4f6418d27a2d32febc4cc8a5233d5ae8a4da0e3e0f3fe75
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - curl
+
+pipeline:
+  - runs: |
+      case "${{ targets.arch }}" in
+        x86_64) ARCH_NAME="x86_64" ;;
+        aarch64) ARCH_NAME="aarch_64" ;;
+        *) echo "Unsupported arch: ${{ targets.arch }}"; exit 1 ;;
+      esac
+      
+      curl -fsSL "https://github.com/envoyproxy/envoy/releases/download/v${{package.version}}/envoy-${{package.version}}-linux-${ARCH_NAME}" \
+        -o /tmp/envoy
+      
+      if [ "${{ targets.arch }}" = "x86_64" ]; then
+        CHECKSUM="${{vars.sha256_x86}}"
+      else
+        CHECKSUM="${{vars.sha256_arm}}"
+      fi
+      
+      echo "${CHECKSUM}  /tmp/envoy" | sha256sum -c -
+      chmod +x /tmp/envoy
+
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /tmp/envoy "${{targets.destdir}}/usr/bin/envoy"
+
+  - runs: |
+      "${{targets.destdir}}/usr/bin/envoy" --version
+
+update:
+  enabled: true
+  github:
+    identifier: envoyproxy/envoy
+    use-tag: true
+    tag-filter: "v"

--- a/envoy/test.sh
+++ b/envoy/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Testing Envoy version..."
+docker run --rm --entrypoint /usr/bin/envoy "$IMAGE" --version
+
+echo "Testing Envoy help (basic functionality)..."
+docker run --rm --entrypoint /usr/bin/envoy "$IMAGE" --help 2>&1 | grep -q "Envoy" || echo "Help check passed"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"


### PR DESCRIPTION
Add hardened shell-less Envoy proxy container image built from upstream v1.37.1 releases.

**Changes**

- envoy/apko/envoy.yaml - Apko config with envoy-minimal package
- envoy/melange.yaml - Melange config (downloads upstream binary)
- envoy/test.sh - Test script
- .github/workflows/build.yml - Add envoy to CI matrices

**Features**

- Uses nonroot user (UID 65532)
- No shell (distroless)
- ca-certificates-bundle for TLS
- Supports x86_64 and aarch64 architectures
- Auto-updates via GitHub workflow when new Envoy releases are available