### PR TITLE
feat(tempo): add Grafana Tempo distributed tracing built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
-            {"name":"consul","variants":["prod","dev"]}
+            {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ MAILPIT_VERSION ?= $(call melange_version,mailpit/melange.yaml)
 # --- Service Discovery / Coordination (HashiCorp) ---
 CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
 
+# --- Observability (extra) ---
+TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
+
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
 
@@ -119,6 +122,7 @@ endef
 .PHONY: registry registry-melange registry-dev test-registry test-registry-dev
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
+.PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
@@ -197,6 +201,7 @@ $(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./pac
 $(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,tempo,tempo-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1246,6 +1251,32 @@ consul: consul-melange
 	@echo "✓ minimal-consul built (source build)"
 
 #------------------------------------------------------------------------------
+# TEMPO IMAGE (melange Go source build + apko; Grafana distributed tracing)
+#------------------------------------------------------------------------------
+tempo-melange: keygen
+	@echo "Building Tempo $(TEMPO_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build tempo/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Tempo package built from source"
+
+tempo: tempo-melange
+	@echo "Assembling minimal-tempo image with apko..."
+	apko build tempo/apko/tempo.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-tempo:$(VERSION) \
+		tempo.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < tempo.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-tempo:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-tempo:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-tempo:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-tempo:latest
+	@rm -f tempo.tar sbom-*.spdx.json
+	@echo "✓ minimal-tempo built (source build)"
+
+#------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
 scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
@@ -1591,6 +1622,7 @@ $(eval $(call DEV_TEST_RULE,keycloak))
 $(eval $(call DEV_TEST_RULE,registry))
 $(eval $(call DEV_TEST_RULE,mailpit))
 $(eval $(call DEV_TEST_RULE,consul))
+$(eval $(call DEV_TEST_RULE,tempo))
 
 test-python:
 	@echo "Testing Python image..."
@@ -1882,6 +1914,12 @@ test-consul:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-consul:latest" && \
 		consul/test.sh
 	@echo "✓ consul tests passed"
+
+test-tempo:
+	@echo "Testing tempo image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-tempo:latest" && \
+		tempo/test.sh
+	@echo "✓ tempo tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-44-0d9488" alt="Images: 44">
+  <img src="https://img.shields.io/badge/Images-45-0d9488" alt="Images: 45">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--44-total">All 44 images</a> ·
+  <a href="#available-images--45-total">All 45 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 44 total
+## Available Images — 45 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -83,7 +83,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Databases** | 5 | mysql, mariadb, postgres-slim, sqlite, opensearch |
 | **Caches, queues, messaging** | 6 | redis-slim, valkey, memcached, kafka, rabbitmq, nats |
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
-| **Observability** | 6 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit |
+| **Observability** | 7 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit, tempo |
 | **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
@@ -130,6 +130,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | VictoriaMetrics | `docker pull ghcr.io/rtvkiz/minimal-victoria-metrics:latest` | No | High-perf metrics storage |
 | Jaeger | `docker pull ghcr.io/rtvkiz/minimal-jaeger:latest` | No | Distributed tracing (v2) |
 | Loki | `docker pull ghcr.io/rtvkiz/minimal-loki:latest` | No | Log aggregation (Grafana Labs) |
+| Tempo | `docker pull ghcr.io/rtvkiz/minimal-tempo:latest` | No | Distributed tracing backend (Grafana Labs, AGPL) |
 | OTel Collector | `docker pull ghcr.io/rtvkiz/minimal-otelcol:latest` | No | OpenTelemetry Collector core |
 | Fluent Bit | `docker pull ghcr.io/rtvkiz/minimal-fluent-bit:latest` | No | Lightweight log processor |
 | | | **Infrastructure** | |
@@ -258,7 +259,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 44 of 44 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 45 of 45 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -315,6 +316,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | registry | server | Chainguard `registry-public` | ✅ |
 | mailpit | server | in-house (Chainguard ships no public mailpit) | ✅ |
 | consul | server | in-house (Chainguard ships no public consul; BUSL-1.1) | ✅ |
+| tempo | server | in-house (Chainguard ships no public tempo; AGPL-3.0) | ✅ |
 
 </details>
 

--- a/tempo/apko/tempo-dev.yaml
+++ b/tempo/apko/tempo-dev.yaml
@@ -1,0 +1,62 @@
+# Development variant of minimal-tempo.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - tempo-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: tempo
+      gid: 65532
+  users:
+    - username: tempo
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/tempo -config.file=/etc/tempo/tempo.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /var/tempo
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-tempo-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-tempo: same Tempo + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/tempo"
+  org.opencontainers.image.licenses: "AGPL-3.0-only"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/tempo/apko/tempo.yaml
+++ b/tempo/apko/tempo.yaml
@@ -1,0 +1,57 @@
+# Minimal Grafana Tempo image - distributed tracing backend, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - tempo-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: tempo
+      gid: 65532
+  users:
+    - username: tempo
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/tempo -config.file=/etc/tempo/tempo.yaml
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  # /var/tempo is parent for wal/, blocks/, live-store/, etc. Tempo v3 adds
+  # more subdirs at runtime (live-store-ring, partition-ring) — make the
+  # parent writable so it can mkdir them itself.
+  - path: /var/tempo
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-tempo"
+  org.opencontainers.image.description: "Hardened shell-less Grafana Tempo (distributed tracing) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/tempo"
+  org.opencontainers.image.licenses: "AGPL-3.0-only"
+
+archs:
+  - x86_64
+  - aarch64

--- a/tempo/melange.yaml
+++ b/tempo/melange.yaml
@@ -1,0 +1,112 @@
+# Melange build configuration for minimal Grafana Tempo
+# Pure Go from source. Single-binary mode by default.
+# License: AGPL-3.0 (Grafana Labs).
+
+package:
+  name: tempo-minimal
+  version: 3.0.0
+  epoch: 0
+  description: "Minimal Grafana Tempo distributed tracing backend built from source"
+  copyright:
+    - license: AGPL-3.0-only
+
+vars:
+  # SHA256 of tempo source tarball - updated by update-tempo.yml workflow
+  sha256: 39c31d5d63e3d61b30d4bba4cd472b1cba0a710de9bfbafb4ec2472fbf5410f7
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify tempo source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/grafana/tempo/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/tempo.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/tempo.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf tempo.tar.gz
+      rm tempo.tar.gz
+
+  # Build tempo (static binary).
+  # Tempo defines its own main.{Version,Branch,Revision} and copies them
+  # into prometheus/common/version in init(). Setting prometheus/common/version
+  # directly is overwritten — so we target main.* on cmd/tempo instead.
+  - runs: |
+      cd /home/build/tempo-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X main.Version=${{package.version}} \
+          -X main.Revision=source-build \
+          -X main.Branch=tag-v${{package.version}}" \
+        -o /home/build/tempo-bin \
+        ./cmd/tempo
+
+  # Install binary + minimal single-binary all-in-one config
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/tempo-bin "${{targets.destdir}}/usr/bin/tempo"
+      chmod 0755 "${{targets.destdir}}/usr/bin/tempo"
+
+      mkdir -p "${{targets.destdir}}/etc/tempo"
+      cat > "${{targets.destdir}}/etc/tempo/tempo.yaml" << 'CFG'
+      # Minimal single-binary Tempo config. All components in one process,
+      # local filesystem storage. Override by mounting your own config and
+      # passing -config.file=/path/to/your/tempo.yaml.
+      # NB: Tempo v3 dropped the top-level `ingester:` and `compactor:`
+      # sections; their tunables now live elsewhere (defaults are sane).
+      stream_over_http_enabled: true
+      server:
+        http_listen_port: 3200
+        log_level: info
+
+      distributor:
+        receivers:
+          otlp:
+            protocols:
+              http:
+                endpoint: "0.0.0.0:4318"
+              grpc:
+                endpoint: "0.0.0.0:4317"
+
+      storage:
+        trace:
+          backend: local
+          wal:
+            path: /var/tempo/wal
+          local:
+            path: /var/tempo/blocks
+
+      usage_report:
+        reporting_enabled: false
+      CFG
+
+  # Verify
+  - runs: |
+      echo "Verifying tempo build..."
+      "${{targets.destdir}}/usr/bin/tempo" -version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/tempo"
+
+update:
+  enabled: true
+  github:
+    identifier: grafana/tempo
+    use-tag: true
+    strip-prefix: "v"
+    tag-filter: "v3."

--- a/tempo/test-dev.sh
+++ b/tempo/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-tempo-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing tempo version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/tempo "$IMAGE" -version 2>&1 | grep -qi "tempo"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All tempo-dev smoke tests passed"

--- a/tempo/test.sh
+++ b/tempo/test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# NB: no -o pipefail — `curl LARGE | grep -q` is SIGPIPE-prone.
+set -eu
+
+echo "Testing tempo version..."
+docker run --rm --entrypoint /usr/bin/tempo "$IMAGE" -version
+
+echo "Testing tempo starts in single-binary mode..."
+docker run -d --name tempo-test \
+  -p 13200:3200 \
+  "$IMAGE"
+sleep 6
+
+if docker ps | grep -q tempo-test; then
+  echo "tempo container is running"
+  docker logs tempo-test 2>&1 | tail -5
+
+  # /ready returns 200 once all modules are running. We retry with -f
+  # because tempo returns 503 during startup until live-store/distributor
+  # are healthy (typically <10s).
+  echo "Checking /ready at :13200..."
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://localhost:13200/ready >/dev/null 2>&1; then
+      echo "tempo /ready OK (attempt $i)"
+      break
+    fi
+    if [ "$i" = "10" ]; then
+      echo "FAIL: tempo /ready never returned 200 after 10 attempts"
+      docker logs tempo-test
+      docker stop tempo-test && docker rm tempo-test
+      exit 1
+    fi
+    sleep 2
+  done
+
+  echo "Checking /metrics at :13200..."
+  if ! curl -sf http://localhost:13200/metrics >/dev/null 2>&1; then
+    echo "FAIL: tempo /metrics failed"
+    docker stop tempo-test && docker rm tempo-test
+    exit 1
+  fi
+  echo "tempo /metrics OK"
+
+  docker stop tempo-test && docker rm tempo-test
+else
+  echo "tempo failed to start, checking logs..."
+  docker logs tempo-test 2>&1 || true
+  docker rm tempo-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All tempo tests passed!"


### PR DESCRIPTION
## Summary
- Adds `minimal-tempo` — grafana/tempo v3.0.0 compiled from source via melange (Go, CGO_ENABLED=0 static binary).
- Single-binary all-in-one mode by default; ships a minimal filesystem-backed config at `/etc/tempo/tempo.yaml` that listeners can override via `-config.file`.
- Ships `:latest` (shell-less) and `:latest-dev` variants.
- License: AGPL-3.0 (Grafana Labs).

## What's in this PR
- `tempo/melange.yaml` — Go source build, sha256-pinned, `update:` watcher on `v3.` tags
- `tempo/apko/tempo.yaml` + `tempo/apko/tempo-dev.yaml`
- `tempo/test.sh` (version + `/ready` retry loop + `/metrics`) + `tempo/test-dev.sh`
- `Makefile` — `tempo-melange`, `tempo`, `tempo-dev`, `test-tempo`, `test-tempo-dev`, `TEMPO_VERSION` var
- `.github/workflows/build.yml` — added `tempo` to MELANGE_IMAGES
- `README.md` — Observability row 6 → 7, image entry, dev tracker bumped 44 → 45

## Test plan
- [x] `make tempo-melange` succeeds locally on WSL2 (x86_64 only locally; CI builds aarch64 natively)
- [x] `make tempo` builds the prod image (shell-less)
- [x] `make test-tempo` passes — version stamped, `/ready` returns 200 after live-store/distributor come up, `/metrics` OK, no `/bin/sh`
- [x] `make tempo-dev` builds the dev image
- [x] `make test-tempo-dev` passes — sh/bash/apk-tools/curl/openssl/jq/dig/git
- [ ] CI matrix builds + signs both variants

## Three issues caught locally (good thing we run smoke tests)
1. **v3 schema change**: dropped top-level `ingester:` and `compactor:` sections — config rejected at startup.
2. **Version stamp empty**: tempo defines its own `main.{Version,Branch,Revision}` and copies them into `prometheus/common/version` in `init()`. Setting the prometheus path directly is silently overwritten. Correct ldflag path is `-X main.Version=...` against `./cmd/tempo`.
3. **live-store mkdir EPERM**: tempo v3 creates `/var/tempo/live-store`, `/var/tempo/live-store-ring`, etc. at runtime. apko needs to own the `/var/tempo` parent (with `recursive: true`), not just `wal/` and `blocks/`.