### PR TITLE
docs(dev-variants): conventions + composition templates

### DIFF
--- a/docs/dev-variants/CONVENTIONS.md
+++ b/docs/dev-variants/CONVENTIONS.md
@@ -1,0 +1,191 @@
+# Dev variant conventions
+
+This document defines what every `minimal-<image>:latest-dev` image looks like.
+Every dev variant in this repo follows these rules; the per-category
+templates in `./templates/` apply them to concrete `apko` configs.
+
+## What a dev variant is
+
+A dev variant is the prod image plus a shell, package manager, and the
+build/debug tooling appropriate to the image's category. It is intended
+for two use cases:
+
+1. **Multi-stage build environments** (`FROM ...:latest-dev AS build`)
+2. **In-pod debugging** (`kubectl debug --image=...:latest-dev`)
+
+It is **not** intended for production deployment. Use the prod tag for
+runtime workloads; copy artifacts out of the dev stage if you needed it
+to compile something.
+
+## What stays identical to prod
+
+These properties are mechanical guarantees, not best-effort:
+
+- **Same source build of the primary binary.** Both prod and dev consume
+  the same melange-built `.apk` from the same workflow run. If we run
+  custom curation (e.g. ruby's json bump, bundler strip), dev inherits
+  that curation unchanged — dev only *adds* packages on top.
+- **Same entrypoint and cmd.** A dev variant is drop-in compatible with
+  its prod counterpart for `docker run IMAGE <args>` use. See
+  [Entrypoint and shell access](#entrypoint-and-shell-access) below.
+- **Same workdir.**
+- **Same nonroot UID** (`65532`) and group.
+- **Same publish cadence**: every push to main, plus the scheduled
+  rebuild every 6h.
+- **Same signing, SBOM, and SLSA build provenance pipeline.**
+
+## What is intentionally different
+
+- **Tag suffix**: prod publishes `:latest` and `:VERSION-rEPOCH`; dev
+  publishes `:latest-dev` and `:VERSION-rEPOCH-dev`. There are no
+  other tag variants.
+- **Larger package surface**: shell, package manager, debug tools,
+  build deps (per category template below).
+- **Annotation**: dev images carry
+  `dev.minimal.variant: "dev"`. Admission controllers can use this to
+  block dev images out of production namespaces.
+- **CVE policy**: dev variants are **not** tracked on the public CVE
+  dashboard. Dev images intentionally ship a larger attack surface
+  (compilers, shells, libcurl, etc.) and chasing CVE counts on dev
+  would be busywork. The daily rebuild still picks up upstream Wolfi
+  patches; we just don't publish a vuln report.
+
+## Entrypoint and shell access
+
+Every dev variant **keeps the prod entrypoint** (e.g. `/usr/bin/ruby`,
+`/usr/sbin/nginx`, `/usr/bin/redis-server`). This is the same convention
+Chainguard uses for their `-dev` images.
+
+Rationale: `RUN bundle install` in a Dockerfile multi-stage build
+invokes `/bin/sh -c` and ignores the entrypoint — so multi-stage build
+works untouched. Interactive shell access requires `--entrypoint`:
+
+```bash
+docker run -it --entrypoint /bin/sh   ghcr.io/rtvkiz/minimal-<image>:latest-dev
+docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
+```
+
+Document this in each image's README dev variant section.
+
+## Required packages in every dev variant
+
+Every dev variant ships at minimum:
+
+| Package | Why |
+|---|---|
+| `wolfi-baselayout` | filesystem skeleton (already in prod) |
+| `busybox` | `/bin/sh`, `/bin/ls`, `/bin/cat`, etc. — the minimum to drop a shell |
+| `bash` | many `docker exec` / `kubectl exec` workflows assume bash |
+| `apk-tools` | lets users install ad-hoc packages without rebuilding the image |
+| `ca-certificates-bundle` | TLS works (already in prod for most images) |
+| `wget` | quick HTTP fetches in shell sessions |
+
+These are non-negotiable — they define the "minimum dev experience"
+across the catalog.
+
+## Category-specific additions
+
+The three templates in `./templates/` map our 40 images to one of
+three categories. Pick the template that matches and customize the
+language/daemon-specific layer.
+
+### Runtime (language / interpreter)
+
+Use for: `python`, `node-slim`, `bun`, `go`, `deno`, `java`, `dotnet`,
+`php`, `ruby` (done), `rails`.
+
+Adds on top of the required minimum:
+
+- Full C/C++ toolchain for native extensions: `build-base`, `gcc`,
+  `binutils`, `make`, `pkgconf`, `posix-cc-wrappers`, `linux-headers`,
+  `openssf-compiler-options`
+- Common dev headers: `glibc-dev`, `libstdc++-dev`, `libxcrypt-dev`
+- `git` for fetching dependencies (`bundle install --git`,
+  `pip install git+...`, `go get`)
+- Language-specific package manager **baked in** when the prod variant
+  strips it (e.g. ruby's `bundler` subpackage). If Wolfi ships the
+  package manager as a separate apk that's compatible with our build,
+  prefer that.
+
+### Daemon (database / cache / message broker)
+
+Use for: `mysql`, `mariadb`, `postgres-slim`, `redis-slim`, `valkey`,
+`memcached`, `kafka`, `rabbitmq`, `nats`, `etcd`, `sqlite`,
+`opensearch`, `qdrant`.
+
+Adds on top of the required minimum:
+
+- The daemon's **client/CLI** (`psql`, `redis-cli`, `mysql`,
+  `valkey-cli`, etc.)
+- Connection/diagnostic tools: `curl`, `socat` (for unix sockets where
+  applicable)
+- For data-tier daemons: `jq` for parsing JSON output from admin
+  endpoints
+
+No C toolchain by default. Add it only if the daemon's debug workflow
+involves building extensions (e.g. postgres `CREATE EXTENSION` from
+source).
+
+### Server (HTTP server / proxy)
+
+Use for: `nginx`, `httpd`, `caddy`, `haproxy`, `traefik`, `envoy`,
+`jaeger`, `otelcol`, `prometheus`, `victoria-metrics`, `loki`,
+`fluent-bit`, `minio`, `coredns`, `gitea`, `jenkins`, `keycloak`,
+`openbao`.
+
+Adds on top of the required minimum:
+
+- HTTP debugging: `curl`, `wget` (wget already in minimum)
+- TLS debugging: `openssl` CLI
+- Network diagnosis: `bind-tools` (dig, host), `iputils` (ping),
+  `tcpdump` for the few cases where packet capture in-pod is needed
+- Server-specific admin CLI if one exists (e.g. `mc` for minio,
+  `nginx -t` is the binary itself)
+
+## Where to deviate
+
+These conventions are defaults, not laws. Deviate when:
+
+- An upstream tool only ships as a Wolfi apk under a non-obvious name
+  (e.g. `mongo-shell` vs `mongosh`).
+- The daemon embeds its own debug surface (e.g. nginx `-T` dumps config;
+  no extra CLI needed).
+- A required minimum package conflicts with the image (`apk-tools`
+  conflicts in some apko-only images that don't carry the apk DB).
+
+In every deviation, leave a comment in the image's `apko-dev.yaml`
+explaining what was dropped/added vs the template and why. Future
+readers (including a 6-months-from-now-you) should be able to see the
+delta at a glance.
+
+## Source of truth for package choices
+
+Where a Chainguard public `*-public/devConfigs` exists for the
+corresponding upstream image, **start by mirroring their package set**.
+They've already debugged the long tail of "what do native gem authors
+actually need?" for popular runtimes.
+
+Where Chainguard has no public dev variant (most servers + daemons in
+their catalog are Enterprise-only), default to the category template.
+Open an issue if a real user reports needing something the template
+missed — don't speculate.
+
+## Adding a dev variant: the 7-step checklist
+
+For each new image:
+
+1. Add `"variants":["prod","dev"]` to the image entry in
+   `.github/workflows/build.yml`.
+2. Copy the appropriate template from `./templates/` to
+   `<image>/apko/<image>-dev.yaml` and fill in the customization
+   comments.
+3. If anything needs baking (CLIs, package managers), add a subpackage
+   to `<image>/melange.yaml`. Prefer a Wolfi apk if one exists.
+4. Create `<image>/test-dev.sh` mirroring `ruby/test-dev.sh`.
+5. Add Makefile targets (will be a one-line macro call once Phase 0
+   PR #3 lands; for now copy ruby's pattern).
+6. Add the image to the dev variant tracker table in the main
+   `README.md`.
+7. Local validation per `CLAUDE.md`:
+   `make <image>(-melange) && make <image>-dev && make test-<image> && make test-<image>-dev`.
+   All four must pass before pushing.

--- a/docs/dev-variants/templates/daemon-dev.yaml
+++ b/docs/dev-variants/templates/daemon-dev.yaml
@@ -1,0 +1,101 @@
+# Template: database / cache / message broker dev variant
+#
+# Use this template when the prod image runs a long-lived daemon
+# (postgres, redis, kafka, etc.). The dev variant adds the daemon's
+# client/CLI so users can `kubectl exec` into a pod and inspect state,
+# plus general HTTP/socket debugging tools.
+#
+# Notably, this template does NOT include a C/C++ toolchain. Daemon
+# debugging rarely requires compiling code in the pod. Add the
+# toolchain (see runtime-dev.yaml) only if the daemon's documented
+# debug workflow involves building extensions from source.
+#
+# How to use:
+#   1. Copy this file to <image>/apko/<image>-dev.yaml.
+#   2. Replace every <PLACEHOLDER> below.
+#   3. Delete the comment blocks marked "TEMPLATE NOTE" once addressed.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Primary daemon binary (same package as prod)
+    - <DAEMON_PACKAGE>
+
+    # Core runtime libs (copy verbatim from your prod apko config)
+    - <RUNTIME_DEPS_FROM_PROD>
+
+    # --- Required dev variant minimum (see CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - ca-certificates-bundle
+    - wget
+
+    # --- Daemon's client / CLI for inspecting state ---
+    - <DAEMON_CLIENT_PACKAGE>
+    # TEMPLATE NOTE: e.g. postgresql-client, redis-cli (often shipped
+    # in the same apk as the server), mysql-client, valkey-cli.
+    # If the prod apk already contains the CLI, leave this commented.
+
+    # --- Connection & diagnostic tools ---
+    - curl
+    - socat
+    # TEMPLATE NOTE: socat is useful for unix-socket daemons (postgres,
+    # mysql). Drop it if your daemon only listens on TCP.
+
+    # --- JSON parsing for admin endpoint output ---
+    - jq
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: <PROD_ENTRYPOINT_COMMAND>
+  # TEMPLATE NOTE: e.g. /usr/bin/redis-server, /usr/local/bin/postgres
+
+cmd: <PROD_CMD>
+# TEMPLATE NOTE: copy from prod (may be empty)
+
+work-dir: <PROD_WORKDIR>
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  # Mirror any prod data dir + permissions exactly so a dev image can
+  # mount the same volumes as prod for inspection.
+  - path: <PROD_DATA_DIR>
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  # TEMPLATE NOTE: e.g. /var/lib/postgresql, /var/lib/redis. Repeat
+  # this block for each prod data path.
+
+annotations:
+  org.opencontainers.image.title: "minimal-<IMAGE_NAME>-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-<IMAGE_NAME>: same daemon + shell + CLI tools. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/<IMAGE_NAME>"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/docs/dev-variants/templates/runtime-dev.yaml
+++ b/docs/dev-variants/templates/runtime-dev.yaml
@@ -1,0 +1,144 @@
+# Template: language runtime dev variant
+#
+# Use this template when the prod image is a language interpreter or
+# compiler (python, node, ruby, go, java, etc.). The dev variant adds
+# a build environment so users can compile native extensions, install
+# packages from source, and run their language's package manager.
+#
+# How to use:
+#   1. Copy this file to <image>/apko/<image>-dev.yaml.
+#   2. Replace every <PLACEHOLDER> below.
+#   3. Delete the comment blocks marked "TEMPLATE NOTE" once you've
+#      addressed them.
+#   4. If the prod image strips a package manager (like ruby strips
+#      bundler) that the dev variant needs, add a subpackage to
+#      <image>/melange.yaml that ships it, and list the subpackage in
+#      the contents.packages section below.
+#
+# Reference: see ruby/apko/ruby-dev.yaml for a fully-worked example.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Primary runtime (same package the prod variant pulls)
+    - <RUNTIME_PACKAGE>
+    # TEMPLATE NOTE: e.g. `ruby-minimal`, `python-3.14`, `nodejs-22`.
+    # If your prod apko config uses a melange-built package, use the
+    # same name here so prod and dev share the .apk artifact.
+
+    # Core runtime libs (mirror these from your prod apko config)
+    - <RUNTIME_DEPS_FROM_PROD>
+    # TEMPLATE NOTE: e.g. glibc, glibc-locale-posix, ld-linux, libgcc,
+    # libstdc++, libssl3, libcrypto3, libcrypt1, zlib, yaml, libffi,
+    # readline, ca-certificates-bundle. Copy verbatim from prod.
+
+    # --- Required dev variant minimum (see CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain for native extension compilation ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++-dev
+    - libxcrypt-dev
+
+    # --- VCS for `bundle install --git`, `pip install git+...`, `go get` ---
+    - git
+
+    # --- Auth + network libs commonly needed by native extensions ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+    - libexpat1
+
+    # --- DB client libs for native extensions (sqlite3, pg, mysql2 builds) ---
+    - sqlite-libs
+
+    # --- Language-specific package manager(s) ---
+    # TEMPLATE NOTE: if Wolfi ships a separate apk that's compatible
+    # with your runtime, add it here (e.g. `pip` is in `python-3.14`
+    # already, but `bundler` is a separate Wolfi apk for the Wolfi
+    # ruby). If you built your runtime from source via melange and
+    # the package manager isn't in the resulting .apk, add a subpackage
+    # to your melange.yaml that ships it, then reference that
+    # subpackage here.
+    - <PACKAGE_MANAGER_PACKAGE>
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility with `docker run IMAGE <args>`.
+  # Users get a shell via `--entrypoint /bin/sh` per CONVENTIONS.md.
+  command: <PROD_ENTRYPOINT_COMMAND>
+  # TEMPLATE NOTE: e.g. /usr/bin/ruby, /usr/bin/python3.14, /usr/bin/node
+
+cmd: <PROD_CMD>
+# TEMPLATE NOTE: e.g. --version
+
+work-dir: <PROD_WORKDIR>
+# TEMPLATE NOTE: e.g. /work (must match prod)
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: <PROD_WORKDIR>
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Writable per-user package install dir for the language's
+  # user-install convention (gem install --user-install, pip install --user, etc.)
+  - path: /home/nonroot/<PACKAGE_USER_DIR>
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  # TEMPLATE NOTE: e.g. .gem (ruby), .local (python), .npm (node)
+
+annotations:
+  org.opencontainers.image.title: "minimal-<IMAGE_NAME>-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-<IMAGE_NAME>: same runtime + shell + build toolchain. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/<IMAGE_NAME>"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/docs/dev-variants/templates/server-dev.yaml
+++ b/docs/dev-variants/templates/server-dev.yaml
@@ -1,0 +1,107 @@
+# Template: HTTP server / proxy / observability daemon dev variant
+#
+# Use this template when the prod image is an HTTP server, proxy, or
+# observability daemon (nginx, traefik, prometheus, otelcol, etc.).
+# The dev variant adds HTTP/TLS/network debugging tools so users can
+# probe the server from inside its own pod.
+#
+# Like daemon-dev.yaml, this template does NOT include a C/C++
+# toolchain. If your image's debug workflow involves running
+# server-side scripts (e.g. nginx with the lua module + custom scripts),
+# add the language toolchain explicitly.
+#
+# How to use:
+#   1. Copy this file to <image>/apko/<image>-dev.yaml.
+#   2. Replace every <PLACEHOLDER> below.
+#   3. Delete the comment blocks marked "TEMPLATE NOTE" once addressed.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Primary server binary (same package as prod)
+    - <SERVER_PACKAGE>
+
+    # Core runtime libs (copy verbatim from your prod apko config)
+    - <RUNTIME_DEPS_FROM_PROD>
+
+    # --- Required dev variant minimum (see CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - ca-certificates-bundle
+    - wget
+
+    # --- HTTP debugging ---
+    - curl
+
+    # --- TLS debugging (cert inspection, expiry checks, s_client probes) ---
+    - openssl
+
+    # --- DNS diagnosis ---
+    - bind-tools
+    # TEMPLATE NOTE: ships `dig`, `host`, `nslookup`. Drop if the server
+    # is a DNS server itself (coredns) — it'll already have these.
+
+    # --- Server-specific admin CLI ---
+    # TEMPLATE NOTE: examples:
+    #   - minio: `mc` (minio client)
+    #   - traefik: nothing extra (uses HTTP API)
+    #   - prometheus: `promtool` (often shipped in same apk)
+    #   - nginx: `nginx -t` is the binary itself
+    # Add the apk here if one exists. Leave commented if not.
+    # - <ADMIN_CLI_PACKAGE>
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: <PROD_ENTRYPOINT_COMMAND>
+  # TEMPLATE NOTE: e.g. /usr/sbin/nginx, /usr/bin/caddy
+
+cmd: <PROD_CMD>
+# TEMPLATE NOTE: copy from prod (often a config flag like
+# `-g daemon off;` for nginx or `run --config /etc/caddy/Caddyfile`)
+
+work-dir: <PROD_WORKDIR>
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  # Mirror any prod runtime/config dirs + permissions exactly so a dev
+  # image can mount the same volumes as prod.
+  - path: <PROD_CONFIG_OR_DATA_DIR>
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  # TEMPLATE NOTE: e.g. /etc/nginx, /var/cache/nginx, /var/log/nginx.
+  # Repeat per prod path.
+
+annotations:
+  org.opencontainers.image.title: "minimal-<IMAGE_NAME>-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-<IMAGE_NAME>: same server + shell + HTTP/TLS debug tools. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/<IMAGE_NAME>"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64


### PR DESCRIPTION
Phase 0/4 of the dev variant rollout. Pure docs — no code, no workflow changes.

## What this adds

- **\`docs/dev-variants/CONVENTIONS.md\`** — defines what every \`:latest-dev\` image looks like across the catalog: required packages, entrypoint behavior, tag suffix, signing parity, CVE policy, 7-step per-image checklist.
- **3 composition templates** in \`docs/dev-variants/templates/\` covering the categories every image in the repo maps to:
  - \`runtime-dev.yaml\` — language runtimes (python, node, ruby, etc.)
  - \`daemon-dev.yaml\` — databases, caches, message brokers
  - \`server-dev.yaml\` — HTTP servers, proxies, observability

## Why now

\`ruby-dev\` (already shipped, see commit 36dc97a) is the worked reference. Before adding 39 more dev variants, fix the multiplication problem: nail down the conventions once so each image PR is mechanical.

## Subsequent Phase 0 PRs

1. ✅ This PR — conventions + templates
2. Extend APKO_MATRIX in \`build.yml\` with variant support (mirrors what we did for BUILD_MELANGE_MATRIX in 36dc97a)
3. Makefile macro for the dev image target so each image is a one-line \`\$(eval ...)\` call
4. README dev variant tracker table covering all 40 images

## Test plan

- [x] All three template YAMLs parse with \`yq eval\`
- [x] \`ruby/apko/ruby-dev.yaml\` (already shipped) conforms to the runtime template's structure
- No code paths changed; nothing to build/test in CI beyond markdown rendering