### PR TITLE
fix(php): work around openssl-hardened-dev stripping deprecated RSA APIs

### DIFF
--- a/php/melange.yaml
+++ b/php/melange.yaml
@@ -5,7 +5,7 @@
 package:
   name: php-minimal
   version: 8.5.5
-  epoch: 1
+  epoch: 2
   description: "Minimal PHP CLI built from source"
   copyright:
     - license: PHP-3.01
@@ -44,11 +44,13 @@ pipeline:
       tar xzf php.tar.gz
       rm php.tar.gz
 
-  # Undo openssl-hardened-dev's no-deprecated configuration.
-  # Wolfi's openssl-hardened-dev installs a configuration.h with OPENSSL_NO_DEPRECATED,
-  # which hides RSA_PKCS1_PADDING and other constants PHP's openssl extension needs.
+  # Undo openssl-hardened-dev's restricted API surface.
+  # Wolfi's openssl-hardened-dev sets OPENSSL_CONFIGURED_API to 30600 and defines
+  # OPENSSL_NO_DEPRECATED, hiding RSA_PKCS1_PADDING, ERR_NUM_ERRORS, and other
+  # symbols that PHP's openssl extension still needs.
   - runs: |
       sed -i 's/^#\s*define\s\+OPENSSL_NO_DEPRECATED$//' /usr/include/openssl/configuration.h
+      sed -i 's/^#\s*define\s\+OPENSSL_CONFIGURED_API\s\+30600/# define OPENSSL_CONFIGURED_API 0/' /usr/include/openssl/configuration.h
 
   # Configure and build PHP (minimal CLI only)
   - runs: |

--- a/php/melange.yaml
+++ b/php/melange.yaml
@@ -5,7 +5,7 @@
 package:
   name: php-minimal
   version: 8.5.5
-  epoch: 2
+  epoch: 3
   description: "Minimal PHP CLI built from source"
   copyright:
     - license: PHP-3.01
@@ -44,17 +44,20 @@ pipeline:
       tar xzf php.tar.gz
       rm php.tar.gz
 
-  # Undo openssl-hardened-dev's restricted API surface.
-  # Wolfi's openssl-hardened-dev sets OPENSSL_CONFIGURED_API to 30600 and defines
-  # OPENSSL_NO_DEPRECATED, hiding RSA_PKCS1_PADDING, ERR_NUM_ERRORS, and other
-  # symbols that PHP's openssl extension still needs.
+  # Work around openssl-hardened-dev's restricted API surface.
+  # Wolfi's openssl-hardened-dev defines OPENSSL_NO_DEPRECATED and sets
+  # OPENSSL_CONFIGURED_API to 30600, which hides ERR_NUM_ERRORS (deprecated
+  # in 3.0), RSA_PKCS1_PADDING, and other symbols PHP's openssl ext needs.
+  # We strip OPENSSL_NO_DEPRECATED and compile with OPENSSL_API_COMPAT=10000
+  # to request the full pre-3.0 API surface while staying within the
+  # OPENSSL_CONFIGURED_API constraint.
   - runs: |
       sed -i 's/^#\s*define\s\+OPENSSL_NO_DEPRECATED$//' /usr/include/openssl/configuration.h
-      sed -i 's/^#\s*define\s\+OPENSSL_CONFIGURED_API\s\+30600/# define OPENSSL_CONFIGURED_API 0/' /usr/include/openssl/configuration.h
 
   # Configure and build PHP (minimal CLI only)
   - runs: |
       cd /home/build/php-${{package.version}}
+      CFLAGS="$CFLAGS -DOPENSSL_API_COMPAT=10000" \
       ./configure \
         --prefix=/usr \
         --disable-all \

--- a/php/melange.yaml
+++ b/php/melange.yaml
@@ -5,7 +5,7 @@
 package:
   name: php-minimal
   version: 8.5.5
-  epoch: 0
+  epoch: 1
   description: "Minimal PHP CLI built from source"
   copyright:
     - license: PHP-3.01
@@ -43,6 +43,12 @@ pipeline:
       cd /home/build
       tar xzf php.tar.gz
       rm php.tar.gz
+
+  # Undo openssl-hardened-dev's no-deprecated configuration.
+  # Wolfi's openssl-hardened-dev installs a configuration.h with OPENSSL_NO_DEPRECATED,
+  # which hides RSA_PKCS1_PADDING and other constants PHP's openssl extension needs.
+  - runs: |
+      sed -i 's/^#\s*define\s\+OPENSSL_NO_DEPRECATED$//' /usr/include/openssl/configuration.h
 
   # Configure and build PHP (minimal CLI only)
   - runs: |


### PR DESCRIPTION
## Summary
- Wolfi's `openssl-hardened-dev` package now installs a `configuration.h` with `OPENSSL_NO_DEPRECATED` defined, hiding `RSA_PKCS1_PADDING` and other constants PHP 8.5's openssl extension still needs
- This broke the PHP melange build in CI (see [failed run](https://github.com/rtvkiz/minimal/actions/runs/24538230901/job/71738192086))
- Fix: strip the `OPENSSL_NO_DEPRECATED` define from the hardened header before compiling

## Root cause
`openssl-hardened-dev` is a transitive dependency that overwrites `/usr/include/openssl/configuration.h` with a version built using `no-deprecated`. This hides all deprecated OpenSSL APIs including RSA padding constants. Node.js has the [same issue](https://github.com/wolfi-dev/os/blob/main/nodejs-23.yaml) — Wolfi falls back to regular `openssl-dev` for it.

## Test plan
- [ ] CI PHP melange build passes on both x86_64 and aarch64
- [ ] `make test-php` passes