### PR TITLE
fix(patch-go-deps): verify version exists in Go proxy before patching

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -201,6 +201,22 @@ jobs:
                   break
                 fi
               done
+              # Verify the version actually exists in the Go module proxy
+              # before generating the patch. Grype's CVE database sometimes
+              # reports fix versions that don't correspond to real upstream
+              # tags (docker/docker v29.3.1 was a recent example — grype said
+              # fix=29.3.1 but the highest docker tag was v28.5.2).
+              # Without this check, the resulting `go get` fails with
+              # "invalid version: unknown revision X.Y.Z" and the whole
+              # melange build is dead. A skip here just means the CVE stays
+              # in the dashboard until grype's data catches up or someone
+              # patches it manually.
+              mod="${mod_ver%@*}"
+              ver="${mod_ver#*@}"
+              if ! curl -fs --max-time 10 "https://proxy.golang.org/${mod}/@v/${ver}.info" >/dev/null 2>&1; then
+                echo "  Skipping ${mod_ver}: version not in Go module proxy"
+                continue
+              fi
               GO_GETS="${GO_GETS}      go get ${mod_ver}\n"
               APPLIED_COUNT=$((APPLIED_COUNT + 1))
             done <<< "$FIXES"


### PR DESCRIPTION
## Summary

Auto-patcher PR #160 failed with \`go: invalid version: unknown revision v29.3.1\` even after the \`+incompatible\` fix from #157 was applied.

Root cause: grype's CVE database reported \`docker/docker@v29.3.1\` as a fix, but the highest real upstream tag is \`v28.5.2\`. The version literally doesn't exist anywhere. \`go get\` correctly refused, taking down the whole patch block.

## Fix

After applying \`+incompatible\` (and any other normalization), hit \`https://proxy.golang.org/<mod>/@v/<ver>.info\` to verify the version exists. If not, skip just that bump and continue with the rest. A skipped bump means the CVE remains visible in the dashboard until grype's data catches up or someone patches manually — much better than red CI blocking every other valid auto-patch.

## Test plan

- [x] YAML parses
- [x] Bash logic dry-run:
  - \`docker/docker@v29.3.1+incompatible\` → correctly skipped
  - \`docker/docker@v28.5.2+incompatible\` → kept
  - \`google/uuid@v1.6.0\` → kept
  - \`google/uuid@v999.9.9\` → correctly skipped
- [x] curl uses \`--max-time 10\` so a proxy outage can't hang the loop

Closes #160.