### PR TITLE
fix(patch-go-deps): add +incompatible suffix for modules that need it

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -170,6 +170,19 @@ jobs:
             MODROOT="${MODROOTS[$IMAGE]}"
             MARKER="${BUILD_MARKERS[$IMAGE]}"
 
+            # Modules that use Go's "+incompatible" versioning: their import
+            # path lacks a /vN suffix despite shipping major versions ≥ 2.
+            # `go get pkg@vX.Y.Z` fails for these with "invalid version: unknown
+            # revision"; the correct form is `go get pkg@vX.Y.Z+incompatible`.
+            # Add to this list when a new offender shows up in CI failures.
+            INCOMPAT_MODULES=(
+              "github.com/docker/docker"
+              "github.com/docker/cli"
+              "github.com/docker/distribution"
+              "github.com/Microsoft/hcsshim"
+              "k8s.io/kubernetes"
+            )
+
             # Build go get commands
             GO_GETS=""
             APPLIED_COUNT=0
@@ -179,6 +192,15 @@ jobs:
                 echo "  Skipping incompatible Loki module bump: $mod_ver"
                 continue
               fi
+              # Apply +incompatible suffix for known modules that need it.
+              mod_path="${mod_ver%@*}"
+              for incompat in "${INCOMPAT_MODULES[@]}"; do
+                if [ "$mod_path" = "$incompat" ] && [[ "$mod_ver" != *"+incompatible" ]]; then
+                  mod_ver="${mod_ver}+incompatible"
+                  echo "  Applied +incompatible suffix: $mod_ver"
+                  break
+                fi
+              done
               GO_GETS="${GO_GETS}      go get ${mod_ver}\n"
               APPLIED_COUNT=$((APPLIED_COUNT + 1))
             done <<< "$FIXES"


### PR DESCRIPTION
## Summary

The auto-patcher (PR #155 was the symptom) generated \`go get github.com/docker/docker@v29.3.1\` which fails with:

\`\`\`
go: invalid version: unknown revision v29.3.1
\`\`\`

docker/docker uses Go's \`+incompatible\` versioning convention: the import path is \`github.com/docker/docker\` (no \`/v29\` suffix) despite major version 29. Per Go module rules, such modules must be fetched as \`pkg@vX.Y.Z+incompatible\`.

## Fix

Small allowlist of known \`+incompatible\` modules in the patch-go-deps workflow. When grype suggests a fix version for one of them, the workflow now appends \`+incompatible\` automatically.

\`\`\`bash
INCOMPAT_MODULES=(
  "github.com/docker/docker"
  "github.com/docker/cli"
  "github.com/docker/distribution"
  "github.com/Microsoft/hcsshim"
  "k8s.io/kubernetes"
)
\`\`\`

Same pattern as the existing loki/prometheus image-specific skip rule a few lines above. New offenders get added to this list when they show up in CI.

## Test plan

- [x] yq parses workflow yaml
- [x] Bash logic verified end-to-end:
  - \`github.com/docker/docker@v29.3.1\` → \`+incompatible\` appended
  - \`github.com/google/uuid@v1.6.0\` → untouched (normal semver)
  - \`k8s.io/kubernetes@v1.34.0\` → \`+incompatible\` appended
- [ ] Next scheduled patch-go-deps run regenerates clean PRs

PR #155 has been closed; this PR replaces it.