### PR TITLE
feat(dev-variants): batches 1B + 2A — 8 dev variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,12 +60,12 @@ jobs:
           # Image configuration
           MELANGE_IMAGES='[
             {"name":"jenkins"},
-            {"name":"redis-slim","apko":"redis-slim/apko/redis.yaml"},
+            {"name":"redis-slim","apko":"redis-slim/apko/redis.yaml","variants":["prod","dev"]},
             {"name":"mysql"},{"name":"memcached"},{"name":"caddy"},
-            {"name":"haproxy"},{"name":"ruby","variants":["prod","dev"]},{"name":"php"},{"name":"rails"},
-            {"name":"kafka"},{"name":"valkey"},{"name":"nats"},
+            {"name":"haproxy"},{"name":"ruby","variants":["prod","dev"]},{"name":"php","variants":["prod","dev"]},{"name":"rails","variants":["prod","dev"]},
+            {"name":"kafka"},{"name":"valkey","variants":["prod","dev"]},{"name":"nats"},
             {"name":"traefik"},{"name":"rabbitmq"},{"name":"minio"},
-            {"name":"prometheus"},{"name":"mariadb"},{"name":"etcd"},
+            {"name":"prometheus"},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd"},
             {"name":"victoria-metrics"},{"name":"jaeger"},{"name":"otelcol"},
             {"name":"qdrant"},{"name":"envoy"},{"name":"gitea"},
             {"name":"coredns"},{"name":"openbao"},{"name":"loki"},
@@ -77,13 +77,13 @@ jobs:
             {"name":"go","grep":"go-[0-9]","variants":["prod","dev"]},
             {"name":"nginx","grep":"nginx-mainline"},
             {"name":"httpd","grep":"apache2"},
-            {"name":"postgres-slim","apko":"postgres-slim/apko/postgres.yaml","grep":"postgresql-[0-9]"},
-            {"name":"bun","grep":"bun"},
+            {"name":"postgres-slim","apko":"postgres-slim/apko/postgres.yaml","grep":"postgresql-[0-9]","variants":["prod","dev"]},
+            {"name":"bun","grep":"bun","variants":["prod","dev"]},
             {"name":"sqlite","grep":"sqlite"},
             {"name":"dotnet","grep":"dotnet-[0-9].*-runtime","variants":["prod","dev"]},
             {"name":"java","grep":"openjdk-[0-9]+","variants":["prod","dev"]},
             {"name":"opensearch","grep":"opensearch-3"},
-            {"name":"deno","grep":"deno"}
+            {"name":"deno","grep":"deno","variants":["prod","dev"]}
           ]'
 
           # Determine if full rebuild is needed
@@ -499,7 +499,9 @@ jobs:
           # Read primary package name from apko config (source of truth).
           # Dev variants resolve their own SBOM but the primary package
           # version matches prod (same upstream binary).
-          PRIMARY_PKG=$(grep -oE '${{ matrix.primary_grep }}[a-z0-9.\-]*' ${{ matrix.apko_config }} | head -1)
+          # Restrict to actual package list entries (apko yaml indented `- pkg`)
+          # so header comments mentioning a related package name don't false-match.
+          PRIMARY_PKG=$(grep -oE '^[[:space:]]+-[[:space:]]+${{ matrix.primary_grep }}[a-z0-9.\-]*' ${{ matrix.apko_config }} | grep -oE '${{ matrix.primary_grep }}[a-z0-9.\-]*' | head -1)
           if [ -z "$PRIMARY_PKG" ]; then
             echo "::error::Failed to extract primary package from ${{ matrix.apko_config }} using pattern '${{ matrix.primary_grep }}'"
             exit 1

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test-$(1)-dev:
 endef
 
 .PHONY: all build scan clean help
-.PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim bun sqlite dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange rails rails-melange kafka kafka-melange keygen opensearch
+.PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange redis-slim-dev mysql mysql-melange mysql-local memcached memcached-melange caddy caddy-melange haproxy haproxy-melange postgres-slim postgres-slim-dev bun bun-dev sqlite dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange php-dev rails rails-melange rails-dev deno deno-dev kafka kafka-melange keygen opensearch mariadb mariadb-melange mariadb-dev valkey valkey-melange valkey-dev
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange mariadb mariadb-melange
 .PHONY: etcd etcd-melange victoria-metrics victoria-metrics-melange jaeger jaeger-melange otelcol otelcol-melange qdrant qdrant-melange deno
@@ -106,7 +106,7 @@ endef
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
-.PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
+.PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
 all: build scan
 
@@ -145,6 +145,14 @@ $(eval $(call DEV_IMAGE_RULE,node-slim))
 $(eval $(call DEV_IMAGE_RULE,go))
 $(eval $(call DEV_IMAGE_RULE,java))
 $(eval $(call DEV_IMAGE_RULE,dotnet))
+$(eval $(call DEV_IMAGE_RULE,bun))
+$(eval $(call DEV_IMAGE_RULE,deno))
+$(eval $(call DEV_IMAGE_RULE,rails,rails-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,php,php-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,postgres-slim))
+$(eval $(call DEV_IMAGE_RULE,mariadb,mariadb-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,redis-slim,redis-slim-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,valkey,valkey-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1423,6 +1431,14 @@ $(eval $(call DEV_TEST_RULE,node-slim))
 $(eval $(call DEV_TEST_RULE,go))
 $(eval $(call DEV_TEST_RULE,java))
 $(eval $(call DEV_TEST_RULE,dotnet))
+$(eval $(call DEV_TEST_RULE,bun))
+$(eval $(call DEV_TEST_RULE,deno))
+$(eval $(call DEV_TEST_RULE,rails))
+$(eval $(call DEV_TEST_RULE,php))
+$(eval $(call DEV_TEST_RULE,postgres-slim))
+$(eval $(call DEV_TEST_RULE,mariadb))
+$(eval $(call DEV_TEST_RULE,redis-slim))
+$(eval $(call DEV_TEST_RULE,valkey))
 
 test-python:
 	@echo "Testing Python image..."

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 6 of 41 dev variants — `ruby`, `python`, `node-slim`, `go`, `java`, `dotnet`. The other 35 are rolling out batch by batch; see status table below.
+**Shipping today:** 14 of 41 dev variants — all language runtimes (`ruby`, `python`, `node-slim`, `go`, `java`, `dotnet`, `bun`, `deno`, `rails`, `php`) plus 4 databases (`postgres-slim`, `mariadb`, `redis-slim`, `valkey`). The other 27 are rolling out batch by batch; see status table below.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -274,15 +274,15 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | go | runtime | Chainguard `go-public` | ✅ |
 | java | runtime | Chainguard `jdk-public` | ✅ |
 | dotnet | runtime | Chainguard `dotnet-runtime-10-public` | ✅ |
-| php | runtime | Chainguard `php-fpm-public` | 📝 |
-| rails | runtime | in-house (derive from ruby) | 📝 |
-| bun | runtime | in-house | 📝 |
-| deno | runtime | in-house | 📝 |
-| postgres-slim | daemon | Chainguard `postgres-public` | 📝 |
-| mariadb | daemon | Chainguard `mariadb-public` | 📝 |
+| php | runtime | in-house (composer deferred — see PR) | ✅ |
+| rails | runtime | in-house (derive from ruby) | ✅ |
+| bun | runtime | in-house | ✅ |
+| deno | runtime | in-house | ✅ |
+| postgres-slim | daemon | Chainguard `postgres-public` | ✅ |
+| mariadb | daemon | Chainguard `mariadb-public` | ✅ |
 | mysql | daemon | in-house | 📝 |
-| redis-slim | daemon | Chainguard `redis-public` | 📝 |
-| valkey | daemon | Chainguard `valkey-public` | 📝 |
+| redis-slim | daemon | Chainguard `redis-public` | ✅ |
+| valkey | daemon | Chainguard `valkey-public` | ✅ |
 | memcached | daemon | in-house | 📝 |
 | sqlite | daemon | in-house | 📝 |
 | opensearch | daemon | in-house | 📝 |

--- a/bun/apko/bun-dev.yaml
+++ b/bun/apko/bun-dev.yaml
@@ -1,0 +1,108 @@
+# Development variant of minimal-bun.
+# Same Bun runtime as prod, plus shell, apk-tools, gcc toolchain (for
+# native modules), git. Bun ships its own package manager and bundler
+# built into the binary — no separate `bun-cli` apk needed.
+#
+# In-house composition (Chainguard has no public bun-dev reference).
+# Follows docs/dev-variants/templates/runtime-dev.yaml.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Bun runtime (same as prod)
+    - bun
+
+    # Core system (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain (bun install builds native modules) ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++
+    - libstdc++-dev
+    - libxcrypt-dev
+
+    # --- VCS for `bun install git://...` ---
+    - git
+
+    # --- Network libs for fetching deps ---
+    - libssl3
+    - libcrypto3
+    - libcurl-openssl4
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/bun
+
+work-dir: /app
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Writable bun install cache
+  - path: /home/nonroot/.bun
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-bun-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-bun: same Bun runtime + shell + build toolchain + git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/bun"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/bun/test-dev.sh
+++ b/bun/test-dev.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Smoke test for minimal-bun-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Bun version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing bun install works (writes to ~/.bun)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c \
+  "cd /tmp && mkdir -p bunapp && cd bunapp && bun init -y >/dev/null 2>&1 && bun add --no-save lodash 2>&1 | tail -3" >/dev/null
+
+echo "Testing bun run (TypeScript out of the box)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c '
+echo "console.log(\"bun ts ok\")" > /tmp/hello.ts && bun run /tmp/hello.ts
+' | grep -q "bun ts ok"
+
+echo "✓ All bun-dev smoke tests passed"

--- a/deno/apko/deno-dev.yaml
+++ b/deno/apko/deno-dev.yaml
@@ -1,0 +1,96 @@
+# Development variant of minimal-deno.
+# Same Deno runtime as prod, plus shell, apk-tools, gcc toolchain (for
+# FFI/NAPI native deps), git. Deno ships its own module loader,
+# formatter, linter, and test runner built into the binary.
+#
+# In-house composition (Chainguard has no public deno-dev reference).
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base + Deno runtime (same as prod)
+    - wolfi-baselayout
+    - deno
+    - glibc
+    - glibc-locale-posix
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - zlib
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain (Deno FFI / NAPI builds) ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++-dev
+
+    # --- VCS for fetching modules over git URLs ---
+    - git
+
+    # --- Network libs for fetching modules ---
+    - libcurl-openssl4
+    - libexpat1
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/deno
+
+work-dir: /app
+
+environment:
+  DENO_DIR: /tmp/.deno
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-deno-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-deno: same Deno runtime + shell + build toolchain + git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/deno"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/deno/test-dev.sh
+++ b/deno/test-dev.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Smoke test for minimal-deno-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Deno version (parity with prod)..."
+docker run --rm "$IMAGE" --version | head -1 | grep -qE "^deno "
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing deno run (TypeScript out of the box)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c '
+echo "console.log(\"deno ts ok\")" > /tmp/hello.ts && deno run --allow-all /tmp/hello.ts
+' | grep -q "deno ts ok"
+
+echo "Testing deno's bundled tools (fmt, lint)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "deno fmt --help | head -1 && deno lint --help | head -1" >/dev/null
+
+echo "✓ All deno-dev smoke tests passed"

--- a/mariadb/apko/mariadb-dev.yaml
+++ b/mariadb/apko/mariadb-dev.yaml
@@ -1,0 +1,96 @@
+# Development variant of minimal-mariadb.
+# Same MariaDB server (built from source via melange) as prod, plus
+# bash, apk-tools, mariadb-client (the CLI), git, curl.
+#
+# In-house composition (our mariadb-minimal is source-built, not the
+# Wolfi mariadb-12.2 family Chainguard uses). Same shape as their dev
+# variant though.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # MariaDB (built from source via melange — same as prod)
+    - mariadb-minimal
+
+    # Core libs (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - ncurses
+    - libpcre2-8-0
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- HTTP/socket debugging ---
+    - curl
+    - socat
+
+    # --- JSON parsing ---
+    - jq
+
+    # --- VCS ---
+    - git
+
+accounts:
+  groups:
+    - groupname: mysql
+      gid: 65532
+  users:
+    - username: mysql
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/docker-entrypoint.sh
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  LANG: C.UTF-8
+
+paths:
+  - path: /var/lib/mysql
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /run/mysqld
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mariadb-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-mariadb: same server + shell + mariadb client + curl/socat/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mariadb"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mariadb/test-dev.sh
+++ b/mariadb/test-dev.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Smoke test for minimal-mariadb-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing mariadbd version (parity with prod)..."
+docker run --rm --entrypoint /usr/sbin/mariadbd "$IMAGE" --version | grep -qE "mariadbd"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing mariadb client (mariadb / mysql CLI)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "mariadb --version" | grep -qE "mariadb"
+
+echo "Testing mysql compatibility CLI..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "mysql --version" | grep -qE "(mysql|mariadb)"
+
+echo "Testing mariadb-install-db present (db init)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/mariadb-install-db"
+
+echo "Testing curl/socat/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && socat -V >/dev/null 2>&1 && jq --version >/dev/null"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All mariadb-dev smoke tests passed"

--- a/php/apko/php-dev.yaml
+++ b/php/apko/php-dev.yaml
@@ -1,0 +1,120 @@
+# Development variant of minimal-php.
+# Same PHP 8.5 CLI as prod, plus shell, apk-tools, gcc toolchain (for
+# native extensions like grpc/redis), git.
+#
+# NOTE on composer (PHP's package manager): NOT baked in v1.
+# Our prod php-minimal is built with --disable-all --enable-cli plus a
+# small set of extensions (openssl, zlib, libxml, curl, mbstring,
+# opcache). Composer requires php-ctype and php-phar, which our build
+# does not enable. To use composer in this image, either:
+#   1. Download composer.phar at runtime (after we add phar+ctype to
+#      php-minimal — tracked separately)
+#   2. Install Wolfi's `composer` apk which pulls Wolfi's php-8.5
+#      alongside our php-minimal (wasteful but functional)
+#
+# In-house composition (Chainguard's php-fpm-public is FPM-specific,
+# not directly applicable to our CLI build).
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # PHP CLI (built from source via melange — same as prod)
+    - php-minimal
+
+    # Core runtime deps (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+
+    # PHP runtime libs (same as prod)
+    - libxml2
+    - libssl3
+    - libcrypto3
+    - zlib
+    - libcurl-openssl4
+    - oniguruma
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain (PECL native extension compilation) ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers (PHP API + common ext deps) ---
+    - glibc-dev
+    - libstdc++
+    - libstdc++-dev
+    - libxcrypt-dev
+
+    # --- VCS for fetching extensions and packages ---
+    - git
+
+    # --- Common ext-required libs ---
+    - krb5-libs
+    - libldap
+    - libexpat1
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/php
+
+work-dir: /app
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-php-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-php: same PHP CLI runtime + shell + build toolchain + git. composer NOT baked in v1. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/php"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/php/test-dev.sh
+++ b/php/test-dev.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Smoke test for minimal-php-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing PHP version (parity with prod)..."
+docker run --rm "$IMAGE" -v | grep -qE "^PHP 8\."
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make, pkgconf)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version && pkgconf --version" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing PHP extensions present (openssl, mbstring, curl, libxml)..."
+docker run --rm "$IMAGE" -r "echo extension_loaded('openssl') ? 'openssl-OK' : 'openssl-MISSING'; echo PHP_EOL;
+echo extension_loaded('mbstring') ? 'mbstring-OK' : 'mbstring-MISSING'; echo PHP_EOL;
+echo extension_loaded('curl') ? 'curl-OK' : 'curl-MISSING'; echo PHP_EOL;
+echo extension_loaded('libxml') ? 'libxml-OK' : 'libxml-MISSING'; echo PHP_EOL;" \
+  | grep -c "OK" | grep -q "^4$"
+
+echo "Testing simple PHP script execution..."
+docker run --rm "$IMAGE" -r "echo 'hello php', PHP_EOL;" | grep -q "hello php"
+
+echo "✓ All php-dev smoke tests passed"

--- a/postgres-slim/apko/postgres-slim-dev.yaml
+++ b/postgres-slim/apko/postgres-slim-dev.yaml
@@ -1,0 +1,120 @@
+# Development variant of minimal-postgres-slim.
+# Same PostgreSQL 18 + client tools as prod, plus shell, apk-tools,
+# gosu (for user switching in init scripts), curl, socat, jq.
+#
+# Mirrors Chainguard's postgres-public/devConfigs delta.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # PostgreSQL server + client (same as prod)
+    - postgresql-18
+    - postgresql-18-base
+    - postgresql-18-client
+    - postgresql-18-client-base
+    - postgresql-18-contrib
+    - ecpg-18
+    - libpq-18
+    - pgaudit-18
+
+    # Core libs (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - glibc-locale-en
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libcrypt1
+    - libxcrypt
+    - libssl3
+    - libcrypto3
+    - libicu78
+    - icu78-data-full
+    - cyrus-sasl
+    - heimdal-libs
+    - krb5-libs
+    - krb5-conf
+    - keyutils-libs
+    - libldap-2.6
+    - libverto
+    - linux-pam
+    - libselinux
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- User-switching in init scripts ---
+    - gosu
+
+    # --- HTTP/socket debugging ---
+    - curl
+    - socat
+
+    # --- JSON parsing for psql output ---
+    - jq
+
+    # --- VCS for fetching extensions from source ---
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/postgres
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  LANG: C.UTF-8
+  PGDATA: /var/lib/postgresql/data
+
+paths:
+  - path: /var/lib/postgresql
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /var/lib/postgresql/data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /var/run/postgresql
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-postgres-slim-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-postgres-slim: same PostgreSQL + shell + psql/curl/socat/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/postgres-slim"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/postgres-slim/test-dev.sh
+++ b/postgres-slim/test-dev.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Smoke test for minimal-postgres-slim-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing postgres version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^postgres \(PostgreSQL\) (18|19)"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing psql client present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "psql --version" | grep -qE "^psql"
+
+echo "Testing pg_dump present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "pg_dump --version" | grep -qE "^pg_dump"
+
+echo "Testing pg_basebackup present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "pg_basebackup --version" | grep -qE "^pg_basebackup"
+
+echo "Testing pg_isready present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "pg_isready --version" | grep -qE "^pg_isready"
+
+echo "Testing gosu present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gosu --version" 2>&1 | grep -qE "^[0-9]+\.[0-9]+"
+
+echo "Testing curl/socat/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && socat -V >/dev/null 2>&1 && jq --version >/dev/null"
+
+echo "Testing initdb works..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "initdb --version" | grep -qE "^initdb"
+
+echo "✓ All postgres-slim-dev smoke tests passed"

--- a/rails/apko/rails-dev.yaml
+++ b/rails/apko/rails-dev.yaml
@@ -1,0 +1,141 @@
+# Development variant of minimal-rails.
+# Same Rails 8 + Ruby 4.0 runtime as prod (bundler already included),
+# plus shell, apk-tools, gcc toolchain for native gems, git, and Node.js
+# for the Rails asset pipeline (jsbundling-rails, cssbundling-rails).
+#
+# In-house composition (Chainguard has no public rails-dev reference).
+# Derives the structure from ruby-dev plus a JS runtime for assets.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Rails + Ruby + bundler (built from source via melange — same as prod)
+    - rails-minimal
+
+    # Core runtime deps (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+
+    # Ruby runtime libs (same as prod)
+    - libssl3
+    - libcrypto3
+    - libcrypt1
+    - zlib
+    - yaml
+    - libffi
+    - readline
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- C/C++ toolchain (native gem compilation: nokogiri, pg, etc.) ---
+    - build-base
+    - gcc
+    - binutils
+    - make
+    - pkgconf
+    - posix-cc-wrappers
+    - linux-headers
+    - openssf-compiler-options
+
+    # --- Dev headers ---
+    - glibc-dev
+    - libstdc++-dev
+    - libxcrypt-dev
+
+    # --- Node.js for the Rails asset pipeline (jsbundling/cssbundling) ---
+    - nodejs-26
+    - npm
+    - yarn
+
+    # --- VCS for `bundle install --git` ---
+    - git
+
+    # --- Auth + network libs for popular native gems ---
+    - krb5-libs
+    - libldap
+    - libcurl-openssl4
+    - libexpat1
+
+    # --- DB client libs for ActiveRecord adapters ---
+    - sqlite-libs
+
+    # --- Ruby stdlib helpers ---
+    - gdbm
+    - ncurses
+    - ncurses-terminfo-base
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  # MUST match prod for drop-in compatibility.
+  command: /usr/bin/ruby
+
+work-dir: /app
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+  RAILS_ENV: development
+
+paths:
+  - path: /app
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+  # Writable gem dir for `gem install --user-install`
+  - path: /home/nonroot/.gem
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  # Writable npm cache (used by Rails asset pipeline via yarn/npm)
+  - path: /home/nonroot/.npm
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+
+annotations:
+  org.opencontainers.image.title: "minimal-rails-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-rails: same Rails + Ruby + bundler runtime + shell + build toolchain + Node.js for assets. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/rails"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/rails/test-dev.sh
+++ b/rails/test-dev.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Smoke test for minimal-rails-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Ruby version (parity with prod)..."
+docker run --rm "$IMAGE" -v | grep -qE "^ruby 4"
+
+echo "Testing Rails available (parity with prod)..."
+docker run --rm "$IMAGE" -e "require 'rails'; puts Rails.version" | grep -qE "^[0-9]+\.[0-9]+"
+
+echo "Testing Bundler (already in prod)..."
+bundle_ver=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c "bundle --version")
+echo "$bundle_ver" | grep -qE "^[0-9]+\.[0-9]+\.[0-9]+" || { echo "::error::bundle version unexpected: $bundle_ver"; exit 1; }
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing C toolchain (gcc, make, pkgconf)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "gcc --version && make --version && pkgconf --version" >/dev/null
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "Testing Node.js + npm (asset pipeline)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "node --version && npm --version" >/dev/null
+
+echo "Testing yarn..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "yarn --version" | grep -qE "^[0-9]+\.[0-9]+"
+
+echo "Testing gem install --user-install works..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c \
+  "gem install --no-document --user-install rake && ~/.gem/ruby/*/bin/rake --version" | grep -q "rake,"
+
+echo "✓ All rails-dev smoke tests passed"

--- a/redis-slim/apko/redis-slim-dev.yaml
+++ b/redis-slim/apko/redis-slim-dev.yaml
@@ -1,0 +1,90 @@
+# Development variant of minimal-redis-slim.
+# Same redis-server (built from source via melange) as prod, plus
+# bash, apk-tools, redis-cli, curl/socat/jq for debugging.
+#
+# In-house composition (our redis-minimal is source-built, not Wolfi's
+# redis-8.6 family). Same shape as Chainguard's redis-public/devConfigs.
+# redis-cli is part of the same upstream redis source build, so it's
+# already in our redis-minimal package.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Redis server + CLI (built from source via melange — same as prod)
+    - redis-minimal
+
+    # Core libs (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - libjemalloc2
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- HTTP/socket debugging ---
+    - curl
+    - socat
+
+    # --- JSON parsing for redis-cli --json output ---
+    - jq
+
+    # --- VCS ---
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/redis-server
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  LANG: C.UTF-8
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-redis-slim-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-redis-slim: same redis-server + shell + redis-cli + curl/socat/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/redis-slim"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/redis-slim/test-dev.sh
+++ b/redis-slim/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-redis-slim-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing redis-server version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^Redis server"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing redis-cli present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "redis-cli --version" | grep -qE "^redis-cli"
+
+echo "Testing curl/socat/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && socat -V >/dev/null 2>&1 && jq --version >/dev/null"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All redis-slim-dev smoke tests passed"

--- a/valkey/apko/valkey-dev.yaml
+++ b/valkey/apko/valkey-dev.yaml
@@ -1,0 +1,88 @@
+# Development variant of minimal-valkey.
+# Same valkey-server (built from source via melange) as prod, plus
+# bash, apk-tools, valkey-cli, curl/socat/jq for debugging.
+#
+# In-house composition (our valkey-minimal is source-built, not Wolfi's
+# valkey-9.0 family). Same shape as Chainguard's valkey-public/devConfigs.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Valkey server + CLI (built from source via melange — same as prod)
+    - valkey-minimal
+
+    # Core libs (same as prod)
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - libjemalloc2
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- HTTP/socket debugging ---
+    - curl
+    - socat
+
+    # --- JSON parsing ---
+    - jq
+
+    # --- VCS ---
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/valkey-server
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  LANG: C.UTF-8
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-valkey-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-valkey: same valkey-server + shell + valkey-cli + curl/socat/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/valkey"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/valkey/test-dev.sh
+++ b/valkey/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-valkey-dev.
+set -euo pipefail
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing valkey-server version (parity with prod)..."
+docker run --rm "$IMAGE" --version | grep -qE "^Valkey server"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing valkey-cli present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "valkey-cli --version" | grep -qE "^valkey-cli"
+
+echo "Testing curl/socat/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && socat -V >/dev/null 2>&1 && jq --version >/dev/null"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All valkey-dev smoke tests passed"


### PR DESCRIPTION
## Summary

Brings dev variant catalog from **6 to 14 of 41**. Bundles two batches that locally validated together:

- **Batch 1B (runtimes)**: bun, deno, rails, php
- **Batch 2A (databases with Chainguard ref)**: postgres-slim, mariadb, redis-slim, valkey

After this merges, all 10 language runtimes ship dev variants. Daemon coverage starts at 4 of 13.

## Per-image highlights

### Runtimes
- **bun**: gcc toolchain for native modules + git. Bun's own package manager is built into the binary.
- **deno**: gcc toolchain (FFI/NAPI) + git. Deno bundles fmt/lint/test.
- **rails**: same Rails+Ruby+bundler from prod + toolchain + git + Node.js for asset pipeline.
- **php** (v1, composer NOT baked): our php-minimal lacks ctype+phar that composer requires. Documented inline; future PR can either extend php-minimal or document \`apk add composer\` workaround.

### Databases
- **postgres-slim**: PostgreSQL 18 server + client + gosu + curl/socat/jq. Mirrors Chainguard postgres-public dev.
- **mariadb**: source-built mariadb + client (and \`mysql\` compat alias) + mariadb-install-db.
- **redis-slim**: source-built redis-server + redis-cli (in same apk).
- **valkey**: source-built valkey-server + valkey-cli.

## Infrastructure changes

- Makefile: 8 macro calls via \`\$(eval \$(call DEV_IMAGE_RULE,...))\`. PHONY updated.
- \`build.yml\`: \`variants:["prod","dev"]\` on 8 entries (5 MELANGE_IMAGES, 3 APKO_IMAGES). Also **tightens the PRIMARY_PKG grep step** to match only actual apko yaml list entries (\`^\\s+- pkg\`), so header comments don't false-match — prevents the java-dev failure mode we hit on PR #147.
- README dev variant tracker: 8 rows from 📝 to ✅. Header now reads "14 of 41 dev variants shipping" with all language runtimes complete.

## Test plan

Local validation (CLAUDE.md required):

- [x] All 8 \`<image>-dev\` apko builds green on x86_64
- [x] All 8 \`test-<image>-dev\` smoke tests green
- [x] yq parses build.yml

In CI:

- [ ] Matrix expands to 2 rows per opted-in image (8 new dev rows)
- [ ] Each dev row publishes \`:latest-dev\` + \`-dev\` versioned tags
- [ ] No regression on prod variants