### PR TITLE
feat(mailpit): add Mailpit SMTP/email testing tool built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
             {"name":"qdrant","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
-            {"name":"registry","variants":["prod","dev"]}
+            {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ OPENSEARCH_VERSION ?= 3.6.0
 # upstream version of distribution/distribution we ship as `minimal-registry`.
 DISTRIBUTION_VERSION ?= $(call melange_version,registry/melange.yaml)
 
+# --- Dev tools ---
+MAILPIT_VERSION ?= $(call melange_version,mailpit/melange.yaml)
+
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
 
@@ -111,6 +114,7 @@ endef
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
 .PHONY: registry registry-melange registry-dev test-registry test-registry-dev
+.PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
@@ -187,6 +191,7 @@ $(eval $(call DEV_IMAGE_RULE,mysql,mysql-melange,--repository-append ./packages 
 $(eval $(call DEV_IMAGE_RULE,qdrant,qdrant-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1184,6 +1189,32 @@ registry: registry-melange
 	@echo "✓ minimal-registry built (source build)"
 
 #------------------------------------------------------------------------------
+# MAILPIT IMAGE (melange Go + npm frontend source build + apko)
+#------------------------------------------------------------------------------
+mailpit-melange: keygen
+	@echo "Building mailpit $(MAILPIT_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build mailpit/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ mailpit package built from source"
+
+mailpit: mailpit-melange
+	@echo "Assembling minimal-mailpit image with apko..."
+	apko build mailpit/apko/mailpit.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-mailpit:$(VERSION) \
+		mailpit.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < mailpit.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mailpit:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mailpit:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mailpit:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mailpit:latest
+	@rm -f mailpit.tar sbom-*.spdx.json
+	@echo "✓ minimal-mailpit built (source build)"
+
+#------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
 scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
@@ -1527,6 +1558,7 @@ $(eval $(call DEV_TEST_RULE,mysql))
 $(eval $(call DEV_TEST_RULE,qdrant))
 $(eval $(call DEV_TEST_RULE,keycloak))
 $(eval $(call DEV_TEST_RULE,registry))
+$(eval $(call DEV_TEST_RULE,mailpit))
 
 test-python:
 	@echo "Testing Python image..."
@@ -1806,6 +1838,12 @@ test-registry:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-registry:latest" && \
 		registry/test.sh
 	@echo "✓ registry tests passed"
+
+test-mailpit:
+	@echo "Testing mailpit image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mailpit:latest" && \
+		mailpit/test.sh
+	@echo "✓ mailpit tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-42-0d9488" alt="Images: 42">
+  <img src="https://img.shields.io/badge/Images-43-0d9488" alt="Images: 43">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--42-total">All 42 images</a> ·
+  <a href="#available-images--43-total">All 43 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 42 total
+## Available Images — 43 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -85,7 +85,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 6 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit |
 | **Infrastructure** | 6 | coredns, etcd, openbao, keycloak, qdrant, registry |
-| **Apps** | 4 | jenkins, gitea, minio, rails |
+| **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
 <details>
 <summary><strong>Full image catalog with pull commands</strong></summary>
@@ -143,6 +143,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Jenkins | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 | Gitea | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Yes | Self-hosted Git service |
 | MinIO | `docker pull ghcr.io/rtvkiz/minimal-minio:latest` | No | S3-compatible object storage |
+| Mailpit | `docker pull ghcr.io/rtvkiz/minimal-mailpit:latest` | No | SMTP & email testing for developers, built from source |
 | | | **AI / ML** | |
 | CUDA Python | *disabled* | No | Python + CUDA 12.9 + cuDNN 9.10 (build paused, code retained) |
 
@@ -256,7 +257,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 42 of 42 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 43 of 43 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -311,6 +312,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | keycloak | server | in-house | ✅ |
 | openbao | server | in-house | ✅ |
 | registry | server | Chainguard `registry-public` | ✅ |
+| mailpit | server | in-house (Chainguard ships no public mailpit) | ✅ |
 
 </details>
 

--- a/mailpit/apko/mailpit-dev.yaml
+++ b/mailpit/apko/mailpit-dev.yaml
@@ -1,0 +1,64 @@
+# Development variant of minimal-mailpit.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mailpit-minimal
+    - ca-certificates-bundle
+    - tzdata
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: mailpit
+      gid: 65532
+  users:
+    - username: mailpit
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mailpit
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  MP_DATABASE: /data/mailpit.db
+  MP_MAX_MESSAGES: "500"
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mailpit-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-mailpit: same SMTP/email tester + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mailpit"
+  org.opencontainers.image.licenses: "MIT"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mailpit/apko/mailpit.yaml
+++ b/mailpit/apko/mailpit.yaml
@@ -1,0 +1,56 @@
+# Minimal Mailpit image - email & SMTP testing tool, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mailpit-minimal
+    - ca-certificates-bundle
+    - tzdata
+
+accounts:
+  groups:
+    - groupname: mailpit
+      gid: 65532
+  users:
+    - username: mailpit
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mailpit
+
+environment:
+  PATH: /usr/bin:/bin
+  MP_DATABASE: /data/mailpit.db
+  MP_MAX_MESSAGES: "500"
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mailpit"
+  org.opencontainers.image.description: "Hardened shell-less Mailpit (SMTP/email testing) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mailpit"
+  org.opencontainers.image.licenses: "MIT"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mailpit/melange.yaml
+++ b/mailpit/melange.yaml
@@ -1,0 +1,82 @@
+# Melange build configuration for minimal Mailpit
+# Builds mailpit from source: npm-built Vue frontend bundled via esbuild
+# is go:embed'd into the final static binary (CGO_ENABLED=0).
+
+package:
+  name: mailpit-minimal
+  version: 1.30.1
+  epoch: 0
+  description: "Minimal Mailpit — email & SMTP testing tool built from source"
+  copyright:
+    - license: MIT
+
+vars:
+  # SHA256 of mailpit source tarball - updated by update-mailpit.yml workflow
+  sha256: bda226e88f828215fc3646258494e71ebfaf82074970ea28a319c91a64c068d2
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+      - nodejs
+      - npm
+
+pipeline:
+  # Download and verify mailpit source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/axllent/mailpit/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/mailpit.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/mailpit.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf mailpit.tar.gz
+      rm mailpit.tar.gz
+
+  # Build Vue/JS frontend assets via npm + esbuild
+  # Outputs go into server/ui/dist which is go:embed'd at compile time.
+  - runs: |
+      cd /home/build/mailpit-${{package.version}}
+      npm ci --no-audit --no-fund
+      npm run package
+
+  # Build mailpit (static Go binary embedding the frontend bundle)
+  - runs: |
+      cd /home/build/mailpit-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X github.com/axllent/mailpit/config.Version=v${{package.version}}" \
+        -o /home/build/mailpit-bin \
+        .
+
+  # Install
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/mailpit-bin "${{targets.destdir}}/usr/bin/mailpit"
+      chmod 0755 "${{targets.destdir}}/usr/bin/mailpit"
+
+  # Verify
+  - runs: |
+      echo "Verifying mailpit build..."
+      "${{targets.destdir}}/usr/bin/mailpit" version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/mailpit"
+
+update:
+  enabled: true
+  github:
+    identifier: axllent/mailpit
+    use-tag: true
+    strip-prefix: "v"

--- a/mailpit/test-dev.sh
+++ b/mailpit/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-mailpit-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing mailpit version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version 2>&1 | grep -qi "mailpit"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All mailpit-dev smoke tests passed"

--- a/mailpit/test.sh
+++ b/mailpit/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Testing mailpit version..."
+docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version
+
+echo "Testing mailpit server starts..."
+docker run -d --name mailpit-test \
+  -p 11025:1025 \
+  -p 18025:8025 \
+  "$IMAGE"
+sleep 5
+
+if docker ps | grep -q mailpit-test; then
+  echo "mailpit container is running"
+  docker logs mailpit-test
+
+  echo "Checking HTTP UI /livez at :18025..."
+  if curl -sf --retry 5 --retry-delay 2 http://localhost:18025/livez; then
+    echo "mailpit HTTP /livez OK"
+  else
+    echo "FAIL: mailpit HTTP /livez check failed"
+    docker logs mailpit-test
+    docker stop mailpit-test && docker rm mailpit-test
+    exit 1
+  fi
+
+  echo "Checking SMTP banner at :11025..."
+  if printf 'QUIT\r\n' | timeout 5 nc -w 3 localhost 11025 | grep -qi "Mailpit"; then
+    echo "mailpit SMTP banner OK"
+  else
+    echo "FAIL: mailpit SMTP banner check failed"
+    docker logs mailpit-test
+    docker stop mailpit-test && docker rm mailpit-test
+    exit 1
+  fi
+
+  docker stop mailpit-test && docker rm mailpit-test
+else
+  echo "mailpit failed to start, checking logs..."
+  docker logs mailpit-test 2>&1 || true
+  docker rm mailpit-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All mailpit tests passed!"


### PR DESCRIPTION
## Summary
- Adds `minimal-mailpit` — axllent/mailpit v1.30.1 compiled from source via melange.
- Vue frontend assets are bundled by esbuild (`npm ci && npm run package`) and `go:embed`'d into the final static Go binary (`CGO_ENABLED=0`).
- Ships `:latest` (27 MB, shell-less) and `:latest-dev` variants.
- Wires into the daily melange/apko pipeline for cosign signing, SBOM, SLSA provenance, and CVE rebuild cadence.
- Catalog now ships 43 of 43 dev variants.

## What's in this PR
- `mailpit/melange.yaml` — Go + npm source build, sha256-pinned, `update:` watcher on upstream tags
- `mailpit/apko/mailpit.yaml` + `mailpit/apko/mailpit-dev.yaml`
- `mailpit/test.sh` (version + HTTP `/livez` + SMTP banner) + `mailpit/test-dev.sh`
- `Makefile` — `mailpit-melange`, `mailpit`, `mailpit-dev`, `test-mailpit`, `test-mailpit-dev`, `MAILPIT_VERSION` var
- `.github/workflows/build.yml` — added `mailpit` to MELANGE_IMAGES
- `README.md` — Apps row, image entry, dev tracker bumped 42 → 43 (badges, header, hero link)

## Test plan
- [x] `make mailpit-melange` succeeds locally on WSL2 — `npm ci`, esbuild, then `go build` (x86_64-only locally; CI builds aarch64 natively)
- [x] `make mailpit` builds the prod image (27 MB, shell-less)
- [x] `make test-mailpit` passes — version, HTTP `/livez` 200, SMTP banner contains `Mailpit`, no `/bin/sh`
- [x] `make mailpit-dev` builds the dev image
- [x] `make test-mailpit-dev` passes — sh/bash/apk-tools/curl/openssl/jq/dig/git
- [ ] CI matrix builds + signs both variants