### PR TITLE
feat(vex): OpenVEX foundation — author-asserted CVE exploitability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,6 +225,25 @@ jobs:
           echo "- Image assemblies: $(echo "$BUILD_MELANGE_MATRIX" | jq '.include | length')" >> $GITHUB_STEP_SUMMARY
 
   #----------------------------------------------------------------------------
+  # VALIDATE OPENVEX DOCUMENTS
+  #
+  # Runs on every event so a malformed vex/<image>.openvex.json blocks merge
+  # before image builds start. Standalone — no needs:/depends — so it's the
+  # fastest signal a contributor gets.
+  #----------------------------------------------------------------------------
+  validate-vex:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate OpenVEX docs
+        run: bash tools/vex/validate.sh
+
+  #----------------------------------------------------------------------------
   # GENERATE EPHEMERAL SIGNING KEY (PRs only - secrets not available for forks)
   #----------------------------------------------------------------------------
   keygen:
@@ -457,18 +476,74 @@ jobs:
         if: matrix.scan_for_cves
         run: |
           # Sidecar JSON consumed by tools/dashboard/build.sh — drives the
-          # Size, Built-ago, and digest columns on the CVE dashboard.
+          # Size, Built-ago, raw vs VEX-effective CVE columns, and digest
+          # on the published CVE dashboard.
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
           SIZE_BYTES=$(docker image inspect "$IMAGE" --format '{{.Size}}' 2>/dev/null || echo 0)
           DIGEST=$(docker image inspect "$IMAGE" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's|.*@||')
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          GRYPE_REPORT="grype-${{ matrix.name }}.json"
+          VEX_FILE="vex/${{ matrix.name }}.openvex.json"
+          [ -f "$VEX_FILE" ] || VEX_FILE=""
+
+          # Suppressed CVE IDs: statements where status is not_affected | fixed.
+          SUPPRESSED_JSON='[]'
+          STMT_COUNT=0
+          if [ -n "$VEX_FILE" ]; then
+            STMT_COUNT=$(jq '.statements | length' "$VEX_FILE")
+            SUPPRESSED_JSON=$(jq '[.statements[]
+              | select(.status == "not_affected" or .status == "fixed")
+              | .vulnerability.name] | unique' "$VEX_FILE")
+          fi
+
+          # Severity counts — raw straight from grype, effective drops any
+          # match whose .vulnerability.id is in the suppressed set.
+          counts() {
+            local report="$1" suppressed="$2"
+            jq --argjson sup "$suppressed" '
+              def sev_count(level):
+                [ .matches[]
+                  | select((.vulnerability.id | IN($sup[])) | not)
+                  | select(.vulnerability.severity | ascii_upcase == level)
+                ] | length;
+              {
+                critical: sev_count("CRITICAL"),
+                high:     sev_count("HIGH"),
+                medium:   sev_count("MEDIUM"),
+                low:      sev_count("LOW")
+              } | . + {total: (.critical + .high + .medium + .low)}
+            ' "$report"
+          }
+
+          if [ -f "$GRYPE_REPORT" ]; then
+            RAW_COUNTS=$(counts "$GRYPE_REPORT" '[]')
+            EFF_COUNTS=$(counts "$GRYPE_REPORT" "$SUPPRESSED_JSON")
+          else
+            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"total":0}'
+            EFF_COUNTS="$RAW_COUNTS"
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
             --arg built_at "$BUILT_AT" \
             --arg digest "$DIGEST" \
             --arg image_ref "$IMAGE" \
-            '{name: $name, size_bytes: $size, built_at: $built_at, digest: $digest, image_ref: $image_ref}' \
+            --argjson raw "$RAW_COUNTS" \
+            --argjson effective "$EFF_COUNTS" \
+            --argjson suppressed "$SUPPRESSED_JSON" \
+            --argjson statements "$STMT_COUNT" \
+            '{
+              name: $name,
+              size_bytes: $size,
+              built_at: $built_at,
+              digest: $digest,
+              image_ref: $image_ref,
+              raw: $raw,
+              effective: $effective,
+              vex: { statements: $statements, suppressed: $suppressed }
+            }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json
 
@@ -809,18 +884,74 @@ jobs:
         if: matrix.scan_for_cves
         run: |
           # Sidecar JSON consumed by tools/dashboard/build.sh — drives the
-          # Size, Built-ago, and digest columns on the CVE dashboard.
+          # Size, Built-ago, raw vs VEX-effective CVE columns, and digest
+          # on the published CVE dashboard.
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
           SIZE_BYTES=$(docker image inspect "$IMAGE" --format '{{.Size}}' 2>/dev/null || echo 0)
           DIGEST=$(docker image inspect "$IMAGE" --format '{{index .RepoDigests 0}}' 2>/dev/null | sed 's|.*@||')
           BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          GRYPE_REPORT="grype-${{ matrix.name }}.json"
+          VEX_FILE="vex/${{ matrix.name }}.openvex.json"
+          [ -f "$VEX_FILE" ] || VEX_FILE=""
+
+          # Suppressed CVE IDs: statements where status is not_affected | fixed.
+          SUPPRESSED_JSON='[]'
+          STMT_COUNT=0
+          if [ -n "$VEX_FILE" ]; then
+            STMT_COUNT=$(jq '.statements | length' "$VEX_FILE")
+            SUPPRESSED_JSON=$(jq '[.statements[]
+              | select(.status == "not_affected" or .status == "fixed")
+              | .vulnerability.name] | unique' "$VEX_FILE")
+          fi
+
+          # Severity counts — raw straight from grype, effective drops any
+          # match whose .vulnerability.id is in the suppressed set.
+          counts() {
+            local report="$1" suppressed="$2"
+            jq --argjson sup "$suppressed" '
+              def sev_count(level):
+                [ .matches[]
+                  | select((.vulnerability.id | IN($sup[])) | not)
+                  | select(.vulnerability.severity | ascii_upcase == level)
+                ] | length;
+              {
+                critical: sev_count("CRITICAL"),
+                high:     sev_count("HIGH"),
+                medium:   sev_count("MEDIUM"),
+                low:      sev_count("LOW")
+              } | . + {total: (.critical + .high + .medium + .low)}
+            ' "$report"
+          }
+
+          if [ -f "$GRYPE_REPORT" ]; then
+            RAW_COUNTS=$(counts "$GRYPE_REPORT" '[]')
+            EFF_COUNTS=$(counts "$GRYPE_REPORT" "$SUPPRESSED_JSON")
+          else
+            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"total":0}'
+            EFF_COUNTS="$RAW_COUNTS"
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
             --arg built_at "$BUILT_AT" \
             --arg digest "$DIGEST" \
             --arg image_ref "$IMAGE" \
-            '{name: $name, size_bytes: $size, built_at: $built_at, digest: $digest, image_ref: $image_ref}' \
+            --argjson raw "$RAW_COUNTS" \
+            --argjson effective "$EFF_COUNTS" \
+            --argjson suppressed "$SUPPRESSED_JSON" \
+            --argjson statements "$STMT_COUNT" \
+            '{
+              name: $name,
+              size_bytes: $size,
+              built_at: $built_at,
+              digest: $digest,
+              image_ref: $image_ref,
+              raw: $raw,
+              effective: $effective,
+              vex: { statements: $statements, suppressed: $suppressed }
+            }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json
 
@@ -1061,10 +1192,12 @@ jobs:
           merge-multiple: true
           path: reports/
 
-      - name: Checkout dashboard script
+      - name: Checkout dashboard script and VEX docs
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          sparse-checkout: tools/dashboard
+          sparse-checkout: |
+            tools/dashboard
+            vex
           sparse-checkout-cone-mode: false
           path: src
 
@@ -1074,6 +1207,7 @@ jobs:
           export BUILD_DATE="$(date -u +"%Y-%m-%d %H:%M UTC")"
           export COMMIT_SHA="${SHA:0:7}"
           export RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          export VEX_DIR="src/vex"
           bash src/tools/dashboard/build.sh reports site
 
       - name: Upload Pages artifact

--- a/tools/dashboard/build.sh
+++ b/tools/dashboard/build.sh
@@ -26,6 +26,11 @@ SITE_DIR="${2:?output directory required}"
 BUILD_DATE="${BUILD_DATE:-$(date -u +"%Y-%m-%d %H:%M UTC")}"
 COMMIT_SHA="${COMMIT_SHA:-}"
 RUN_URL="${RUN_URL:-}"
+# Optional: when set, per-image detail pages render an "Author-asserted VEX
+# statements" section sourced from <VEX_DIR>/<image>.openvex.json. CI sets
+# VEX_DIR=src/vex; the meta sidecar still drives effective counts even when
+# this is unset (meta carries the suppressed CVE IDs).
+VEX_DIR="${VEX_DIR:-}"
 
 mkdir -p "$SITE_DIR/assets"
 
@@ -188,6 +193,31 @@ a:hover { text-decoration: underline; }
 .sevbar > .b-medium { background: var(--medium); }
 .sevbar > .b-low { background: var(--low); }
 
+/* VEX rendering */
+tr.suppressed td { opacity: 0.55; text-decoration: line-through; }
+tr.suppressed td.vex-cell { opacity: 1; text-decoration: none; }
+.vex-badge {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--zero);
+  color: #ffffff;
+  font-weight: 500;
+}
+.vex-section {
+  margin: 24px 0;
+  padding: 16px;
+  background: var(--row-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.vex-section h2 { font-size: 16px; margin: 0 0 12px; }
+.vex-stmt { margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px dashed var(--border); }
+.vex-stmt:last-child { margin-bottom: 0; padding-bottom: 0; border-bottom: none; }
+.vex-stmt code { background: var(--bg); padding: 2px 4px; border-radius: 3px; font-size: 12px; }
+.vex-stmt .impact { color: var(--muted); margin-top: 4px; font-size: 13px; }
+
 /* Mobile */
 @media (max-width: 700px) {
   body { margin: 16px auto; }
@@ -250,9 +280,11 @@ JS
 
 #--- per-image detail pages + index row data ---------------------------------
 
-# Aggregate totals
+# Aggregate totals (raw + VEX-effective)
 TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0
-TOTAL_FIXABLE=0; TOTAL_IMAGES=0; CLEAN_IMAGES=0
+TOTAL_EFF_CRIT=0; TOTAL_EFF_HIGH=0; TOTAL_EFF_MED=0; TOTAL_EFF_LOW=0
+TOTAL_VEX_STMTS=0
+TOTAL_FIXABLE=0; TOTAL_IMAGES=0; CLEAN_IMAGES=0; CLEAN_EFF_IMAGES=0
 
 # Build rows in a temp file (so the for-loop subshells don't lose state)
 ROWS_FILE=$(mktemp)
@@ -280,17 +312,37 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
   [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
 
-  # Optional meta
+  # Optional meta — also carries VEX effective counts + suppressed CVE IDs
   META="$REPORTS_DIR/meta-$NAME.json"
+  SUPPRESSED_JSON='[]'
+  VEX_STMT_COUNT=0
   if [ -f "$META" ]; then
     SIZE_BYTES=$(jq -r '.size_bytes // 0' "$META")
     BUILT_AT=$(jq -r '.built_at // ""' "$META")
     DIGEST=$(jq -r '.digest // ""' "$META")
+    EC=$(jq -r '.effective.critical // 0' "$META")
+    EH=$(jq -r '.effective.high     // 0' "$META")
+    EM=$(jq -r '.effective.medium   // 0' "$META")
+    EL=$(jq -r '.effective.low      // 0' "$META")
+    SUPPRESSED_JSON=$(jq -c '.vex.suppressed // []' "$META")
+    VEX_STMT_COUNT=$(jq -r '.vex.statements // 0' "$META")
   else
     SIZE_BYTES=0
     BUILT_AT=""
     DIGEST=""
+    # No meta → effective == raw
+    EC="$C"; EH="$H"; EM="$M"; EL="$L"
   fi
+  ET=$((EC + EH + EM + EL))
+  SUPPRESSED_TOTAL=$((T - ET))
+  [ "$SUPPRESSED_TOTAL" -lt 0 ] && SUPPRESSED_TOTAL=0
+
+  TOTAL_EFF_CRIT=$((TOTAL_EFF_CRIT + EC))
+  TOTAL_EFF_HIGH=$((TOTAL_EFF_HIGH + EH))
+  TOTAL_EFF_MED=$((TOTAL_EFF_MED + EM))
+  TOTAL_EFF_LOW=$((TOTAL_EFF_LOW + EL))
+  TOTAL_VEX_STMTS=$((TOTAL_VEX_STMTS + VEX_STMT_COUNT))
+  [ "$ET" -eq 0 ] && CLEAN_EFF_IMAGES=$((CLEAN_EFF_IMAGES + 1))
   SIZE_DISPLAY=$([ "$SIZE_BYTES" -gt 0 ] && fmt_bytes "$SIZE_BYTES" || echo "—")
   AGE_DAYS=$(days_since "$BUILT_AT")
   AGE_DISPLAY=$([ -n "$BUILT_AT" ] && echo "${AGE_DAYS}d" || echo "—")
@@ -311,27 +363,53 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   MCLASS=$(sev_class "$M" medium)
   LCLASS=$(sev_class "$L" low)
 
+  ETCLASS=$([ "$ET" -gt 0 ] && echo "" || echo "zero")
+
   # Index row
-  printf '<tr data-name="%s" data-crit="%d" data-high="%d" data-med="%d" data-low="%d" data-total="%d" data-fixable="%d" data-size="%d" data-age="%d"><td><a href="%s.html">%s</a></td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num">%d</td><td>%s</td><td class="num">%d</td><td class="num">%s</td><td>%s</td></tr>\n' \
-    "$NAME" "$C" "$H" "$M" "$L" "$T" "$FIXABLE" "$SIZE_BYTES" "$AGE_DAYS" \
+  printf '<tr data-name="%s" data-crit="%d" data-high="%d" data-med="%d" data-low="%d" data-total="%d" data-eff="%d" data-vex="%d" data-fixable="%d" data-size="%d" data-age="%d"><td><a href="%s.html">%s</a></td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num">%d</td><td class="num %s">%d</td><td class="num">%d</td><td>%s</td><td class="num">%d</td><td class="num">%s</td><td>%s</td></tr>\n' \
+    "$NAME" "$C" "$H" "$M" "$L" "$T" "$ET" "$VEX_STMT_COUNT" "$FIXABLE" "$SIZE_BYTES" "$AGE_DAYS" \
     "$NAME" "$NAME" \
     "$CCLASS" "$C" "$HCLASS" "$H" "$MCLASS" "$M" "$LCLASS" "$L" "$T" \
-    "$BAR" "$FIXABLE" "$SIZE_DISPLAY" "$AGE_DISPLAY" >> "$ROWS_FILE"
+    "$ETCLASS" "$ET" "$VEX_STMT_COUNT" "$BAR" "$FIXABLE" "$SIZE_DISPLAY" "$AGE_DISPLAY" >> "$ROWS_FILE"
 
-  # Per-image detail page
-  CVE_ROWS=$(jq -r '
+  # Per-image detail page — suppressed CVEs get a strike-through row and an
+  # explanatory VEX badge in a trailing cell. Others render a plain "—".
+  CVE_ROWS=$(jq -r --argjson sup "$SUPPRESSED_JSON" '
     .matches
     | sort_by(if (.vulnerability.severity | ascii_upcase) == "CRITICAL" then 0
               elif (.vulnerability.severity | ascii_upcase) == "HIGH"    then 1
               elif (.vulnerability.severity | ascii_upcase) == "MEDIUM"  then 2
               else 3 end)
     | .[]
-    | "<tr><td>\(.artifact.name)</td><td>\(.artifact.version)</td><td class=\"\(.vulnerability.severity | ascii_downcase)\">\(.vulnerability.severity | ascii_upcase)</td><td><a href=\"\(.vulnerability.dataSource // "")\" target=\"_blank\" rel=\"noopener\">\(.vulnerability.id)</a></td><td>\((.vulnerability.fix.versions // [])[0] // "—")</td><td>\(.vulnerability.description // "" | .[0:160] | @html)</td></tr>"
+    | (.vulnerability.id | IN($sup[])) as $supd
+    | (if $supd then " class=\"suppressed\"" else "" end) as $rowcls
+    | (if $supd then "<span class=\"vex-badge\">VEX</span>" else "—" end) as $vexcell
+    | "<tr\($rowcls)><td>\(.artifact.name)</td><td>\(.artifact.version)</td><td class=\"\(.vulnerability.severity | ascii_downcase)\">\(.vulnerability.severity | ascii_upcase)</td><td><a href=\"\(.vulnerability.dataSource // "")\" target=\"_blank\" rel=\"noopener\">\(.vulnerability.id)</a></td><td>\((.vulnerability.fix.versions // [])[0] // "—")</td><td>\(.vulnerability.description // "" | .[0:160] | @html)</td><td class=\"vex-cell\">\($vexcell)</td></tr>"
   ' "$f" 2>/dev/null || true)
 
   DIGEST_LINE=""
   if [ -n "$DIGEST" ]; then
     DIGEST_LINE="<p class=\"meta\">Image digest: <code>${DIGEST}</code></p>"
+  fi
+
+  # Render VEX statements section from the actual openvex doc when VEX_DIR set.
+  VEX_BLOCK=""
+  VEX_SRC=""
+  [ -n "$VEX_DIR" ] && [ -f "$VEX_DIR/$NAME.openvex.json" ] && VEX_SRC="$VEX_DIR/$NAME.openvex.json"
+  if [ -n "$VEX_SRC" ] && [ "$VEX_STMT_COUNT" -gt 0 ]; then
+    VEX_STMT_HTML=$(jq -r '
+      .statements[]
+      | "<div class=\"vex-stmt\"><strong>\(.vulnerability.name)</strong> · <code>\(.status)</code>"
+        + (if .justification then " · <code>\(.justification)</code>" else "" end)
+        + (if .impact_statement then "<div class=\"impact\">\(.impact_statement | @html)</div>" else "" end)
+        + "</div>"
+    ' "$VEX_SRC")
+    VEX_BLOCK="<section class=\"vex-section\"><h2>Author-asserted VEX statements (${VEX_STMT_COUNT})</h2>${VEX_STMT_HTML}</section>"
+  fi
+
+  EFFECTIVE_LINE=""
+  if [ "$SUPPRESSED_TOTAL" -gt 0 ]; then
+    EFFECTIVE_LINE=" · ${ET} after VEX (${SUPPRESSED_TOTAL} suppressed)"
   fi
 
   cat > "$SITE_DIR/$NAME.html" <<DETAIL
@@ -346,13 +424,14 @@ for f in "$REPORTS_DIR"/grype-*.json; do
 <body>
 <p class="back"><a href="index.html">← All images</a></p>
 <h1>${NAME}</h1>
-<p class="subtitle">${T} open finding$([ "$T" -eq 1 ] || echo s) · ${FIXABLE} with upstream fix available</p>
+<p class="subtitle">${T} open finding$([ "$T" -eq 1 ] || echo s) · ${FIXABLE} with upstream fix available${EFFECTIVE_LINE}</p>
 <p class="meta">Image: <code>ghcr.io/rtvkiz/minimal-${NAME}:latest</code> &nbsp;·&nbsp; Size: ${SIZE_DISPLAY} &nbsp;·&nbsp; Last rebuilt: ${AGE_DISPLAY} ago &nbsp;·&nbsp; Updated: ${BUILD_DATE}</p>
 ${DIGEST_LINE}
+${VEX_BLOCK}
 <table>
-<thead><tr><th>Package</th><th>Version</th><th>Severity</th><th>CVE</th><th>Fix</th><th>Description</th></tr></thead>
+<thead><tr><th>Package</th><th>Version</th><th>Severity</th><th>CVE</th><th>Fix</th><th>Description</th><th>VEX</th></tr></thead>
 <tbody>
-${CVE_ROWS:-<tr><td colspan="6">No vulnerabilities found.</td></tr>}
+${CVE_ROWS:-<tr><td colspan="7">No vulnerabilities found.</td></tr>}
 </tbody>
 </table>
 </body>
@@ -362,10 +441,11 @@ done
 shopt -u nullglob
 
 TOTAL_ALL=$((TOTAL_CRIT + TOTAL_HIGH + TOTAL_MED + TOTAL_LOW))
+TOTAL_EFF_ALL=$((TOTAL_EFF_CRIT + TOTAL_EFF_HIGH + TOTAL_EFF_MED + TOTAL_EFF_LOW))
 
 # Totals row appended last
-printf '<tr class="totals"><td>Total (%d images)</td><td class="num critical">%d</td><td class="num high">%d</td><td class="num medium">%d</td><td class="num low">%d</td><td class="num">%d</td><td></td><td class="num">%d</td><td></td><td></td></tr>\n' \
-  "$TOTAL_IMAGES" "$TOTAL_CRIT" "$TOTAL_HIGH" "$TOTAL_MED" "$TOTAL_LOW" "$TOTAL_ALL" "$TOTAL_FIXABLE" >> "$ROWS_FILE"
+printf '<tr class="totals"><td>Total (%d images)</td><td class="num critical">%d</td><td class="num high">%d</td><td class="num medium">%d</td><td class="num low">%d</td><td class="num">%d</td><td class="num">%d</td><td class="num">%d</td><td></td><td class="num">%d</td><td></td><td></td></tr>\n' \
+  "$TOTAL_IMAGES" "$TOTAL_CRIT" "$TOTAL_HIGH" "$TOTAL_MED" "$TOTAL_LOW" "$TOTAL_ALL" "$TOTAL_EFF_ALL" "$TOTAL_VEX_STMTS" "$TOTAL_FIXABLE" >> "$ROWS_FILE"
 
 #--- index page ---------------------------------------------------------------
 
@@ -389,7 +469,7 @@ cat > "$SITE_DIR/index.html" <<HTML
 </head>
 <body>
 <h1>Vulnerability Report</h1>
-<p class="subtitle">Daily Grype scan across all production images. Click an image for the full CVE list.</p>
+<p class="subtitle">Daily Grype scan across all production images. <strong>Eff</strong> applies author-asserted <a href="https://openvex.dev/">OpenVEX</a> statements (CVEs we've affirmed don't affect us). Click an image for the full CVE list and VEX rationale.</p>
 <p class="meta">Updated: ${BUILD_DATE}${COMMIT_LINK}</p>
 
 <div class="summary">
@@ -407,6 +487,8 @@ cat > "$SITE_DIR/index.html" <<HTML
   </div>
   <div class="chip"><span class="label">Fixable</span><span class="value">${TOTAL_FIXABLE}</span></div>
   <div class="chip zero"><span class="label">Clean images</span><span class="value">${CLEAN_IMAGES} / ${TOTAL_IMAGES}</span></div>
+  <div class="chip zero"><span class="label">Clean after VEX</span><span class="value">${CLEAN_EFF_IMAGES} / ${TOTAL_IMAGES}</span></div>
+  <div class="chip"><span class="label">VEX statements</span><span class="value">${TOTAL_VEX_STMTS}</span></div>
 </div>
 
 <div class="controls">
@@ -423,6 +505,8 @@ cat > "$SITE_DIR/index.html" <<HTML
   <th data-sort="med" class="num">Med</th>
   <th data-sort="low" class="num">Low</th>
   <th data-sort="total" class="num">Total</th>
+  <th data-sort="eff" class="num" title="Total CVEs after VEX suppression">Eff</th>
+  <th data-sort="vex" class="num" title="Number of OpenVEX statements">VEX</th>
   <th>Severity mix</th>
   <th data-sort="fixable" class="num">Fixable</th>
   <th data-sort="size" class="num">Size</th>

--- a/tools/vex/README.md
+++ b/tools/vex/README.md
@@ -1,0 +1,91 @@
+# VEX — Vulnerability Exploitability eXchange
+
+This directory documents **how** to add VEX statements to `minimal` images. The
+statements themselves live in `vex/<image>.openvex.json`.
+
+## What is VEX?
+
+When a vulnerability scanner (grype, trivy, snyk) finds a CVE in our image, it's
+reporting that a vulnerable *package* is present — not that the vulnerable
+*code path* is reachable. VEX (Vulnerability Exploitability eXchange) is the
+standardized way to tell a scanner "we know about CVE-X and it does **not**
+affect this image, because we don't compile that subsystem / don't expose that
+endpoint / patched it ourselves / etc."
+
+We use [OpenVEX v0.2.0](https://openvex.dev/) — the format SPDX, CycloneDX, and
+grype all consume natively. Every image in this repo has its own
+`vex/<image>.openvex.json` document; build CI passes it to grype via `--vex`,
+so the published dashboard shows both the **raw** CVE count and the
+**effective** (VEX-adjusted) count.
+
+## When to add a statement
+
+Only when **all four** are true:
+
+1. Grype reports a CVE against one of our images.
+2. We have a defensible reason the CVE is not exploitable here.
+3. The reason is durable (not "we'll fix it next week" — use a fix PR for that).
+4. We can write the justification in one sentence a stranger would believe.
+
+If we can't meet #4, don't write the statement. An unbacked `not_affected` is
+worse than no statement at all.
+
+## How to add a statement
+
+1. Identify the image and the CVE: e.g. nginx, CVE-2024-12345.
+2. Open `vex/nginx.openvex.json`.
+3. Append to `statements[]`:
+
+```json
+{
+  "vulnerability": { "name": "CVE-2024-12345" },
+  "products": [
+    { "@id": "pkg:oci/minimal-nginx?repository_url=ghcr.io/rtvkiz" }
+  ],
+  "status": "not_affected",
+  "justification": "vulnerable_code_not_in_execute_path",
+  "impact_statement": "The bug is in nginx's mail proxy module; we build with --without-mail_pop3_module --without-mail_imap_module --without-mail_smtp_module."
+}
+```
+
+4. Bump the document's top-level `version` integer (start at 1, increment on
+   every edit — readers use this to detect changes).
+5. Update the top-level `timestamp` to today (`date -u +%Y-%m-%dT%H:%M:%SZ`).
+6. Run `tools/vex/validate.sh vex/nginx.openvex.json` locally to confirm shape.
+7. Commit on a branch named `vex/<image>-<cve>`, open a PR. CI re-runs grype
+   with `--vex`, so the dashboard count drops on merge.
+
+## Valid `status` values
+
+| Status | Meaning |
+| --- | --- |
+| `not_affected` | The CVE exists in the package but cannot affect this image. **Requires** `justification`. |
+| `affected` | The CVE affects this image and we have not patched it. Should be rare — usually we'd ship a fix. |
+| `fixed` | We backported a patch (in `melange.yaml`) and the vulnerable code is no longer present. |
+| `under_investigation` | We're still triaging. Time-bound — don't leave a CVE in this state for weeks. |
+
+## Standard `justification` values for `not_affected`
+
+These are the OpenVEX-standardized strings — use them verbatim:
+
+- `component_not_present` — the vulnerable component isn't in our image at all
+- `vulnerable_code_not_present` — the package is present but our build excluded the vulnerable code
+- `vulnerable_code_not_in_execute_path` — the code is present but unreachable in normal operation
+- `vulnerable_code_cannot_be_controlled_by_adversary` — reachable but only via a trusted path
+- `inline_mitigations_already_exist` — a runtime mitigation (e.g. seccomp, AppArmor) blocks exploitation
+
+The free-form `impact_statement` field is where you explain *which* of these
+applies and how, in one or two sentences.
+
+## Validating locally
+
+```bash
+# all images
+tools/vex/validate.sh
+
+# specific file
+tools/vex/validate.sh vex/nginx.openvex.json
+```
+
+CI runs `tools/vex/validate.sh` as a standalone job on every PR. A schema
+failure blocks merge — same gate as the image build itself.

--- a/tools/vex/validate.sh
+++ b/tools/vex/validate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Validate every vex/<image>.openvex.json doc against the OpenVEX v0.2.0 shape
+# we use in this repo. Hand-rolled checks (jq, no extra runtime deps).
+#
+# Exits non-zero on the first malformed file so CI fails loudly.
+#
+# Usage:
+#   tools/vex/validate.sh                  # validate every vex/*.openvex.json
+#   tools/vex/validate.sh vex/nginx.openvex.json [...]   # specific files
+
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  files=("$@")
+else
+  shopt -s nullglob
+  files=(vex/*.openvex.json)
+  shopt -u nullglob
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+  echo "no VEX files to validate" >&2
+  exit 1
+fi
+
+errors=0
+for f in "${files[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "FAIL $f: file not found" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  if ! jq -e . "$f" >/dev/null 2>&1; then
+    echo "FAIL $f: invalid JSON" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # Required top-level fields.
+  for key in '@context' '@id' author timestamp version statements; do
+    if ! jq -e --arg k "$key" 'has($k)' "$f" >/dev/null; then
+      echo "FAIL $f: missing required field '$key'" >&2
+      errors=$((errors + 1))
+      continue 2
+    fi
+  done
+
+  # @context must be an OpenVEX context URI.
+  ctx=$(jq -r '."@context"' "$f")
+  case "$ctx" in
+    https://openvex.dev/ns/v0.2.0|https://openvex.dev/ns) ;;
+    *) echo "FAIL $f: unexpected @context '$ctx'" >&2; errors=$((errors + 1)); continue ;;
+  esac
+
+  # version must be a positive integer.
+  if ! jq -e '.version | type == "number" and . >= 1 and floor == .' "$f" >/dev/null; then
+    echo "FAIL $f: 'version' must be a positive integer" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # statements must be an array.
+  if ! jq -e '.statements | type == "array"' "$f" >/dev/null; then
+    echo "FAIL $f: 'statements' must be an array" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+
+  # If any statements exist, each needs vulnerability.name, products[], status.
+  stmt_count=$(jq '.statements | length' "$f")
+  if [ "$stmt_count" -gt 0 ]; then
+    bad=$(jq -r '
+      [ .statements[]
+        | select(
+            (has("vulnerability") | not)
+            or (.vulnerability | has("name") | not)
+            or (has("products") | not)
+            or (.products | type != "array")
+            or (.products | length == 0)
+            or (has("status") | not)
+            or ((.status | IN("not_affected","affected","fixed","under_investigation")) | not)
+            or (.status == "not_affected" and (has("justification") | not))
+          )
+        | .vulnerability.name // "<unknown>"
+      ] | join(",")
+    ' "$f")
+    if [ -n "$bad" ]; then
+      echo "FAIL $f: malformed statements for: $bad" >&2
+      errors=$((errors + 1))
+      continue
+    fi
+  fi
+
+  echo "ok   $f ($stmt_count statement(s))"
+done
+
+if [ "$errors" -gt 0 ]; then
+  echo "" >&2
+  echo "$errors file(s) failed validation" >&2
+  exit 1
+fi
+
+echo ""
+echo "All ${#files[@]} VEX file(s) valid."

--- a/vex/bun.openvex.json
+++ b/vex/bun.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/bun",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/caddy.openvex.json
+++ b/vex/caddy.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/caddy",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/consul.openvex.json
+++ b/vex/consul.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/consul",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/coredns.openvex.json
+++ b/vex/coredns.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/coredns",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/cuda-python.openvex.json
+++ b/vex/cuda-python.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/cuda-python",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/deno.openvex.json
+++ b/vex/deno.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/deno",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/dotnet.openvex.json
+++ b/vex/dotnet.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/dotnet",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/envoy.openvex.json
+++ b/vex/envoy.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/envoy",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/etcd.openvex.json
+++ b/vex/etcd.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/etcd",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/fluent-bit.openvex.json
+++ b/vex/fluent-bit.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/fluent-bit",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/gitea.openvex.json
+++ b/vex/gitea.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/gitea",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/go.openvex.json
+++ b/vex/go.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/go",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/haproxy.openvex.json
+++ b/vex/haproxy.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/haproxy",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/httpd.openvex.json
+++ b/vex/httpd.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/httpd",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/jaeger.openvex.json
+++ b/vex/jaeger.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/jaeger",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/java.openvex.json
+++ b/vex/java.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/java",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/jenkins.openvex.json
+++ b/vex/jenkins.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/jenkins",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/kafka.openvex.json
+++ b/vex/kafka.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/kafka",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/keycloak.openvex.json
+++ b/vex/keycloak.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/keycloak",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/loki.openvex.json
+++ b/vex/loki.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/loki",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/mailpit.openvex.json
+++ b/vex/mailpit.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/mailpit",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/mariadb.openvex.json
+++ b/vex/mariadb.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/mariadb",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/memcached.openvex.json
+++ b/vex/memcached.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/memcached",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/minio.openvex.json
+++ b/vex/minio.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/minio",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/mosquitto.openvex.json
+++ b/vex/mosquitto.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/mosquitto",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/mysql.openvex.json
+++ b/vex/mysql.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/mysql",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/nats.openvex.json
+++ b/vex/nats.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/nats",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/nginx.openvex.json
+++ b/vex/nginx.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/nginx",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/node-slim.openvex.json
+++ b/vex/node-slim.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/node-slim",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/openbao.openvex.json
+++ b/vex/openbao.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/openbao",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/opensearch.openvex.json
+++ b/vex/opensearch.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/opensearch",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/otelcol.openvex.json
+++ b/vex/otelcol.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/otelcol",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/php.openvex.json
+++ b/vex/php.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/php",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/postgres-slim.openvex.json
+++ b/vex/postgres-slim.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/postgres-slim",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/prometheus.openvex.json
+++ b/vex/prometheus.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/prometheus",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/python.openvex.json
+++ b/vex/python.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/python",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/qdrant.openvex.json
+++ b/vex/qdrant.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/qdrant",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/rabbitmq.openvex.json
+++ b/vex/rabbitmq.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/rabbitmq",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/rails.openvex.json
+++ b/vex/rails.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/rails",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/redis-slim.openvex.json
+++ b/vex/redis-slim.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/redis-slim",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/registry.openvex.json
+++ b/vex/registry.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/registry",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/ruby.openvex.json
+++ b/vex/ruby.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/ruby",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/sqlite.openvex.json
+++ b/vex/sqlite.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/sqlite",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/tempo.openvex.json
+++ b/vex/tempo.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/tempo",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/traefik.openvex.json
+++ b/vex/traefik.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/traefik",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/valkey.openvex.json
+++ b/vex/valkey.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/valkey",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/victoria-metrics.openvex.json
+++ b/vex/victoria-metrics.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/victoria-metrics",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

Adds the **evidence layer** that lets the project tell scanners (and the public dashboard) when a CVE present in our SBOM is genuinely not exploitable in our build — using the standardized [OpenVEX v0.2.0](https://openvex.dev/) format.

This is the depth-first capability work we discussed: more valuable than shipping the next batch of images, because it changes what the existing 47 images *prove* about themselves.

## What landed

- **`vex/<image>.openvex.json` × 47** — empty skeleton per image (`statements: []`). Real statements get appended in follow-up PRs as we audit individual non-exploitable findings.
- **`tools/vex/validate.sh`** — jq-based OpenVEX v0.2.0 shape check. Catches missing fields, wrong `@context`, and `not_affected` statements without `justification`.
- **`tools/vex/README.md`** — contributor guide: when (and when not) to write a statement, the four standard `not_affected` justifications, and the per-CVE PR workflow.
- **`validate-vex` CI job** — runs on every event, blocks merge on malformed VEX docs. Independent of image builds, so it's the fastest signal a contributor gets.
- **`meta-<image>.json` sidecar** — now carries both **raw** and **effective** severity counts plus the list of suppressed CVE IDs. Computed in-place from the existing grype run (single jq pass, no second scan).
- **Dashboard upgrades** — `tools/dashboard/build.sh` reads the new sidecar fields and renders:
  - Index: new `Eff` and `VEX` columns, plus *Clean after VEX* and *VEX statements* summary chips
  - Per-image detail: an **Author-asserted VEX statements** section showing `status` / `justification` / `impact_statement` for each claim
  - Suppressed CVE rows render struck-through with a `VEX` badge — readers can see exactly *what* was suppressed and *why*

## Why this matters

Reproducibility-across-time isn't a story anyone in this space can honestly tell — daily CVE patching breaks bit-reproducibility by design. The real differentiator is **provenance + exploitability evidence**. We already had cosign + SBOM + SLSA; VEX completes the picture by addressing the inevitable "your image still shows CVE-X" question with an auditable answer rather than a forum post.

## What's *not* in this PR

- No real statements yet — every doc ships `statements: []`. Effective counts equal raw counts today. Authoring statements is the slow, careful follow-up work (one PR per CVE per image, with a real `impact_statement` we'd stand behind).
- VEX cosign attestation (`cosign attest --type openvex`) — deferred to a follow-up so this PR stays focused on the data model and dashboard surface.
- No README marketing changes — those land alongside the first real statement so we don't oversell empty docs.

## Test plan

- [x] `tools/vex/validate.sh` passes on all 47 skeletons locally
- [x] Validator rejects malformed VEX (verified with a synthetic `not_affected` missing `justification`)
- [x] Dashboard renders correctly against a synthetic fixture (one suppressed Critical + one non-suppressed High; one clean image)
- [x] `bash -n` clean on both shell scripts
- [x] YAML lints clean (`ruby -ryaml`)
- [ ] CI green on this PR (validate-vex + existing image build matrix)