### PR TITLE
feat(registry): add OCI distribution registry built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,8 @@ jobs:
             {"name":"victoria-metrics","variants":["prod","dev"]},{"name":"jaeger","variants":["prod","dev"]},{"name":"otelcol","variants":["prod","dev"]},
             {"name":"qdrant","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
-            {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]}
+            {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
+            {"name":"registry","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ FLUENT_BIT_VERSION ?= $(call melange_version,fluent-bit/melange.yaml)
 QDRANT_VERSION ?= $(call melange_version,qdrant/melange.yaml)
 OPENSEARCH_VERSION ?= 3.6.0
 
+# --- Registries ---
+# NB: REGISTRY (above) is the OCI registry hostname; DISTRIBUTION_VERSION is the
+# upstream version of distribution/distribution we ship as `minimal-registry`.
+DISTRIBUTION_VERSION ?= $(call melange_version,registry/melange.yaml)
+
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
 
@@ -105,6 +110,7 @@ endef
 .PHONY: cuda-python cuda-python-melange
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
+.PHONY: registry registry-melange registry-dev test-registry test-registry-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
@@ -180,6 +186,7 @@ $(eval $(call DEV_IMAGE_RULE,openbao,openbao-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,mysql,mysql-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,qdrant,qdrant-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1151,6 +1158,32 @@ keycloak: keycloak-melange
 	@echo "✓ minimal-keycloak built (pre-built distribution)"
 
 #------------------------------------------------------------------------------
+# REGISTRY IMAGE (melange source build + apko — distribution/distribution)
+#------------------------------------------------------------------------------
+registry-melange: keygen
+	@echo "Building distribution $(DISTRIBUTION_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build registry/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ registry (distribution) package built from source"
+
+registry: registry-melange
+	@echo "Assembling minimal-registry image with apko..."
+	apko build registry/apko/registry.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-registry:$(VERSION) \
+		registry.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < registry.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-registry:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-registry:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-registry:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-registry:latest
+	@rm -f registry.tar sbom-*.spdx.json
+	@echo "✓ minimal-registry built (source build)"
+
+#------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
 scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
@@ -1493,6 +1526,7 @@ $(eval $(call DEV_TEST_RULE,openbao))
 $(eval $(call DEV_TEST_RULE,mysql))
 $(eval $(call DEV_TEST_RULE,qdrant))
 $(eval $(call DEV_TEST_RULE,keycloak))
+$(eval $(call DEV_TEST_RULE,registry))
 
 test-python:
 	@echo "Testing Python image..."
@@ -1766,6 +1800,12 @@ test-minio:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-minio:latest" && \
 		minio/test.sh
 	@echo "✓ MinIO tests passed"
+
+test-registry:
+	@echo "Testing registry image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-registry:latest" && \
+		registry/test.sh
+	@echo "✓ registry tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | OpenBao | `docker pull ghcr.io/rtvkiz/minimal-openbao:latest` | No | Secret management (Vault fork) |
 | Keycloak | `docker pull ghcr.io/rtvkiz/minimal-keycloak:latest` | Yes | Identity & access management |
 | Qdrant | `docker pull ghcr.io/rtvkiz/minimal-qdrant:latest` | No | Vector DB for AI/ML (Rust) |
+| Registry | `docker pull ghcr.io/rtvkiz/minimal-registry:latest` | No | OCI distribution registry (Docker Registry v2), built from source |
 | | | **Apps** | |
 | Jenkins | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 | Gitea | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Yes | Self-hosted Git service |
@@ -255,7 +256,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 41 of 41 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 42 of 42 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -309,6 +310,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | jenkins | server | in-house | ✅ |
 | keycloak | server | in-house | ✅ |
 | openbao | server | in-house | ✅ |
+| registry | server | Chainguard `registry-public` | ✅ |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-41-0d9488" alt="Images: 41">
+  <img src="https://img.shields.io/badge/Images-42-0d9488" alt="Images: 42">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--41-total">All 41 images</a> ·
+  <a href="#available-images--42-total">All 42 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 41 total
+## Available Images — 42 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -84,7 +84,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Caches, queues, messaging** | 6 | redis-slim, valkey, memcached, kafka, rabbitmq, nats |
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 6 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit |
-| **Infrastructure** | 5 | coredns, etcd, openbao, keycloak, qdrant |
+| **Infrastructure** | 6 | coredns, etcd, openbao, keycloak, qdrant, registry |
 | **Apps** | 4 | jenkins, gitea, minio, rails |
 
 <details>

--- a/registry/apko/registry-dev.yaml
+++ b/registry/apko/registry-dev.yaml
@@ -1,0 +1,61 @@
+# Development variant of minimal-registry.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - registry-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: registry
+      gid: 65532
+  users:
+    - username: registry
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/registry serve /etc/distribution/config.yml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /var/lib/registry
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-registry-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-registry: same registry binary + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/registry"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/registry/apko/registry.yaml
+++ b/registry/apko/registry.yaml
@@ -1,0 +1,53 @@
+# Minimal Docker Registry (distribution) image - built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - registry-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: registry
+      gid: 65532
+  users:
+    - username: registry
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/registry serve /etc/distribution/config.yml
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /var/lib/registry
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-registry"
+  org.opencontainers.image.description: "Hardened shell-less OCI distribution registry (Docker Registry v2) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/registry"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/registry/melange.yaml
+++ b/registry/melange.yaml
@@ -1,0 +1,105 @@
+# Melange build configuration for minimal Docker Registry (distribution)
+# Builds the OCI distribution registry from source (Go) as a static binary
+# CGO_ENABLED=0 produces fully static binary - zero runtime deps
+
+package:
+  name: registry-minimal
+  version: 3.1.1
+  epoch: 0
+  description: "Minimal OCI distribution registry (Docker Registry v2) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of the distribution source tarball - updated by update-registry.yml workflow
+  sha256: 419183e8c1426b5d625732cf6846a2d48ad8e898a1659d7bec7171b7d156673e
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify distribution source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/distribution/distribution/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/distribution.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/distribution.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf distribution.tar.gz
+      rm distribution.tar.gz
+
+  # Build the registry binary (static)
+  # NB: upstream source tree contains a ./registry/ subdir, so -o /home/build/registry-bin
+  # avoids collision with `go build -o registry` writing into that directory.
+  - runs: |
+      cd /home/build/distribution-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X github.com/distribution/distribution/v3/version.version=${{package.version}} \
+          -X github.com/distribution/distribution/v3/version.revision=source-build \
+          -X github.com/distribution/distribution/v3/version.mainpkg=github.com/distribution/distribution/v3" \
+        -o /home/build/registry-bin \
+        ./cmd/registry
+
+  # Install binary + default filesystem config
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/registry-bin "${{targets.destdir}}/usr/bin/registry"
+      chmod 0755 "${{targets.destdir}}/usr/bin/registry"
+
+      mkdir -p "${{targets.destdir}}/etc/distribution"
+      cat > "${{targets.destdir}}/etc/distribution/config.yml" << 'CFG'
+      version: 0.1
+      log:
+        level: info
+        fields:
+          service: registry
+      storage:
+        filesystem:
+          rootdirectory: /var/lib/registry
+        cache:
+          blobdescriptor: inmemory
+      http:
+        addr: :5000
+        headers:
+          X-Content-Type-Options: [nosniff]
+        debug:
+          addr: :5001
+          prometheus:
+            enabled: false
+      health:
+        storagedriver:
+          enabled: true
+          interval: 10s
+          threshold: 3
+      CFG
+
+  # Verify
+  - runs: |
+      echo "Verifying registry build..."
+      "${{targets.destdir}}/usr/bin/registry" --version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/registry"
+
+update:
+  enabled: true
+  github:
+    identifier: distribution/distribution
+    use-tag: true
+    tag-filter: "v3."
+    strip-prefix: "v"

--- a/registry/test-dev.sh
+++ b/registry/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-registry-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing registry version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/registry "$IMAGE" --version 2>&1 | grep -qE "registry"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All registry-dev smoke tests passed"

--- a/registry/test.sh
+++ b/registry/test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Testing registry version..."
+docker run --rm --entrypoint /usr/bin/registry "$IMAGE" --version
+
+echo "Testing registry server starts..."
+docker run -d --name registry-test \
+  -p 15000:5000 \
+  "$IMAGE"
+sleep 5
+
+if docker ps | grep -q registry-test; then
+  echo "registry container is running"
+  docker logs registry-test
+
+  echo "Checking /v2/ endpoint at :15000..."
+  if curl -sf --retry 5 --retry-delay 2 http://localhost:15000/v2/ | grep -q '{}'; then
+    echo "registry /v2/ endpoint OK"
+  else
+    echo "FAIL: registry /v2/ endpoint check failed"
+    docker logs registry-test
+    docker stop registry-test && docker rm registry-test
+    exit 1
+  fi
+
+  docker stop registry-test && docker rm registry-test
+else
+  echo "registry failed to start, checking logs..."
+  docker logs registry-test 2>&1 || true
+  docker rm registry-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All registry tests passed!"


### PR DESCRIPTION
## Summary
- Adds `minimal-registry` — distribution/distribution v3.1.1 compiled from source via melange (Go, CGO_ENABLED=0 static binary) and assembled with apko.
- Ships `:latest` (54 MB, shell-less) and `:latest-dev` (128 MB) variants.
- Wires into the existing daily build matrix, so SBOM, cosign signing, SLSA provenance, and CVE rebuild cadence apply automatically.
- Catalog now ships 42 of 42 dev variants.

## What's in this PR
- `registry/melange.yaml` — Go source build, sha256-pinned, `update:` watcher on `v3.` tags
- `registry/apko/registry.yaml` + `registry/apko/registry-dev.yaml`
- `registry/test.sh` + `registry/test-dev.sh`
- `Makefile` — `registry-melange`, `registry`, `registry-dev`, `test-registry`, `test-registry-dev`, `DISTRIBUTION_VERSION` var
- `.github/workflows/build.yml` — added `registry` to MELANGE_IMAGES matrix
- `README.md` — image entry + dev variant tracker bumped to 42/42

## Test plan
- [x] `make registry-melange` succeeds locally on WSL2 (x86_64-only locally; CI builds aarch64 natively)
- [x] `make registry` builds the prod image (54 MB, shell-less)
- [x] `make test-registry` passes — version, `/v2/` endpoint OK, no `/bin/sh`
- [x] `make registry-dev` builds the dev image (128 MB)
- [x] `make test-registry-dev` passes — sh/bash/apk-tools/curl/openssl/jq/dig/git
- [ ] CI matrix builds + signs both variants