### PR TITLE
feat(dev-variants): batch 1A — node-slim, go, java, dotnet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,15 +73,15 @@ jobs:
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},
-            {"name":"node-slim","apko":"node-slim/apko/node.yaml","grep":"nodejs-[0-9]"},
-            {"name":"go","grep":"go-[0-9]"},
+            {"name":"node-slim","apko":"node-slim/apko/node.yaml","grep":"nodejs-[0-9]","variants":["prod","dev"]},
+            {"name":"go","grep":"go-[0-9]","variants":["prod","dev"]},
             {"name":"nginx","grep":"nginx-mainline"},
             {"name":"httpd","grep":"apache2"},
             {"name":"postgres-slim","apko":"postgres-slim/apko/postgres.yaml","grep":"postgresql-[0-9]"},
             {"name":"bun","grep":"bun"},
             {"name":"sqlite","grep":"sqlite"},
-            {"name":"dotnet","grep":"dotnet-[0-9].*-runtime"},
-            {"name":"java","grep":"openjdk-[0-9]+"},
+            {"name":"dotnet","grep":"dotnet-[0-9].*-runtime","variants":["prod","dev"]},
+            {"name":"java","grep":"openjdk-[0-9]+","variants":["prod","dev"]},
             {"name":"opensearch","grep":"opensearch-3"},
             {"name":"deno","grep":"deno"}
           ]'
@@ -154,23 +154,22 @@ jobs:
             }
           ]}')
 
-          # Generate build-apko matrix
+          # Generate build-apko matrix.
           # Per-image variant fan-out: same convention as BUILD_MELANGE_MATRIX.
           # Images opt-in to a dev variant by adding `"variants":["prod","dev"]`
-          # plus an apko-dev config (defaults to <name>/apko/<name>-dev.yaml,
-          # or <prod_apko_path_with_-dev_suffix> if the prod config uses a
-          # custom path). See docs/dev-variants/CONVENTIONS.md.
+          # plus a `<name>/apko/<name>-dev.yaml` file (universal convention,
+          # regardless of what the prod apko file is named).
+          # See docs/dev-variants/CONVENTIONS.md.
           APKO_MATRIX=$(echo "$APKO_IMAGES" | jq -c --argjson changed "$CHANGED" '{include: [
             .[] | select(.name as $n | $changed | index($n)) | . as $img |
             ($img.variants // ["prod"])[] as $variant |
-            ($img.apko // ($img.name + "/apko/" + $img.name + ".yaml")) as $prod_config |
             {
               name: $img.name,
               variant: $variant,
               apko_config: (
                 if $variant == "dev"
-                then ($prod_config | sub("\\.yaml$"; "-dev.yaml"))
-                else $prod_config
+                then ($img.name + "/apko/" + $img.name + "-dev.yaml")
+                else ($img.apko // ($img.name + "/apko/" + $img.name + ".yaml"))
                 end
               ),
               primary_grep: $img.grep,

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-$(1)-dev:
 endef
 
 .PHONY: all build scan clean help
-.PHONY: python python-dev jenkins jenkins-melange go node-slim nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet java ruby ruby-melange ruby-dev php php-melange rails rails-melange kafka kafka-melange keygen opensearch
+.PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange rails rails-melange kafka kafka-melange keygen opensearch
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange mariadb mariadb-melange
 .PHONY: etcd etcd-melange victoria-metrics victoria-metrics-melange jaeger jaeger-melange otelcol otelcol-melange qdrant qdrant-melange deno
@@ -106,7 +106,7 @@ endef
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
-.PHONY: test-python test-python-dev test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-ruby-dev test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
+.PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
 all: build scan
 
@@ -141,6 +141,10 @@ python:
 	@echo "✓ minimal-python built (Wolfi package, shell-less)"
 
 $(eval $(call DEV_IMAGE_RULE,python))
+$(eval $(call DEV_IMAGE_RULE,node-slim))
+$(eval $(call DEV_IMAGE_RULE,go))
+$(eval $(call DEV_IMAGE_RULE,java))
+$(eval $(call DEV_IMAGE_RULE,dotnet))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1415,6 +1419,10 @@ size:
 test: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-cuda-python
 
 $(eval $(call DEV_TEST_RULE,python))
+$(eval $(call DEV_TEST_RULE,node-slim))
+$(eval $(call DEV_TEST_RULE,go))
+$(eval $(call DEV_TEST_RULE,java))
+$(eval $(call DEV_TEST_RULE,dotnet))
 
 test-python:
 	@echo "Testing Python image..."

--- a/README.md
+++ b/README.md
@@ -255,20 +255,25 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-#### Status
+**Shipping today:** 6 of 41 dev variants — `ruby`, `python`, `node-slim`, `go`, `java`, `dotnet`. The other 35 are rolling out batch by batch; see status table below.
 
-Legend: ✅ shipping `:latest-dev` · 🚧 in progress · 📝 planned · — n/a
+<details>
+<summary><strong>Per-image dev variant status</strong></summary>
+
+<br>
+
+Legend: ✅ shipping `:latest-dev` · 🚧 in progress · 📝 planned
 
 Categories follow the three templates in [`docs/dev-variants/templates/`](docs/dev-variants/templates/) (runtime / daemon / server). The "Reference" column shows where we mirror Chainguard's public `<image>-public/devConfigs` package set; **in-house** means Chainguard ships an Enterprise-only image and we designed the dev composition ourselves.
 
 | Image | Category | Reference | Status |
 |---|---|---|---|
 | ruby | runtime | Chainguard `ruby-public` | ✅ |
-| python | runtime | Chainguard `python-public` | 🚧 |
-| node-slim | runtime | Chainguard `node-public` | 📝 |
-| go | runtime | Chainguard `go-public` | 📝 |
-| java | runtime | Chainguard `jdk-public` | 📝 |
-| dotnet | runtime | Chainguard `dotnet-runtime-10-public` | 📝 |
+| python | runtime | Chainguard `python-public` | ✅ |
+| node-slim | runtime | Chainguard `node-public` | ✅ |
+| go | runtime | Chainguard `go-public` | ✅ |
+| java | runtime | Chainguard `jdk-public` | ✅ |
+| dotnet | runtime | Chainguard `dotnet-runtime-10-public` | ✅ |
 | php | runtime | Chainguard `php-fpm-public` | 📝 |
 | rails | runtime | in-house (derive from ruby) | 📝 |
 | bun | runtime | in-house | 📝 |
@@ -304,6 +309,8 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | jenkins | server | in-house | 📝 |
 | keycloak | server | in-house | 📝 |
 | openbao | server | in-house | 📝 |
+
+</details>
 
 ```dockerfile
 # Production Dockerfile — pin by version tag, ideally by digest

--- a/dotnet/apko/dotnet-dev.yaml
+++ b/dotnet/apko/dotnet-dev.yaml
@@ -1,0 +1,116 @@
+# Development variant of minimal-dotnet.
+#
+# Prod ships dotnet-10-runtime (just the runtime). Dev ships dotnet-10
+# (full SDK with dotnet build, dotnet publish, dotnet test, etc.) plus
+# shell, apk-tools, git, full ICU data, tzdata.
+#
+# Mirrors Chainguard's dotnet-runtime-10-public/devConfigs.
+# Notably no C toolchain — dotnet build doesn't need it.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Full .NET 10 SDK + runtime (SDK is a separate Wolfi package)
+    - dotnet-10
+    - dotnet-10-runtime
+    - dotnet-10-sdk
+    - dotnet-10-targeting-pack
+
+    # Core runtime deps (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+
+    # .NET-specific runtime deps (same as prod)
+    - icu
+    - libunwind
+    - lttng-ust
+    - libxcrypt
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    - zlib
+    - xz
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- VCS for `dotnet add package` with Git refs ---
+    - git
+
+    # --- Full ICU data (prod ships smaller default) ---
+    - icu-data-full
+
+    # --- Timezone data (required by DateTimeZone APIs at build time) ---
+    - tzdata
+
+    # --- Auth + network libs for NuGet feeds, private package sources ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+    - libexpat1
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/dotnet
+
+work-dir: /app
+
+environment:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "1"
+  LANG: C.UTF-8
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # NuGet global packages cache
+  - path: /home/nonroot/.nuget
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-dotnet-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-dotnet: full .NET 10 SDK + shell + git + full ICU + tzdata. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/dotnet"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/dotnet/test-dev.sh
+++ b/dotnet/test-dev.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Smoke test for minimal-dotnet-dev.
+# Validates full SDK + shell + git on top of dotnet prod (runtime only).
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing .NET runtime version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^1[0-9]\."
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing full SDK present (dotnet build, dotnet new)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dotnet --list-sdks" | grep -qE "^1[0-9]\."
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing dotnet new + build (end-to-end SDK exercise)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c '
+cd /tmp && dotnet new console -n hello -o hello --no-restore >/dev/null &&
+cd hello && dotnet build --nologo --verbosity quiet 2>&1 | tail -3 &&
+dotnet bin/Debug/net*/hello.dll
+' | grep -q "Hello, World!"
+
+echo "✓ All dotnet-dev smoke tests passed"

--- a/go/apko/go-dev.yaml
+++ b/go/apko/go-dev.yaml
@@ -1,0 +1,128 @@
+# Development variant of minimal-go.
+#
+# Note: minimal-go's prod image already includes the GCC toolchain, git,
+# and most build deps because Go itself needs them. The dev variant adds
+# only what's missing for interactive debugging:
+#   - shell (busybox + bash)
+#   - apk-tools (install ad-hoc packages)
+#   - openssh-client (SSH-based git URLs for private modules)
+#   - extended auth stack (krb5, ldap) for private go modules
+#
+# Mirrors Chainguard's go-public/devConfigs delta.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Go runtime (same as prod)
+    - go-1.26
+
+    # Build tools (same as prod — already in go prod)
+    - binutils
+    - build-base
+    - gcc
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # Core system (same as prod)
+    - ca-certificates-bundle
+    - glibc
+    - glibc-dev
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libstdc++-dev
+    - libcrypt1
+    - libxcrypt
+    - libxcrypt-dev
+    - zlib
+    - libssl3
+    - libcrypto3
+    - libcurl-openssl4
+    - libnghttp2-14
+    - nghttp3
+    - libidn2
+    - libpsl
+    - libunistring
+    - libbrotlicommon1
+    - libbrotlidec1
+    - git
+    - nss-db
+    - nss-hesiod
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- Private module fetching via SSH ---
+    - openssh-client
+
+    # --- Extended auth stack for private modules ---
+    - krb5-libs
+    - libldap
+    - libexpat1
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/go
+
+work-dir: /app
+
+environment:
+  CGO_ENABLED: "1"
+  GOOS: linux
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+  GOROOT: /usr/lib/go
+  GOPATH: /go
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /go
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-go-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-go: same Go toolchain + shell + openssh-client for private module fetching. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/go"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/go/test-dev.sh
+++ b/go/test-dev.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Smoke test for minimal-go-dev.
+# Validates shell + openssh + auth stack on top of go prod (which already
+# ships the toolchain). Most prod assertions are covered by go/test.sh.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Go version (parity with prod)..."
+docker run --rm "$IMAGE" version | grep -qE "^go version go1\.2[6-9]"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing toolchain (gcc, make — needed for cgo)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version" >/dev/null
+
+echo "Testing git (prod parity)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing openssh-client (private module fetch via SSH)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "ssh -V" 2>&1 | grep -qE "OpenSSH_"
+
+echo "Testing Go build works (cgo path)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c '
+cd /tmp && mkdir -p hello && cd hello &&
+cat > main.go <<EOF
+package main
+/*
+static int add(int a, int b) { return a + b; }
+*/
+import "C"
+import "fmt"
+func main() { fmt.Println("3+4 =", C.add(3, 4)) }
+EOF
+go mod init hello >/dev/null 2>&1 &&
+CGO_ENABLED=1 go build -o /tmp/hello-bin ./... &&
+/tmp/hello-bin
+' | grep -q "3+4 = 7"
+
+echo "✓ All go-dev smoke tests passed"

--- a/java/apko/java-dev.yaml
+++ b/java/apko/java-dev.yaml
@@ -1,0 +1,109 @@
+# Development variant of minimal-java.
+#
+# Prod ships the JRE only. Dev ships the full OpenJDK 26 distribution
+# (javac, jar, jdeps, etc.) plus shell, apk-tools, git.
+# Mirrors Chainguard's jdk-public/devConfigs.
+#
+# Note: maven and gradle are NOT baked in — same as Chainguard. Most
+# Java projects use the Maven Wrapper (./mvnw) or Gradle Wrapper
+# (./gradlew) which download the build tool on first use. Add to your
+# Dockerfile via `RUN apk add maven` or `apk add gradle` if needed.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Full OpenJDK 26 (javac + java runtime; replaces -jre from prod)
+    - openjdk-26
+    - openjdk-26-default-jdk
+
+    # Core runtime deps (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    - zlib
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- VCS for source-based deps ---
+    - git
+
+    # --- Java desktop graphics libs (AWT / Java2D for tools like JConsole,
+    #     also required by some build-time bytecode generators) ---
+    - freetype
+    - fontconfig
+    - lcms2
+    - giflib
+    - alsa-lib
+
+    # --- Auth + network libs commonly needed by enterprise Java apps ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/java
+
+work-dir: /app
+
+environment:
+  JAVA_HOME: /usr/lib/jvm/java-26-openjdk
+  PATH: /usr/lib/jvm/java-26-openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Maven local repo dir for `mvn install` from build stages
+  - path: /home/nonroot/.m2
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-java-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-java: full OpenJDK 26 (not just JRE) + shell + git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/java"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/java/test-dev.sh
+++ b/java/test-dev.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Smoke test for minimal-java-dev.
+# Validates full JDK + shell + git on top of java prod (which ships JRE only).
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Java version (parity with prod)..."
+docker run --rm "$IMAGE" -version 2>&1 | grep -qE "openjdk version \"2[6-9]"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing javac (full JDK, not just JRE)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "javac -version" 2>&1 | grep -qE "javac 2[6-9]"
+
+echo "Testing jar tool present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "jar --version" | grep -qE "^jar 2[6-9]"
+
+echo "Testing jdeps present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "jdeps --version" | grep -qE "^2[6-9]"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing compile + run a tiny program..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c '
+cd /tmp && cat > Hello.java <<EOF
+public class Hello { public static void main(String[] args) { System.out.println("javac+java OK"); } }
+EOF
+javac Hello.java && java -cp /tmp Hello
+' | grep -q "javac+java OK"
+
+echo "✓ All java-dev smoke tests passed"

--- a/node-slim/apko/node-slim-dev.yaml
+++ b/node-slim/apko/node-slim-dev.yaml
@@ -1,0 +1,127 @@
+# Development variant of minimal-node-slim.
+# Same Node.js 26 runtime as prod, plus shell, npm/yarn/pnpm/corepack,
+# build toolchain (for node-gyp), git, and native-module deps.
+# Intended for CI build stages and in-pod debugging. NOT for production.
+#
+# Mirrors Chainguard's node-public/devConfigs package set.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Node.js runtime (same as prod)
+    - nodejs-26
+
+    # Init system (same as prod entrypoint chain)
+    - dumb-init
+
+    # Core libs (same as prod)
+    - glibc
+    - libstdc++
+    - libgcc
+    - libssl3
+    - libcrypto3
+    - zlib
+    - c-ares
+    - libuv
+    - nghttp2
+    - libbrotlicommon1
+    - libbrotlidec1
+    - libbrotlienc1
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain (node-gyp builds native modules) ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++-dev
+    - libxcrypt-dev
+
+    # --- Node package managers (all baked in, switchable via corepack) ---
+    - npm
+    - yarn
+    - pnpm
+    - corepack
+    - node-gyp
+
+    # --- VCS for `npm install git+...` ---
+    - git
+
+    # --- Auth + network libs commonly needed by native modules ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+    - libexpat1
+    - libidn2
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/dumb-init -- /usr/bin/node
+
+work-dir: /app
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+  NODE_ENV: development
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Writable npm cache + global dir for `npm install -g` without root
+  - path: /home/nonroot/.npm
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-node-slim-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-node-slim: same Node.js runtime + shell + build toolchain + npm/yarn/pnpm. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/node-slim"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/node-slim/test-dev.sh
+++ b/node-slim/test-dev.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Smoke test for minimal-node-slim-dev.
+# Validates shell + toolchain + node package managers while preserving
+# prod runtime parity.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Node.js version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^v(26|2[6-9])\."
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make, pkgconf)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version && pkgconf --version" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing npm baked in..."
+npm_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "npm --version")
+echo "$npm_ver" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+" || { echo "::error::npm version unexpected: $npm_ver"; exit 1; }
+
+echo "Testing yarn baked in..."
+yarn_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "yarn --version")
+echo "$yarn_ver" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+" || { echo "::error::yarn version unexpected: $yarn_ver"; exit 1; }
+
+echo "Testing pnpm baked in..."
+pnpm_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "pnpm --version")
+echo "$pnpm_ver" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+" || { echo "::error::pnpm version unexpected: $pnpm_ver"; exit 1; }
+
+echo "Testing corepack baked in..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "corepack --version" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+"
+
+echo "Testing node-gyp baked in..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "node-gyp --version" | grep -qE "^v?[0-9]+\."
+
+echo "Testing npm install works (writes to ~/.npm)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c \
+  "cd /tmp && npm init -y >/dev/null && npm install --silent --no-fund --no-audit lodash && node -e 'console.log(require(\"lodash\").VERSION || \"lodash loaded\")'" \
+  | grep -qE "(lodash loaded|^[0-9]+\.[0-9]+\.[0-9]+)"
+
+echo "Testing core node modules (crypto, fs, http)..."
+docker run --rm "$IMAGE" -e "require('crypto'); require('fs'); require('http'); console.log('Core modules OK')" \
+  | grep -q "Core modules OK"
+
+echo "✓ All node-slim-dev smoke tests passed"


### PR DESCRIPTION
## Summary

First Phase 1 batch: 4 language runtime dev variants. Each mirrors the corresponding Chainguard \`<image>-public/devConfigs\` package set as closely as Wolfi naming allows.

Brings the dev variant catalog from 2 (ruby, python) to **6 of 41**.

## Per-image notes

- **node-slim** — full npm/yarn/pnpm/corepack/node-gyp baked in, C++ toolchain for native modules. Entrypoint stays \`/usr/bin/dumb-init -- /usr/bin/node\`.
- **go** — shell + openssh-client + extended auth stack on top of prod (which already ships the toolchain since Go needs it). Smallest dev/prod delta in the catalog.
- **java** — full \`openjdk-26\` (not just \`-jre\`) so \`javac\` and build tools work. AWT graphics libs for JConsole etc. Maven/Gradle not baked in — use the wrapper scripts (\`./mvnw\`, \`./gradlew\`), same convention as Chainguard.
- **dotnet** — full \`dotnet-10-sdk\` + targeting pack (prod is runtime-only). Full ICU data + tzdata for build-time globalization APIs. No C toolchain — dotnet build doesn't need it.

## Infrastructure changes

- Makefile macro calls for the 4 images (one-liners thanks to PR #146).
- \`build.yml\`: \`variants:["prod","dev"]\` on the 4 \`APKO_IMAGES\` entries. Also simplifies APKO_MATRIX dev-path derivation to use the universal \`<name>/apko/<name>-dev.yaml\` convention.
- README dev variant tracker: 4 rows from 📝 to ✅, plus collapses the 41-row table behind a \`<details>\` summary so it stops dominating the page.

## Test plan

Local validation (CLAUDE.md required):

- [x] All 4 \`make <image>-dev\` builds green
- [x] All 4 \`make test-<image>-dev\` smoke tests green
- [x] \`make <image>\` (prod) unchanged

In CI:

- [ ] APKO_MATRIX produces 2 rows for each of node-slim/go/java/dotnet (prod + dev)
- [ ] Each dev row publishes \`:latest-dev\` + \`-dev\` versioned tags
- [ ] Each dev row signs, attests, skips grype scan