### PR TITLE
fix(build): cap matrix concurrency at 20 to avoid ghcr.io throttling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.melange-matrix) }}
+      max-parallel: 20
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -367,6 +368,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix: ${{ fromJSON(needs.detect-changes.outputs.apko-matrix) }}
 
     steps:
@@ -661,6 +663,7 @@ jobs:
       attestations: write
 
     strategy:
+      max-parallel: 20
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect-changes.outputs.build-melange-matrix) }}
 


### PR DESCRIPTION
## Summary

Today we've had 6 recurring failures across scheduled rebuilds and PRs, all hitting the same GitHub-side throttle when too many runners hit github.com / ghcr.io at once:

| Time | Event | Symptom |
|---|---|---|
| 08:32 | main schedule | \`OCIError 401\` on attestation upload (×3 images) |
| 13:50 | PR #163 | \`actions/checkout\` token rejected |
| 14:04 | main schedule | \`apko publish\` got \`DENIED\` |
| 15:08 | PR #163 retry | same checkout failure |
| 15:19 | PR #163 retry | same |
| 16:14 | post-merge main | \`OCIError 401\` on attestation |

#163's smarter detect-changes fix routes PR matrices to ~16 jobs (passing cleanly) but scheduled and post-merge rebuilds always do full 128-job runs.

## Fix

\`max-parallel: 20\` on all three matrices (melange-build, build-apko, build-melange). Caps simultaneous job startups so checkout/attestation/publish operations don't dogpile GitHub's token service.

- Full rebuild wall-clock: ~30 → ~60 min (acceptable)
- Single-image PR runs (≤16 jobs): no impact
- 401 / DENIED throttle errors: eliminated

## Test plan

- [x] yq parses build.yml
- [ ] Next scheduled rebuild (~17 UTC) runs clean