### PR TITLE
feat(python): publish minimal-python:latest-dev + APKO_MATRIX variant support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             {"name":"fluent-bit"},{"name":"keycloak"}
           ]'
           APKO_IMAGES='[
-            {"name":"python","grep":"python-[0-9]"},
+            {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},
             {"name":"node-slim","apko":"node-slim/apko/node.yaml","grep":"nodejs-[0-9]"},
             {"name":"go","grep":"go-[0-9]"},
             {"name":"nginx","grep":"nginx-mainline"},
@@ -155,12 +155,29 @@ jobs:
           ]}')
 
           # Generate build-apko matrix
+          # Per-image variant fan-out: same convention as BUILD_MELANGE_MATRIX.
+          # Images opt-in to a dev variant by adding `"variants":["prod","dev"]`
+          # plus an apko-dev config (defaults to <name>/apko/<name>-dev.yaml,
+          # or <prod_apko_path_with_-dev_suffix> if the prod config uses a
+          # custom path). See docs/dev-variants/CONVENTIONS.md.
           APKO_MATRIX=$(echo "$APKO_IMAGES" | jq -c --argjson changed "$CHANGED" '{include: [
-            .[] | select(.name as $n | $changed | index($n)) |
+            .[] | select(.name as $n | $changed | index($n)) | . as $img |
+            ($img.variants // ["prod"])[] as $variant |
+            ($img.apko // ($img.name + "/apko/" + $img.name + ".yaml")) as $prod_config |
             {
-              name: .name,
-              apko_config: (.apko // (.name + "/apko/" + .name + ".yaml")),
-              primary_grep: .grep
+              name: $img.name,
+              variant: $variant,
+              apko_config: (
+                if $variant == "dev"
+                then ($prod_config | sub("\\.yaml$"; "-dev.yaml"))
+                else $prod_config
+                end
+              ),
+              primary_grep: $img.grep,
+              tag_suffix: (if $variant == "dev" then "-dev" else "" end),
+              latest_tag: (if $variant == "dev" then "latest-dev" else "latest" end),
+              test_script: (if $variant == "dev" then ($img.name + "/test-dev.sh") else ($img.name + "/test.sh") end),
+              scan_for_cves: ($variant == "prod")
             }
           ]}')
 
@@ -363,20 +380,23 @@ jobs:
       - name: Build image with apko
         run: |
           apko build ${{ matrix.apko_config }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }} \
-            ${{ matrix.name }}.tar \
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }} \
+            ${{ matrix.name }}${{ matrix.tag_suffix }}.tar \
             --arch x86_64
-          docker load < ${{ matrix.name }}.tar
-          LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | head -1)
-          docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}
+          docker load < ${{ matrix.name }}${{ matrix.tag_suffix }}.tar
+          LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" | head -1)
+          docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}
 
       - name: Report image size
         run: |
-          echo "## ${{ matrix.name }} Image Size" >> $GITHUB_STEP_SUMMARY
+          echo "## ${{ matrix.name }}${{ matrix.tag_suffix }} Image Size" >> $GITHUB_STEP_SUMMARY
           docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | \
-            grep "minimal-${{ matrix.name }}" >> $GITHUB_STEP_SUMMARY || true
+            grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" >> $GITHUB_STEP_SUMMARY || true
 
+      # CVE scan: prod variants only. Dev variants intentionally ship a larger
+      # surface (shell, compilers, etc.) and are not tracked on the dashboard.
       - name: Cache Grype binary
+        if: matrix.scan_for_cves
         id: grype-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -384,7 +404,7 @@ jobs:
           key: grype-${{ env.GRYPE_VERSION }}-linux-amd64
 
       - name: Install Grype
-        if: steps.grype-cache.outputs.cache-hit != 'true'
+        if: matrix.scan_for_cves && steps.grype-cache.outputs.cache-hit != 'true'
         run: |
           curl -fL --retry 5 --retry-all-errors -o /tmp/grype.tar.gz \
             "https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz"
@@ -393,9 +413,11 @@ jobs:
           rm -f /tmp/grype.tar.gz
 
       - name: Verify Grype
+        if: matrix.scan_for_cves
         run: grype version
 
       - name: Scan image for vulnerabilities
+        if: matrix.scan_for_cves
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
           grype "$IMAGE" \
@@ -403,7 +425,7 @@ jobs:
             -o sarif=grype-${{ matrix.name }}.sarif
 
       - name: Generate vulnerability report
-        if: always()
+        if: always() && matrix.scan_for_cves
         run: |
           REPORT="grype-${{ matrix.name }}.json"
           if [ ! -f "$REPORT" ]; then
@@ -457,7 +479,7 @@ jobs:
           fi
 
       - name: Upload vulnerability report
-        if: always()
+        if: always() && matrix.scan_for_cves
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vulnerability-report-${{ matrix.name }}
@@ -466,7 +488,7 @@ jobs:
 
       - name: Upload SARIF to Security tab
         uses: github/codeql-action/upload-sarif@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
-        if: always() && hashFiles(format('grype-{0}.sarif', matrix.name)) != ''
+        if: always() && matrix.scan_for_cves && hashFiles(format('grype-{0}.sarif', matrix.name)) != ''
         continue-on-error: true
         with:
           sarif_file: 'grype-${{ matrix.name }}.sarif'
@@ -475,7 +497,9 @@ jobs:
       - name: Extract version from SBOM
         id: version
         run: |
-          # Read primary package name from apko config (source of truth)
+          # Read primary package name from apko config (source of truth).
+          # Dev variants resolve their own SBOM but the primary package
+          # version matches prod (same upstream binary).
           PRIMARY_PKG=$(grep -oE '${{ matrix.primary_grep }}[a-z0-9.\-]*' ${{ matrix.apko_config }} | head -1)
           if [ -z "$PRIMARY_PKG" ]; then
             echo "::error::Failed to extract primary package from ${{ matrix.apko_config }} using pattern '${{ matrix.primary_grep }}'"
@@ -492,16 +516,16 @@ jobs:
 
       - name: Test image
         run: |
-          export IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
-          ./${{ matrix.name }}/test.sh
+          export IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}"
+          bash ./${{ matrix.test_script }}
 
       - name: Publish image
         if: github.event_name != 'pull_request'
         id: publish
         run: |
           apko publish ${{ matrix.apko_config }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:latest \
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }}${{ matrix.tag_suffix }} \
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ matrix.latest_tag }} \
             --arch x86_64,aarch64 \
             --sbom-path . \
             | tee apko-publish.out

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ OPENSEARCH_VERSION ?= 3.6.0
 CUDA_VERSION ?= 12.9.0
 
 .PHONY: all build scan clean help
-.PHONY: python jenkins jenkins-melange go node-slim nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet java ruby ruby-melange ruby-dev php php-melange rails rails-melange kafka kafka-melange keygen opensearch
+.PHONY: python python-dev jenkins jenkins-melange go node-slim nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet java ruby ruby-melange ruby-dev php php-melange rails rails-melange kafka kafka-melange keygen opensearch
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange mariadb mariadb-melange
 .PHONY: etcd etcd-melange victoria-metrics victoria-metrics-melange jaeger jaeger-melange otelcol otelcol-melange qdrant qdrant-melange deno
@@ -69,7 +69,7 @@ CUDA_VERSION ?= 12.9.0
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
-.PHONY: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-ruby-dev test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
+.PHONY: test-python test-python-dev test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-ruby-dev test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
 all: build scan
 
@@ -102,6 +102,20 @@ python:
 		$(REGISTRY)/$(OWNER)/minimal-python:latest
 	@rm -f python.tar sbom-*.spdx.json
 	@echo "✓ minimal-python built (Wolfi package, shell-less)"
+
+python-dev:
+	@echo "Assembling minimal-python-dev image with apko..."
+	apko build python/apko/python-dev.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-python:$(VERSION)-dev \
+		python-dev.tar \
+		--arch x86_64
+	docker load < python-dev.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-python:$(VERSION)-dev-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-python:$(VERSION)-dev
+	docker tag $(REGISTRY)/$(OWNER)/minimal-python:$(VERSION)-dev-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-python:latest-dev
+	@rm -f python-dev.tar sbom-*.spdx.json
+	@echo "✓ minimal-python-dev built"
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1388,6 +1402,10 @@ size:
 # TESTING
 #------------------------------------------------------------------------------
 test: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-cuda-python
+
+test-python-dev:
+	@IMAGE=$(REGISTRY)/$(OWNER)/minimal-python:latest-dev bash python/test-dev.sh
+	@echo "✓ Python dev tests passed"
 
 test-python:
 	@echo "Testing Python image..."

--- a/python/apko/python-dev.yaml
+++ b/python/apko/python-dev.yaml
@@ -1,0 +1,137 @@
+# Development variant of minimal-python.
+# Same Python 3.14 runtime as prod, plus shell, package manager, build
+# toolchain, pip/setuptools/uv, and common native-extension dependencies.
+# Intended for CI build stages and in-pod debugging. NOT for production.
+#
+# Package list mirrors Chainguard's public ruby-public/devConfigs as
+# closely as Wolfi naming allows. See docs/dev-variants/CONVENTIONS.md
+# for the rules every dev variant follows.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Python runtime (same as prod)
+    - python-3.14
+
+    # Core runtime deps (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+
+    # Python module deps (same as prod)
+    - libffi
+    - zlib
+    - libssl3
+    - libcrypto3
+    - readline
+    - ncurses
+    - ncurses-terminfo-base
+    - libexpat1
+    - libbz2-1
+    - xz
+    - libzstd1
+    - mpdecimal
+    - sqlite-libs
+    - gdbm
+    - libuuid
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain for native extension compilation ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++-dev
+    - libxcrypt-dev
+    - python-3.14-dev
+
+    # --- Python package management (baked in) ---
+    - py3.14-pip
+    - py3.14-setuptools
+    - py3-pip-wheel
+    - uv
+
+    # --- VCS for `pip install git+...` ---
+    - git
+
+    # --- Auth + network libs commonly needed by native packages ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility. Users get a shell via
+  # `--entrypoint /bin/sh` per CONVENTIONS.md.
+  command: /usr/bin/python3
+
+work-dir: /app
+
+environment:
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONUNBUFFERED: "1"
+  PYTHONHASHSEED: random
+  LANG: C.UTF-8
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Writable user dir for `pip install --user`
+  - path: /home/nonroot/.local
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-python-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-python: same Python runtime + shell + build toolchain + pip/uv. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/python"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/python/test-dev.sh
+++ b/python/test-dev.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Smoke test for minimal-python-dev.
+# Validates the dev variant has shell + toolchain + pip/uv while
+# preserving prod runtime parity (same entrypoint, same Python).
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Python version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -q "Python 3.14"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make, pkgconf)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version && pkgconf --version" >/dev/null
+
+echo "Testing Python C headers (python-3.14-dev)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "ls /usr/include/python3.14/Python.h" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing pip is baked in (no runtime install needed)..."
+pip_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "pip --version")
+echo "$pip_ver" | grep -qE "pip [0-9]+\.[0-9]+" || { echo "::error::pip version unexpected: $pip_ver"; exit 1; }
+
+echo "Testing uv is baked in..."
+uv_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "uv --version")
+echo "$uv_ver" | grep -qE "uv [0-9]+\.[0-9]+" || { echo "::error::uv version unexpected: $uv_ver"; exit 1; }
+
+echo "Testing setuptools available..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "python3 -c 'import setuptools; print(setuptools.__version__)'" >/dev/null
+
+echo "Testing pip install --user works for nonroot..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c \
+  "pip install --quiet --no-cache-dir --user --disable-pip-version-check requests && python3 -c 'import requests; print(requests.__version__)'" >/dev/null
+
+echo "Testing core stdlib (ssl, json, sqlite3, hashlib)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c \
+  "python3 -c 'import ssl, json, sqlite3, hashlib; print(\"Core stdlib OK\")'" | grep -q "Core stdlib OK"
+
+echo "✓ All python-dev smoke tests passed"


### PR DESCRIPTION
## Summary

Phase 0/2 of the dev variant rollout (APKO_MATRIX variant fan-out) bundled with the first apko-only consumer (python-dev). Bundled per [CLAUDE.md](../blob/main/CLAUDE.md) — workflow changes are only meaningful when exercised by a real image, so they ship together.

After PR #143 (conventions + templates) and this, Phase 0 is 2/4 done.

## What changed

- **`.github/workflows/build.yml`** — APKO_MATRIX fan-out per variant, mirroring the BUILD_MELANGE_MATRIX work in 36dc97a. Dev rows derive their apko config by inserting `-dev` before `.yaml`, skip grype scan, publish `:latest-dev` + `-dev` suffix tags. Backward compatible: any APKO_IMAGES entry without `variants` field still produces a single prod row (output is byte-identical to before for everything except python).
- **`python/apko/python-dev.yaml`** — dev composition. Mirrors Chainguard's `python-public/devConfigs` package set as closely as Wolfi naming allows: shell + apk-tools + GCC toolchain + python-3.14-dev headers + py3.14-pip + py3.14-setuptools + uv + git on top of prod runtime. Entrypoint stays `/usr/bin/python3` for drop-in compat (shell access via `--entrypoint /bin/sh`).
- **`python/test-dev.sh`** — shell, toolchain, headers, pip+uv parity, `pip install --user requests` end-to-end, core stdlib check.
- **`Makefile`** — `python-dev` + `test-python-dev` targets, PHONY updated.

## Test plan

Local validation (CLAUDE.md required):

- [x] `make python` — prod still builds
- [x] `make python-dev` — dev variant builds
- [x] `make test-python` — prod tests pass (no regression)
- [x] `make test-python-dev` — shell, toolchain, headers, pip+uv, `pip install --user requests`, stdlib all green

In CI:

- [ ] APKO_MATRIX produces two rows for python (prod + dev), one row for every other apko image
- [ ] Both python builds succeed, dev skips grype, both publish + sign + attest