### PR TITLE
feat(dev-variants): batch 3D partial — coredns, gitea, jenkins, openbao

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,16 +59,16 @@ jobs:
         run: |
           # Image configuration
           MELANGE_IMAGES='[
-            {"name":"jenkins"},
+            {"name":"jenkins","variants":["prod","dev"]},
             {"name":"redis-slim","apko":"redis-slim/apko/redis.yaml","variants":["prod","dev"]},
-            {"name":"mysql"},{"name":"memcached","variants":["prod","dev"]},{"name":"caddy"},
-            {"name":"haproxy","variants":["prod","dev"]},{"name":"ruby","variants":["prod","dev"]},{"name":"php","variants":["prod","dev"]},{"name":"rails","variants":["prod","dev"]},{"name":"caddy","variants":["prod","dev"]},
+            {"name":"mysql"},{"name":"memcached","variants":["prod","dev"]},{"name":"caddy","variants":["prod","dev"]},
+            {"name":"haproxy","variants":["prod","dev"]},{"name":"ruby","variants":["prod","dev"]},{"name":"php","variants":["prod","dev"]},{"name":"rails","variants":["prod","dev"]},
             {"name":"kafka","variants":["prod","dev"]},{"name":"valkey","variants":["prod","dev"]},{"name":"nats","variants":["prod","dev"]},
             {"name":"traefik","variants":["prod","dev"]},{"name":"rabbitmq","variants":["prod","dev"]},{"name":"minio","variants":["prod","dev"]},
             {"name":"prometheus","variants":["prod","dev"]},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd","variants":["prod","dev"]},
             {"name":"victoria-metrics","variants":["prod","dev"]},{"name":"jaeger","variants":["prod","dev"]},{"name":"otelcol","variants":["prod","dev"]},
-            {"name":"qdrant"},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea"},
-            {"name":"coredns"},{"name":"openbao"},{"name":"loki","variants":["prod","dev"]},
+            {"name":"qdrant"},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
+            {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak"}
           ]'
           APKO_IMAGES='[

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ $(eval $(call DEV_IMAGE_RULE,jaeger,jaeger-melange,--repository-append ./package
 $(eval $(call DEV_IMAGE_RULE,otelcol,otelcol-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,loki,loki-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,fluent-bit,fluent-bit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,coredns,coredns-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,gitea,gitea-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,jenkins,jenkins-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,openbao,openbao-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1479,6 +1483,10 @@ $(eval $(call DEV_TEST_RULE,jaeger))
 $(eval $(call DEV_TEST_RULE,otelcol))
 $(eval $(call DEV_TEST_RULE,loki))
 $(eval $(call DEV_TEST_RULE,fluent-bit))
+$(eval $(call DEV_TEST_RULE,coredns))
+$(eval $(call DEV_TEST_RULE,gitea))
+$(eval $(call DEV_TEST_RULE,jenkins))
+$(eval $(call DEV_TEST_RULE,openbao))
 
 test-python:
 	@echo "Testing Python image..."

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 34 of 41 dev variants — all 10 language runtimes, 7 of 8 databases, 4 messaging/coord daemons, 7 servers, and 6 observability daemons (prometheus, victoria-metrics, jaeger, otelcol, loki, fluent-bit). The other 7 are rolling out batch by batch; mysql and qdrant queued for follow-up (heavy source builds).
+**Shipping today:** 38 of 41 dev variants — all 10 language runtimes, 7 of 8 databases, 4 messaging/coord daemons, and 17 of 18 servers/apps/infra. Only `mysql`, `qdrant`, `keycloak` remain (heavy source builds; ship via follow-up PRs).
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -304,11 +304,11 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | otelcol | server | in-house | ✅ |
 | loki | server | in-house | ✅ |
 | fluent-bit | server | in-house | ✅ |
-| coredns | server | in-house | 📝 |
-| gitea | server | in-house | 📝 |
-| jenkins | server | in-house | 📝 |
+| coredns | server | in-house | ✅ |
+| gitea | server | in-house | ✅ |
+| jenkins | server | in-house | ✅ |
 | keycloak | server | in-house | 📝 |
-| openbao | server | in-house | 📝 |
+| openbao | server | in-house | ✅ |
 
 </details>
 

--- a/coredns/apko/coredns-dev.yaml
+++ b/coredns/apko/coredns-dev.yaml
@@ -1,0 +1,68 @@
+# Development variant of minimal-coredns.
+# Same source-built coredns + ca-certs, plus shell + curl/openssl + jq.
+# Skip bind-tools — coredns is a DNS server itself, dig conflicts with port 53.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - coredns-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: coredns
+      gid: 65532
+  users:
+    - username: coredns
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/coredns
+
+cmd: -conf /etc/coredns/Corefile
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/coredns
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-coredns-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-coredns: same CoreDNS + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/coredns"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/coredns/test-dev.sh
+++ b/coredns/test-dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing coredns binary present (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/coredns "$IMAGE" -version 2>&1 | grep -qE "CoreDNS"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "✓ All coredns-dev smoke tests passed"

--- a/gitea/apko/gitea-dev.yaml
+++ b/gitea/apko/gitea-dev.yaml
@@ -1,0 +1,95 @@
+# Development variant of minimal-gitea.
+# Prod already includes git + busybox + netcat (gitea shells out). Dev
+# adds bash + apk-tools + openssl + dig + jq for HTTP API debugging.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Same as prod
+    - wolfi-baselayout
+    - gitea-minimal
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - sqlite-libs
+    - git
+    - busybox
+    - netcat-openbsd
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+
+    # Dev additions
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+
+accounts:
+  groups:
+    - groupname: gitea
+      gid: 65532
+  users:
+    - username: gitea
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/gitea web --config /etc/gitea/app.ini
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+  GITEA_CUSTOM: /data/gitea
+  GITEA_WORK_DIR: /var/lib/gitea
+
+paths:
+  - path: /etc/gitea
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /data/gitea
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/lib/gitea
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/lib/gitea/repositories
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-gitea-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-gitea: same Gitea + bash + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/gitea"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/gitea/test-dev.sh
+++ b/gitea/test-dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing gitea version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/gitea "$IMAGE" --version | grep -qiE "^gitea version"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing git (prod parity)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "✓ All gitea-dev smoke tests passed"

--- a/jenkins/apko/jenkins-dev.yaml
+++ b/jenkins/apko/jenkins-dev.yaml
@@ -1,0 +1,157 @@
+# Development variant of minimal-jenkins.
+# Prod already ships a wide CLI surface (coreutils, git, ssh, gnupg,
+# curl, perl, etc.) for plugin compatibility. Dev just adds: bash,
+# apk-tools, openssl, dig, jq.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Mirror prod exactly
+    - wolfi-baselayout
+    - jenkins-minimal
+    - coreutils
+    - diffutils
+    - findutils
+    - grep
+    - gzip
+    - less
+    - patch
+    - procps
+    - sed
+    - shadow
+    - unzip
+    - tzdata
+    - tini
+    - curl
+    - libcurl-openssl4
+    - git
+    - git-lfs
+    - openssh-client
+    - openssh-keygen
+    - gnupg
+    - gnutar
+    - glibc
+    - glibc-locale-en
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libcrypt1
+    - libxcrypt
+    - zlib
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    - java-cacerts
+    - p11-kit
+    - p11-kit-trust
+    - libnghttp2-14
+    - nghttp3
+    - libidn2
+    - libpsl
+    - libtasn1
+    - libunistring
+    - libbrotlicommon1
+    - libbrotlidec1
+    - libbz2-1
+    - libexpat1
+    - libffi
+    - alsa-lib
+    - libjpeg-turbo
+    - giflib
+    - lcms2
+    - ttf-dejavu
+    - libx11
+    - libxau
+    - libxcb
+    - libxdmcp
+    - libxext
+    - libxi
+    - libxrender
+    - libxtst
+    - cyrus-sasl
+    - heimdal-libs
+    - krb5-libs
+    - krb5-conf
+    - keyutils-libs
+    - libldap-2.6
+    - libverto
+    - libacl1
+    - libattr1
+    - libaudit
+    - libbsd
+    - libcap-ng
+    - libcom_err
+    - libedit
+    - libmd
+    - libpcre2-8-0
+    - libproc-2-0
+    - libselinux
+    - libsemanage
+    - libsepol
+    - linux-pam
+    - sqlite-libs
+    - gdbm
+    - ncurses
+    - ncurses-terminfo-base
+    - readline
+    - debianutils
+    - perl
+
+    # Dev additions
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - openssl
+    - bind-tools
+    - jq
+
+accounts:
+  groups:
+    - groupname: jenkins
+      gid: 1000
+  users:
+    - username: jenkins
+      uid: 1000
+      gid: 1000
+  run-as: 1000
+
+entrypoint:
+  command: /sbin/tini -- /usr/bin/java -Xmx512m -Djava.awt.headless=true -jar /usr/share/jenkins/jenkins.war
+
+environment:
+  JAVA_HOME: /usr/lib/jvm/java-21-minimal
+  JENKINS_HOME: /var/jenkins_home
+  LANG: C.UTF-8
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+
+paths:
+  - path: /var/jenkins_home
+    type: directory
+    uid: 1000
+    gid: 1000
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 1000
+    gid: 1000
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-jenkins-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-jenkins: same Jenkins + bash + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/jenkins"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/jenkins/test-dev.sh
+++ b/jenkins/test-dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing jenkins.war present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -f /usr/share/jenkins/jenkins.war"
+echo "Testing JRE present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/lib/jvm/java-21-minimal/bin/java"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing git (prod parity)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "✓ All jenkins-dev smoke tests passed"

--- a/openbao/apko/openbao-dev.yaml
+++ b/openbao/apko/openbao-dev.yaml
@@ -1,0 +1,76 @@
+# Development variant of minimal-openbao.
+# Same source-built bao + ca-certs, plus shell + curl/openssl/dig/jq
+# (essential for Vault/Bao API interaction).
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - openbao-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: openbao
+      gid: 65532
+  users:
+    - username: openbao
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/bao server
+
+cmd: -config=/etc/openbao/openbao.hcl
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  BAO_ADDR: "http://127.0.0.1:8200"
+  SKIP_SETCAP: "true"
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/openbao
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /openbao/data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-openbao-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-openbao: same OpenBao + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/openbao"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/openbao/test-dev.sh
+++ b/openbao/test-dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing bao version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/bao "$IMAGE" version | grep -qE "OpenBao"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "✓ All openbao-dev smoke tests passed"


### PR DESCRIPTION
## Summary

4 of 5 planned apps/infra. **keycloak deferred** — fails locally on WSL2 with melange chown errors. CI builds it fine.

Catalog: **34 → 38 of 41**.

## Infrastructure

- Makefile: 4 macro calls.
- build.yml: cleaned 2 stale duplicates discovered while editing (jenkins, caddy). One canonical entry per image.
- README: header "38 of 41", 4 rows ✅, keycloak 📝.

## Deferred list (3 of 41)

| Image | Reason |
|---|---|
| mysql | CMake/sql_gis build fails on WSL2 (CI green) |
| qdrant | Rust release build too heavy for WSL2 (CI green) |
| keycloak | bwrap chown errors on WSL2 (CI green) |

All three will ship via tiny follow-up PRs.

## Test plan

- [x] All 4 melange + apko dev builds green
- [x] All 4 smoke tests green
- [x] yq parses build.yml