### PR TITLE
feat(mosquitto): add Eclipse Mosquitto MQTT broker built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,8 @@ jobs:
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
-            {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]}
+            {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]},
+            {"name":"mosquitto","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
 # --- Observability (extra) ---
 TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 
+# --- Messaging (MQTT) ---
+MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
+
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
 
@@ -123,6 +126,7 @@ endef
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
 .PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
+.PHONY: mosquitto mosquitto-melange mosquitto-dev test-mosquitto test-mosquitto-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
 
@@ -202,6 +206,7 @@ $(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./pac
 $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,tempo,tempo-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,mosquitto,mosquitto-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -1277,6 +1282,32 @@ tempo: tempo-melange
 	@echo "✓ minimal-tempo built (source build)"
 
 #------------------------------------------------------------------------------
+# MOSQUITTO IMAGE (melange C source build + apko; Eclipse MQTT broker)
+#------------------------------------------------------------------------------
+mosquitto-melange: keygen
+	@echo "Building Mosquitto $(MOSQUITTO_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build mosquitto/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Mosquitto package built from source"
+
+mosquitto: mosquitto-melange
+	@echo "Assembling minimal-mosquitto image with apko..."
+	apko build mosquitto/apko/mosquitto.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-mosquitto:$(VERSION) \
+		mosquitto.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < mosquitto.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mosquitto:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mosquitto:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mosquitto:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mosquitto:latest
+	@rm -f mosquitto.tar sbom-*.spdx.json
+	@echo "✓ minimal-mosquitto built (source build)"
+
+#------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
 scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
@@ -1623,6 +1654,7 @@ $(eval $(call DEV_TEST_RULE,registry))
 $(eval $(call DEV_TEST_RULE,mailpit))
 $(eval $(call DEV_TEST_RULE,consul))
 $(eval $(call DEV_TEST_RULE,tempo))
+$(eval $(call DEV_TEST_RULE,mosquitto))
 
 test-python:
 	@echo "Testing Python image..."
@@ -1920,6 +1952,12 @@ test-tempo:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-tempo:latest" && \
 		tempo/test.sh
 	@echo "✓ tempo tests passed"
+
+test-mosquitto:
+	@echo "Testing mosquitto image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mosquitto:latest" && \
+		mosquitto/test.sh
+	@echo "✓ mosquitto tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-45-0d9488" alt="Images: 45">
+  <img src="https://img.shields.io/badge/Images-46-0d9488" alt="Images: 46">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--45-total">All 45 images</a> ·
+  <a href="#available-images--46-total">All 46 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,13 +75,13 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 45 total
+## Available Images — 46 total
 
 | Category | Count | Highlights |
 |---|---|---|
 | **Languages & runtimes** | 9 | python, node-slim, bun, go, java, ruby, php, dotnet, deno |
 | **Databases** | 5 | mysql, mariadb, postgres-slim, sqlite, opensearch |
-| **Caches, queues, messaging** | 6 | redis-slim, valkey, memcached, kafka, rabbitmq, nats |
+| **Caches, queues, messaging** | 7 | redis-slim, valkey, memcached, kafka, rabbitmq, nats, mosquitto |
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 7 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit, tempo |
 | **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
@@ -118,6 +118,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Kafka | `docker pull ghcr.io/rtvkiz/minimal-kafka:latest` | Yes | Apache Kafka 4.x, KRaft mode |
 | RabbitMQ | `docker pull ghcr.io/rtvkiz/minimal-rabbitmq:latest` | Yes | RabbitMQ 4.x AMQP broker |
 | NATS | `docker pull ghcr.io/rtvkiz/minimal-nats:latest` | No | NATS Server with JetStream |
+| Mosquitto | `docker pull ghcr.io/rtvkiz/minimal-mosquitto:latest` | No | Eclipse Mosquitto MQTT broker (EPL-2.0/EDL-1.0) |
 | | | **Web Servers & Proxies** | |
 | Nginx | `docker pull ghcr.io/rtvkiz/minimal-nginx:latest` | No | Reverse proxy, static files |
 | HTTPD | `docker pull ghcr.io/rtvkiz/minimal-httpd:latest` | Maybe* | Apache web server |
@@ -259,7 +260,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 45 of 45 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 46 of 46 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -317,6 +318,7 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | mailpit | server | in-house (Chainguard ships no public mailpit) | ✅ |
 | consul | server | in-house (Chainguard ships no public consul; BUSL-1.1) | ✅ |
 | tempo | server | in-house (Chainguard ships no public tempo; AGPL-3.0) | ✅ |
+| mosquitto | daemon | in-house (Chainguard ships no public mosquitto; EPL-2.0/EDL-1.0) | ✅ |
 
 </details>
 

--- a/mosquitto/apko/mosquitto-dev.yaml
+++ b/mosquitto/apko/mosquitto-dev.yaml
@@ -1,0 +1,62 @@
+# Development variant of minimal-mosquitto.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mosquitto-minimal
+    - ca-certificates-bundle
+    - openssl
+    - cjson
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: mosquitto
+      gid: 65532
+  users:
+    - username: mosquitto
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mosquitto -c /etc/mosquitto/mosquitto.conf
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /var/lib/mosquitto
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mosquitto-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-mosquitto: same MQTT broker + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mosquitto"
+  org.opencontainers.image.licenses: "EPL-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mosquitto/apko/mosquitto.yaml
+++ b/mosquitto/apko/mosquitto.yaml
@@ -1,0 +1,56 @@
+# Minimal Eclipse Mosquitto image - MQTT broker, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mosquitto-minimal
+    - ca-certificates-bundle
+    # Runtime deps for the broker + clients
+    - openssl
+    - cjson
+
+accounts:
+  groups:
+    - groupname: mosquitto
+      gid: 65532
+  users:
+    - username: mosquitto
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mosquitto -c /etc/mosquitto/mosquitto.conf
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /var/lib/mosquitto
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mosquitto"
+  org.opencontainers.image.description: "Hardened shell-less Eclipse Mosquitto MQTT broker built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mosquitto"
+  org.opencontainers.image.licenses: "EPL-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mosquitto/melange.yaml
+++ b/mosquitto/melange.yaml
@@ -1,0 +1,110 @@
+# Melange build configuration for minimal Eclipse Mosquitto
+# Pure C from source, make-based build.
+# License: EPL-2.0 OR EDL-1.0 (dual-licensed by Eclipse Foundation).
+
+package:
+  name: mosquitto-minimal
+  version: 2.0.20
+  epoch: 0
+  description: "Minimal Eclipse Mosquitto MQTT broker built from source"
+  copyright:
+    - license: EPL-2.0
+
+vars:
+  # SHA256 of mosquitto source tarball - updated by update-mosquitto.yml workflow
+  sha256: ebd07d89d2a446a7f74100ad51272e4a8bf300b61634a7812e19f068f2759de8
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - openssl-dev
+      - cjson-dev
+
+pipeline:
+  # Download and verify mosquitto source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://mosquitto.org/files/source/mosquitto-${{package.version}}.tar.gz" \
+        -o /home/build/mosquitto.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/mosquitto.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf mosquitto.tar.gz
+      rm mosquitto.tar.gz
+
+  # Build: TLS yes, docs no, no bundled deps, no websockets/SRV (avoids
+  # extra runtime deps we don't want), CJSON yes for mosquitto_ctrl.
+  - runs: |
+      cd /home/build/mosquitto-${{package.version}}
+      make -j"$(nproc)" \
+        WITH_TLS=yes \
+        WITH_TLS_PSK=yes \
+        WITH_THREADING=yes \
+        WITH_DOCS=no \
+        WITH_BUNDLED_DEPS=yes \
+        WITH_CJSON=yes \
+        WITH_SRV=no \
+        WITH_WEBSOCKETS=no \
+        WITH_SHARED_LIBRARIES=yes \
+        WITH_STATIC_LIBRARIES=no \
+        prefix=/usr
+
+  # Install into destdir
+  - runs: |
+      cd /home/build/mosquitto-${{package.version}}
+      make install \
+        WITH_TLS=yes \
+        WITH_DOCS=no \
+        WITH_BUNDLED_DEPS=yes \
+        WITH_CJSON=yes \
+        WITH_SRV=no \
+        WITH_WEBSOCKETS=no \
+        WITH_SHARED_LIBRARIES=yes \
+        WITH_STATIC_LIBRARIES=no \
+        prefix=/usr \
+        DESTDIR="${{targets.destdir}}"
+
+      # Wolfi enforces usrmerge — /usr/sbin doesn't exist on these images.
+      # Upstream installs the broker at sbin/mosquitto; relocate to /usr/bin.
+      if [ -f "${{targets.destdir}}/usr/sbin/mosquitto" ]; then
+        mv "${{targets.destdir}}/usr/sbin/mosquitto" "${{targets.destdir}}/usr/bin/mosquitto"
+        rmdir "${{targets.destdir}}/usr/sbin" 2>/dev/null || true
+      fi
+
+      # Replace upstream's commented-out default config with a minimal
+      # broker that listens on all interfaces and allows anonymous
+      # connections — sane default for the smoke test and for a fresh
+      # container. Users override by mounting their own /etc/mosquitto.conf.
+      mkdir -p "${{targets.destdir}}/etc/mosquitto"
+      cat > "${{targets.destdir}}/etc/mosquitto/mosquitto.conf" << 'CFG'
+      # Minimal mosquitto config — broker only, anonymous, no persistence.
+      listener 1883 0.0.0.0
+      allow_anonymous true
+      persistence false
+      log_dest stdout
+      log_type all
+      CFG
+
+  # Verify
+  - runs: |
+      echo "Verifying mosquitto build..."
+      "${{targets.destdir}}/usr/bin/mosquitto" --help | head -3
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/mosquitto"
+      echo "Tools:"
+      ls "${{targets.destdir}}/usr/bin/mosquitto"* 2>/dev/null
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 7710

--- a/mosquitto/test-dev.sh
+++ b/mosquitto/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-mosquitto-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing mosquitto version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/mosquitto "$IMAGE" -h 2>&1 | head -1 | grep -qi "mosquitto"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All mosquitto-dev smoke tests passed"

--- a/mosquitto/test.sh
+++ b/mosquitto/test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` can SIGPIPE.
+set -eu
+
+echo "Testing mosquitto version..."
+docker run --rm --entrypoint /usr/bin/mosquitto "$IMAGE" -h 2>&1 | head -1 | grep -qi "mosquitto"
+
+echo "Testing mosquitto_pub present..."
+docker run --rm --entrypoint /usr/bin/mosquitto_pub "$IMAGE" --help 2>&1 | head -1 | grep -qi "mosquitto_pub"
+
+echo "Testing mosquitto broker starts..."
+docker run -d --name mosquitto-test \
+  -p 11883:1883 \
+  "$IMAGE"
+sleep 4
+
+if docker ps | grep -q mosquitto-test; then
+  echo "mosquitto container is running"
+  docker logs mosquitto-test 2>&1 | tail -5
+
+  # Pub/sub round-trip via a sidecar container sharing the host network.
+  # mosquitto_pub will exit non-zero if it can't reach the broker.
+  echo "Publishing test message to broker on host:11883..."
+  if docker run --rm --network host --entrypoint /usr/bin/mosquitto_pub "$IMAGE" \
+       -h localhost -p 11883 -t minimal/test -m "ok" -q 1; then
+    echo "mosquitto_pub round-trip OK"
+  else
+    echo "FAIL: mosquitto_pub could not reach broker"
+    docker logs mosquitto-test
+    docker stop mosquitto-test && docker rm mosquitto-test
+    exit 1
+  fi
+
+  docker stop mosquitto-test && docker rm mosquitto-test
+else
+  echo "mosquitto failed to start, checking logs..."
+  docker logs mosquitto-test 2>&1 || true
+  docker rm mosquitto-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All mosquitto tests passed!"


### PR DESCRIPTION
## Summary
- Adds `minimal-mosquitto` — eclipse/mosquitto v2.0.20 compiled from source via melange (C, make-based).
- Built with TLS + TLS-PSK; WebSockets and SRV disabled to keep the runtime closure small.
- Ships `:latest` (shell-less, broker + clients) and `:latest-dev` variants.
- License: **EPL-2.0 OR EDL-1.0** (dual-licensed by Eclipse Foundation).

## Default config
A minimal `/etc/mosquitto/mosquitto.conf` is baked in:
- `listener 1883 0.0.0.0`
- `allow_anonymous true`
- `persistence false`
- `log_dest stdout`

Override by mounting your own config and overriding the cmd.

## What's in this PR
- `mosquitto/melange.yaml` — make source build, sha256-pinned, `update:` watcher
- `mosquitto/apko/mosquitto.yaml` + `mosquitto/apko/mosquitto-dev.yaml`
- `mosquitto/test.sh` (real pub/sub round-trip via a sidecar `mosquitto_pub` container, not just a port check) + `mosquitto/test-dev.sh`
- `Makefile` — `mosquitto-melange`, `mosquitto`, `mosquitto-dev`, `test-mosquitto`, `test-mosquitto-dev`, `MOSQUITTO_VERSION` var
- `.github/workflows/build.yml` — added `mosquitto` to MELANGE_IMAGES
- `README.md` — Caches/Queues/Messaging row 6 → 7, image entry, dev tracker bumped 45 → 46

## Test plan
- [x] `make mosquitto-melange` succeeds locally on WSL2 (x86_64 only locally; CI builds aarch64 natively)
- [x] `make mosquitto` builds the prod image (shell-less)
- [x] `make test-mosquitto` passes — version, mosquitto_pub round-trips a message through the broker, no `/bin/sh`
- [x] `make mosquitto-dev` builds the dev image
- [x] `make test-mosquitto-dev` passes — sh/bash/apk-tools/curl/openssl/jq/dig/git
- [ ] CI matrix builds + signs both variants

## Two issues caught locally
1. **utlist.h missing** with `WITH_BUNDLED_DEPS=no` — Wolfi doesn't ship `uthash`. Switched to bundled (header-only, no real risk; same as upstream Docker image).
2. **Wolfi `usrmerge` lint rejection** — upstream installs the broker at `/usr/sbin/mosquitto`. Wolfi requires `/usr/bin`. Added a relocate step in the install pipeline so the package passes lint.

Batch A complete: registry, mailpit, consul, tempo, mosquitto. 5 new from-source images shipping.