### PR TITLE
feat(consul): add HashiCorp Consul service discovery built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,8 @@ jobs:
             {"name":"qdrant","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
-            {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]}
+            {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
+            {"name":"consul","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ DISTRIBUTION_VERSION ?= $(call melange_version,registry/melange.yaml)
 # --- Dev tools ---
 MAILPIT_VERSION ?= $(call melange_version,mailpit/melange.yaml)
 
+# --- Service Discovery / Coordination (HashiCorp) ---
+CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
+
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
 
@@ -115,6 +118,7 @@ endef
 .PHONY: gitea gitea-melange
 .PHONY: registry registry-melange registry-dev test-registry test-registry-dev
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
+.PHONY: consul consul-melange consul-dev test-consul test-consul-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
@@ -192,6 +196,7 @@ $(eval $(call DEV_IMAGE_RULE,qdrant,qdrant-melange,--repository-append ./package
 $(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1215,6 +1220,32 @@ mailpit: mailpit-melange
 	@echo "✓ minimal-mailpit built (source build)"
 
 #------------------------------------------------------------------------------
+# CONSUL IMAGE (melange Go source build + apko; BUSL-1.1)
+#------------------------------------------------------------------------------
+consul-melange: keygen
+	@echo "Building Consul $(CONSUL_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build consul/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Consul package built from source"
+
+consul: consul-melange
+	@echo "Assembling minimal-consul image with apko..."
+	apko build consul/apko/consul.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-consul:$(VERSION) \
+		consul.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < consul.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-consul:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-consul:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-consul:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-consul:latest
+	@rm -f consul.tar sbom-*.spdx.json
+	@echo "✓ minimal-consul built (source build)"
+
+#------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
 scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
@@ -1559,6 +1590,7 @@ $(eval $(call DEV_TEST_RULE,qdrant))
 $(eval $(call DEV_TEST_RULE,keycloak))
 $(eval $(call DEV_TEST_RULE,registry))
 $(eval $(call DEV_TEST_RULE,mailpit))
+$(eval $(call DEV_TEST_RULE,consul))
 
 test-python:
 	@echo "Testing Python image..."
@@ -1844,6 +1876,12 @@ test-mailpit:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mailpit:latest" && \
 		mailpit/test.sh
 	@echo "✓ mailpit tests passed"
+
+test-consul:
+	@echo "Testing consul image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-consul:latest" && \
+		consul/test.sh
+	@echo "✓ consul tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-43-0d9488" alt="Images: 43">
+  <img src="https://img.shields.io/badge/Images-44-0d9488" alt="Images: 44">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--43-total">All 43 images</a> ·
+  <a href="#available-images--44-total">All 44 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 43 total
+## Available Images — 44 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -84,7 +84,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Caches, queues, messaging** | 6 | redis-slim, valkey, memcached, kafka, rabbitmq, nats |
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 6 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit |
-| **Infrastructure** | 6 | coredns, etcd, openbao, keycloak, qdrant, registry |
+| **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
 <details>
@@ -139,6 +139,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Keycloak | `docker pull ghcr.io/rtvkiz/minimal-keycloak:latest` | Yes | Identity & access management |
 | Qdrant | `docker pull ghcr.io/rtvkiz/minimal-qdrant:latest` | No | Vector DB for AI/ML (Rust) |
 | Registry | `docker pull ghcr.io/rtvkiz/minimal-registry:latest` | No | OCI distribution registry (Docker Registry v2), built from source |
+| Consul | `docker pull ghcr.io/rtvkiz/minimal-consul:latest` | No | HashiCorp Consul service discovery + KV (BUSL-1.1) |
 | | | **Apps** | |
 | Jenkins | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 | Gitea | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Yes | Self-hosted Git service |
@@ -257,7 +258,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 43 of 43 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 44 of 44 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -313,6 +314,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | openbao | server | in-house | ✅ |
 | registry | server | Chainguard `registry-public` | ✅ |
 | mailpit | server | in-house (Chainguard ships no public mailpit) | ✅ |
+| consul | server | in-house (Chainguard ships no public consul; BUSL-1.1) | ✅ |
 
 </details>
 

--- a/consul/apko/consul-dev.yaml
+++ b/consul/apko/consul-dev.yaml
@@ -1,0 +1,68 @@
+# Development variant of minimal-consul.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - consul-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: consul
+      gid: 65532
+  users:
+    - username: consul
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/consul
+
+cmd: agent -dev -client=0.0.0.0
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /consul/data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /consul/config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-consul-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-consul (BUSL-1.1): same Consul + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/consul"
+  org.opencontainers.image.licenses: "BUSL-1.1"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/consul/apko/consul.yaml
+++ b/consul/apko/consul.yaml
@@ -1,0 +1,65 @@
+# Minimal HashiCorp Consul image - built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+#
+# License: BUSL-1.1 (since Consul v1.16+). Production use OK for non-competing
+# services. See https://www.hashicorp.com/license-faq for details.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - consul-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: consul
+      gid: 65532
+  users:
+    - username: consul
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Default to single-node dev mode (data is in-memory, fine for getting started
+# and for our smoke test). Override `cmd` for production usage.
+entrypoint:
+  command: /usr/bin/consul
+
+cmd: agent -dev -client=0.0.0.0
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /consul/data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /consul/config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-consul"
+  org.opencontainers.image.description: "Hardened shell-less HashiCorp Consul (BUSL-1.1) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/consul"
+  org.opencontainers.image.licenses: "BUSL-1.1"
+
+archs:
+  - x86_64
+  - aarch64

--- a/consul/melange.yaml
+++ b/consul/melange.yaml
@@ -1,0 +1,80 @@
+# Melange build configuration for minimal HashiCorp Consul
+# Pure Go from source. Upstream tarball ships the pre-built UI under
+# agent/uiserver/dist/, which is go:embed'd at compile time — no yarn/ember
+# step required to get the web UI.
+#
+# License: BUSL-1.1 (Business Source License) since Consul v1.16+ (Aug 2023).
+# Allowed for production use except as a competing managed Consul service.
+
+package:
+  name: consul-minimal
+  version: 2.0.0
+  epoch: 0
+  description: "Minimal HashiCorp Consul (service discovery + KV) built from source"
+  copyright:
+    - license: BUSL-1.1
+
+vars:
+  # SHA256 of consul source tarball - updated by update-consul.yml workflow
+  sha256: cf0fb38b3150cc5be4e0e05d0ecfd9198e427725b8262a43396707b76193f3c7
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify consul source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/hashicorp/consul/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/consul.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/consul.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf consul.tar.gz
+      rm consul.tar.gz
+
+  # Build consul (static binary, embedded UI is already in source tree)
+  - runs: |
+      cd /home/build/consul-${{package.version}}
+      BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X github.com/hashicorp/consul/version.GitCommit=source-build \
+          -X github.com/hashicorp/consul/version.BuildDate=${BUILD_DATE}" \
+        -o /home/build/consul-bin \
+        .
+
+  # Install
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/consul-bin "${{targets.destdir}}/usr/bin/consul"
+      chmod 0755 "${{targets.destdir}}/usr/bin/consul"
+
+  # Verify
+  - runs: |
+      echo "Verifying consul build..."
+      "${{targets.destdir}}/usr/bin/consul" version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/consul"
+
+update:
+  enabled: true
+  github:
+    identifier: hashicorp/consul
+    use-tag: true
+    strip-prefix: "v"
+    tag-filter: "v2."

--- a/consul/test-dev.sh
+++ b/consul/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-consul-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing consul version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/consul "$IMAGE" version 2>&1 | grep -qi "consul v"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All consul-dev smoke tests passed"

--- a/consul/test.sh
+++ b/consul/test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# NB: no -o pipefail — `curl LARGE | grep -q` is SIGPIPE-prone (grep closes
+# the pipe early, curl exits 141, pipefail blows the script). We capture curl
+# output to a variable then grep, which avoids the pipe entirely.
+set -eu
+
+echo "Testing consul version..."
+docker run --rm --entrypoint /usr/bin/consul "$IMAGE" version
+
+echo "Testing consul agent starts..."
+docker run -d --name consul-test \
+  -p 18500:8500 \
+  "$IMAGE"
+sleep 8
+
+if docker ps | grep -q consul-test; then
+  echo "consul container is running"
+  docker logs consul-test 2>&1 | tail -5
+
+  echo "Checking /v1/status/leader at :18500..."
+  LEADER=$(curl -sf --retry 8 --retry-delay 2 http://localhost:18500/v1/status/leader || true)
+  if echo "$LEADER" | grep -qE '"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+"'; then
+    echo "consul has a leader ($LEADER) — cluster healthy"
+  else
+    echo "FAIL: consul /v1/status/leader returned: $LEADER"
+    docker logs consul-test
+    docker stop consul-test && docker rm consul-test
+    exit 1
+  fi
+
+  echo "Checking UI at :18500/ui/..."
+  UI=$(curl -sf --retry 3 --retry-delay 1 http://localhost:18500/ui/ || true)
+  if echo "$UI" | grep -qi "consul"; then
+    echo "consul UI OK"
+  else
+    echo "FAIL: consul UI check failed"
+    docker logs consul-test
+    docker stop consul-test && docker rm consul-test
+    exit 1
+  fi
+
+  docker stop consul-test && docker rm consul-test
+else
+  echo "consul failed to start, checking logs..."
+  docker logs consul-test 2>&1 || true
+  docker rm consul-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All consul tests passed!"


### PR DESCRIPTION
## Summary
- Adds `minimal-consul` — hashicorp/consul v2.0.0 compiled from source via melange (Go, CGO_ENABLED=0 static binary).
- Upstream source tarball ships pre-built UI under `agent/uiserver/dist/`; `go:embed` picks it up automatically, so no yarn/ember step is required.
- Ships `:latest` (shell-less) and `:latest-dev` variants.
- Wires into daily melange/apko pipeline for cosign signing, SBOM, SLSA provenance, and CVE rebuild cadence.

## License caveat — BUSL-1.1
HashiCorp re-licensed Consul to BSL 1.1 starting v1.16 (Aug 2023). v2.0.0 is BSL. Production use is allowed except as a competing managed Consul service. Same pattern as our MinIO (AGPL): the image carries its own license, flagged in apko annotations and the README. See https://www.hashicorp.com/license-faq.

## What's in this PR
- `consul/melange.yaml` — Go source build, sha256-pinned, `update:` watcher on `v2.` tags
- `consul/apko/consul.yaml` + `consul/apko/consul-dev.yaml` (BUSL-1.1 noted in annotations)
- `consul/test.sh` (version + `/v1/status/leader` + `/ui/`) + `consul/test-dev.sh`
- `Makefile` — `consul-melange`, `consul`, `consul-dev`, `test-consul`, `test-consul-dev`, `CONSUL_VERSION` var
- `.github/workflows/build.yml` — added `consul` to MELANGE_IMAGES
- `README.md` — Infrastructure row, image entry with license note, dev tracker bumped 43 → 44 (badges, header, hero link)

## Test plan
- [x] `make consul-melange` succeeds locally on WSL2 (x86_64-only locally; CI builds aarch64 natively)
- [x] `make consul` builds the prod image (shell-less)
- [x] `make test-consul` passes — version, `/v1/status/leader` returns leader, `/ui/` serves HTML, no `/bin/sh`
- [x] `make consul-dev` builds the dev image
- [x] `make test-consul-dev` passes — sh/bash/apk-tools/curl/openssl/jq/dig/git
- [ ] CI matrix builds + signs both variants

## Bonus catch
The first local test run failed on the UI check with `curl | grep -q` SIGPIPE — large HTML response triggers grep to close the pipe early, curl exits 141, `set -o pipefail` blows the script. Fix: capture curl output to a variable then grep. Test script comment documents this for future image authors.