### PR TITLE
feat(dev-variants): final 3 — mysql, qdrant, keycloak (catalog complete)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,15 +61,15 @@ jobs:
           MELANGE_IMAGES='[
             {"name":"jenkins","variants":["prod","dev"]},
             {"name":"redis-slim","apko":"redis-slim/apko/redis.yaml","variants":["prod","dev"]},
-            {"name":"mysql"},{"name":"memcached","variants":["prod","dev"]},{"name":"caddy","variants":["prod","dev"]},
+            {"name":"mysql","variants":["prod","dev"]},{"name":"memcached","variants":["prod","dev"]},{"name":"caddy","variants":["prod","dev"]},
             {"name":"haproxy","variants":["prod","dev"]},{"name":"ruby","variants":["prod","dev"]},{"name":"php","variants":["prod","dev"]},{"name":"rails","variants":["prod","dev"]},
             {"name":"kafka","variants":["prod","dev"]},{"name":"valkey","variants":["prod","dev"]},{"name":"nats","variants":["prod","dev"]},
             {"name":"traefik","variants":["prod","dev"]},{"name":"rabbitmq","variants":["prod","dev"]},{"name":"minio","variants":["prod","dev"]},
             {"name":"prometheus","variants":["prod","dev"]},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd","variants":["prod","dev"]},
             {"name":"victoria-metrics","variants":["prod","dev"]},{"name":"jaeger","variants":["prod","dev"]},{"name":"otelcol","variants":["prod","dev"]},
-            {"name":"qdrant"},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
+            {"name":"qdrant","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
-            {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak"}
+            {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,9 @@ $(eval $(call DEV_IMAGE_RULE,coredns,coredns-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,gitea,gitea-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,jenkins,jenkins-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,openbao,openbao-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,mysql,mysql-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,qdrant,qdrant-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1487,6 +1490,9 @@ $(eval $(call DEV_TEST_RULE,coredns))
 $(eval $(call DEV_TEST_RULE,gitea))
 $(eval $(call DEV_TEST_RULE,jenkins))
 $(eval $(call DEV_TEST_RULE,openbao))
+$(eval $(call DEV_TEST_RULE,mysql))
+$(eval $(call DEV_TEST_RULE,qdrant))
+$(eval $(call DEV_TEST_RULE,keycloak))
 
 test-python:
 	@echo "Testing Python image..."

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 38 of 41 dev variants — all 10 language runtimes, 7 of 8 databases, 4 messaging/coord daemons, and 17 of 18 servers/apps/infra. Only `mysql`, `qdrant`, `keycloak` remain (heavy source builds; ship via follow-up PRs).
+**Shipping today:** 41 of 41 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -280,7 +280,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | deno | runtime | in-house | ✅ |
 | postgres-slim | daemon | Chainguard `postgres-public` | ✅ |
 | mariadb | daemon | Chainguard `mariadb-public` | ✅ |
-| mysql | daemon | in-house | 📝 |
+| mysql | daemon | in-house | ✅ |
 | redis-slim | daemon | Chainguard `redis-public` | ✅ |
 | valkey | daemon | Chainguard `valkey-public` | ✅ |
 | memcached | daemon | in-house | ✅ |
@@ -290,7 +290,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | rabbitmq | daemon | in-house | ✅ |
 | nats | daemon | in-house | ✅ |
 | etcd | daemon | in-house | ✅ |
-| qdrant | daemon | in-house | 📝 |
+| qdrant | daemon | in-house | ✅ |
 | nginx | server | Chainguard `nginx-public` | ✅ |
 | haproxy | server | Chainguard `haproxy-public` | ✅ |
 | minio | server | Chainguard `minio-client-public` (server in-house) | ✅ |
@@ -307,7 +307,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | coredns | server | in-house | ✅ |
 | gitea | server | in-house | ✅ |
 | jenkins | server | in-house | ✅ |
-| keycloak | server | in-house | 📝 |
+| keycloak | server | in-house | ✅ |
 | openbao | server | in-house | ✅ |
 
 </details>

--- a/keycloak/apko/keycloak-dev.yaml
+++ b/keycloak/apko/keycloak-dev.yaml
@@ -1,0 +1,68 @@
+# Development variant of minimal-keycloak.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - keycloak-minimal
+    - ca-certificates-bundle
+    - openjdk-21-default-jvm
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: keycloak
+      gid: 65532
+  users:
+    - username: keycloak
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /opt/keycloak/bin/kc.sh
+
+cmd: start-dev
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/opt/keycloak/bin
+  JAVA_HOME: /usr/lib/jvm/java-21-openjdk
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+  KC_HEALTH_ENABLED: "true"
+
+paths:
+  - path: /opt/keycloak
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-keycloak-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-keycloak: same Keycloak + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/keycloak"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/keycloak/test-dev.sh
+++ b/keycloak/test-dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing keycloak entrypoint present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /opt/keycloak/bin/kc.sh"
+echo "Testing JDK 21 present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "/usr/lib/jvm/java-21-openjdk/bin/java -version" 2>&1 | grep -qE 'openjdk version "21'
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "✓ All keycloak-dev smoke tests passed"

--- a/mysql/apko/mysql-dev.yaml
+++ b/mysql/apko/mysql-dev.yaml
@@ -1,0 +1,82 @@
+# Development variant of minimal-mysql.
+# Same source-built MySQL server as prod, plus bash, apk-tools, mysql
+# client, curl/socat/jq for debugging.
+#
+# In-house composition.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mysql-minimal
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - ncurses
+    - libevent
+    - libprotobuf-lite
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - socat
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: mysql
+      gid: 65532
+  users:
+    - username: mysql
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/docker-entrypoint.sh
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  LANG: C.UTF-8
+
+paths:
+  - path: /var/lib/mysql
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /run/mysqld
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mysql-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-mysql: same server + shell + mysql client + curl/socat/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mysql"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mysql/test-dev.sh
+++ b/mysql/test-dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing mysqld present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/sbin/mysqld"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing mysql client present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "mysql --version" | grep -qiE "mysql"
+echo "Testing curl/socat/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && socat -V >/dev/null 2>&1 && jq --version >/dev/null"
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "✓ All mysql-dev smoke tests passed"

--- a/qdrant/apko/qdrant-dev.yaml
+++ b/qdrant/apko/qdrant-dev.yaml
@@ -1,0 +1,81 @@
+# Development variant of minimal-qdrant.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - qdrant-minimal
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libstdc++
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: qdrant
+      gid: 65532
+  users:
+    - username: qdrant
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/qdrant
+
+work-dir: /qdrant
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  QDRANT__SERVICE__HTTP_PORT: "6333"
+  QDRANT__SERVICE__GRPC_PORT: "6334"
+  QDRANT__STORAGE__STORAGE_PATH: /qdrant/storage
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /qdrant
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /qdrant/storage
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-qdrant-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-qdrant: same vector search engine + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/qdrant"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/qdrant/test-dev.sh
+++ b/qdrant/test-dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+: "${IMAGE:?IMAGE env var required}"
+echo "Testing qdrant present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/qdrant"
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+echo "✓ All qdrant-dev smoke tests passed"


### PR DESCRIPTION
## Summary

Last 3 dev variants. Catalog: **38 → 41 of 41** — every image in the catalog now ships a \`:latest-dev\` companion.

## Validation exception per CLAUDE.md

All 3 were deferred from earlier PRs because their **melange source builds fail on the local WSL2 sandbox** (not a code issue):

| Image | Local failure | Doc trail | CI on prod variant |
|---|---|---|---|
| mysql | CMake/sql_gis error | #158 | ✅ green every scheduled rebuild |
| qdrant | cargo build --release too heavy | #159 | ✅ green |
| keycloak | bwrap chown invalid-argument | #175 | ✅ green |

The dev variants are pure-additive (same packages list as prod + shell + apk-tools + curl/openssl/jq/dig + git). CI builds them on real Ubuntu runners where the WSL2 issues don't apply.

## Per-image composition

- **mysql** — mirrors mariadb-dev (daemon template). mysql client ships in mysql-minimal.
- **qdrant** — server template (HTTP/gRPC API on 6333/6334).
- **keycloak** — server template + OpenJDK 21 (parity with prod).

## After this lands

Dev variant rollout complete. Future image additions to the catalog should ship a dev variant in the same PR — see [\`docs/dev-variants/CONVENTIONS.md\`](docs/dev-variants/CONVENTIONS.md).

## Test plan

- [x] yq parses build.yml
- [x] yq parses 3 new dev yamls
- [ ] CI builds mysql-dev (x86_64 + aarch64) — validated by prod track record
- [ ] CI builds qdrant-dev
- [ ] CI builds keycloak-dev