### PR TITLE
feat(dev-variants): batch 3C — 6 observability daemons

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,11 @@ jobs:
             {"name":"haproxy","variants":["prod","dev"]},{"name":"ruby","variants":["prod","dev"]},{"name":"php","variants":["prod","dev"]},{"name":"rails","variants":["prod","dev"]},{"name":"caddy","variants":["prod","dev"]},
             {"name":"kafka","variants":["prod","dev"]},{"name":"valkey","variants":["prod","dev"]},{"name":"nats","variants":["prod","dev"]},
             {"name":"traefik","variants":["prod","dev"]},{"name":"rabbitmq","variants":["prod","dev"]},{"name":"minio","variants":["prod","dev"]},
-            {"name":"prometheus"},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd","variants":["prod","dev"]},
-            {"name":"victoria-metrics"},{"name":"jaeger"},{"name":"otelcol"},
+            {"name":"prometheus","variants":["prod","dev"]},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd","variants":["prod","dev"]},
+            {"name":"victoria-metrics","variants":["prod","dev"]},{"name":"jaeger","variants":["prod","dev"]},{"name":"otelcol","variants":["prod","dev"]},
             {"name":"qdrant"},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea"},
-            {"name":"coredns"},{"name":"openbao"},{"name":"loki"},
-            {"name":"fluent-bit"},{"name":"keycloak"}
+            {"name":"coredns"},{"name":"openbao"},{"name":"loki","variants":["prod","dev"]},
+            {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak"}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,12 @@ $(eval $(call DEV_IMAGE_RULE,httpd))
 $(eval $(call DEV_IMAGE_RULE,caddy,caddy-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,traefik,traefik-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,envoy,envoy-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,prometheus,prometheus-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,victoria-metrics,victoria-metrics-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,jaeger,jaeger-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,otelcol,otelcol-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,loki,loki-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,fluent-bit,fluent-bit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1467,6 +1473,12 @@ $(eval $(call DEV_TEST_RULE,httpd))
 $(eval $(call DEV_TEST_RULE,caddy))
 $(eval $(call DEV_TEST_RULE,traefik))
 $(eval $(call DEV_TEST_RULE,envoy))
+$(eval $(call DEV_TEST_RULE,prometheus))
+$(eval $(call DEV_TEST_RULE,victoria-metrics))
+$(eval $(call DEV_TEST_RULE,jaeger))
+$(eval $(call DEV_TEST_RULE,otelcol))
+$(eval $(call DEV_TEST_RULE,loki))
+$(eval $(call DEV_TEST_RULE,fluent-bit))
 
 test-python:
 	@echo "Testing Python image..."

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 28 of 41 dev variants — all 10 language runtimes, 7 of 8 databases, 4 messaging/coord daemons, and 7 servers (nginx, haproxy, minio, httpd, caddy, traefik, envoy). The other 13 are rolling out batch by batch; mysql and qdrant queued for follow-up (heavy source builds).
+**Shipping today:** 34 of 41 dev variants — all 10 language runtimes, 7 of 8 databases, 4 messaging/coord daemons, 7 servers, and 6 observability daemons (prometheus, victoria-metrics, jaeger, otelcol, loki, fluent-bit). The other 7 are rolling out batch by batch; mysql and qdrant queued for follow-up (heavy source builds).
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -298,12 +298,12 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | caddy | server | in-house | ✅ |
 | traefik | server | in-house | ✅ |
 | envoy | server | in-house | ✅ |
-| prometheus | server | in-house | 📝 |
-| victoria-metrics | server | in-house | 📝 |
-| jaeger | server | in-house | 📝 |
-| otelcol | server | in-house | 📝 |
-| loki | server | in-house | 📝 |
-| fluent-bit | server | in-house | 📝 |
+| prometheus | server | in-house | ✅ |
+| victoria-metrics | server | in-house | ✅ |
+| jaeger | server | in-house | ✅ |
+| otelcol | server | in-house | ✅ |
+| loki | server | in-house | ✅ |
+| fluent-bit | server | in-house | ✅ |
 | coredns | server | in-house | 📝 |
 | gitea | server | in-house | 📝 |
 | jenkins | server | in-house | 📝 |

--- a/fluent-bit/apko/fluent-bit-dev.yaml
+++ b/fluent-bit/apko/fluent-bit-dev.yaml
@@ -1,0 +1,65 @@
+# Development variant of minimal-fluent-bit.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - fluent-bit-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/fluent-bit
+
+cmd: -c /etc/fluent-bit/fluent-bit.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/fluent-bit
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-fluent-bit-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-fluent-bit: same fluent-bit + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/fluent-bit"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/fluent-bit/test-dev.sh
+++ b/fluent-bit/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-fluent-bit-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing fluent-bit binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/fluent-bit"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All fluent-bit-dev smoke tests passed"

--- a/jaeger/apko/jaeger-dev.yaml
+++ b/jaeger/apko/jaeger-dev.yaml
@@ -1,0 +1,65 @@
+# Development variant of minimal-jaeger.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - jaeger-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/jaeger
+
+cmd: --config=/etc/jaeger/config.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/jaeger
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-jaeger-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-jaeger: same jaeger + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/jaeger"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/jaeger/test-dev.sh
+++ b/jaeger/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-jaeger-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing jaeger binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/jaeger"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All jaeger-dev smoke tests passed"

--- a/loki/apko/loki-dev.yaml
+++ b/loki/apko/loki-dev.yaml
@@ -1,0 +1,71 @@
+# Development variant of minimal-loki.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - loki-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/loki
+
+cmd: -config.file=/etc/loki/loki.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/loki
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /loki
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-loki-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-loki: same Loki + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/loki"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/loki/test-dev.sh
+++ b/loki/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-loki-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing loki binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/loki"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All loki-dev smoke tests passed"

--- a/otelcol/apko/otelcol-dev.yaml
+++ b/otelcol/apko/otelcol-dev.yaml
@@ -1,0 +1,65 @@
+# Development variant of minimal-otelcol.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - otelcol-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/otelcol
+
+cmd: --config=/etc/otelcol/config.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/otelcol
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-otelcol-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-otelcol: same OpenTelemetry Collector + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/otelcol"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/otelcol/test-dev.sh
+++ b/otelcol/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-otelcol-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing otelcol binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/otelcol"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All otelcol-dev smoke tests passed"

--- a/prometheus/apko/prometheus-dev.yaml
+++ b/prometheus/apko/prometheus-dev.yaml
@@ -1,0 +1,82 @@
+# Development variant of minimal-prometheus.
+# Same source-built prometheus + ca-certs, plus shell + curl/openssl/dig
+# + jq for HTTP API debugging.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - prometheus-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: prometheus
+      gid: 65532
+  users:
+    - username: prometheus
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/prometheus
+
+cmd: >-
+  --config.file=/etc/prometheus/prometheus.yml
+  --storage.tsdb.path=/prometheus
+  --web.console.libraries=/usr/share/prometheus/console_libraries
+  --web.console.templates=/usr/share/prometheus/consoles
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/prometheus
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /etc/prometheus/rules
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /prometheus
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-prometheus-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-prometheus: same prometheus + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/prometheus"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/prometheus/test-dev.sh
+++ b/prometheus/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-prometheus-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing prometheus binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/prometheus"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All prometheus-dev smoke tests passed"

--- a/victoria-metrics/apko/victoria-metrics-dev.yaml
+++ b/victoria-metrics/apko/victoria-metrics-dev.yaml
@@ -1,0 +1,68 @@
+# Development variant of minimal-victoria-metrics.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - victoria-metrics-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/victoria-metrics
+
+cmd: >-
+  --storageDataPath=/victoria-metrics-data
+  --httpListenAddr=:8428
+  --retentionPeriod=1
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /victoria-metrics-data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-victoria-metrics-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-victoria-metrics: same VM + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/victoria-metrics"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/victoria-metrics/test-dev.sh
+++ b/victoria-metrics/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-victoria-metrics-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing victoria-metrics binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/victoria-metrics"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All victoria-metrics-dev smoke tests passed"


### PR DESCRIPTION
## Summary

prometheus, victoria-metrics, jaeger, otelcol, loki, fluent-bit. All in-house composition. Catalog: **28 → 34 of 41**.

All 6 are HTTP-API-driven daemons with identical dev needs — same source-built daemon + standard server debug toolkit (\`curl + openssl + jq + dig\`).

## Test plan

Local validation (CLAUDE.md):
- [x] 6 melange x86_64 builds green
- [x] 6 apko dev builds green
- [x] 6 smoke tests green
- [x] yq parses build.yml

CI:
- [ ] Smart detect-changes routes partial rebuild (image-entry-only diff)
- [ ] Each prod + dev row builds, publishes, signs, attests