### PR TITLE
feat(helm): add Helm 3 CLI built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,8 @@ jobs:
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
             {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]},
-            {"name":"mosquitto","variants":["prod","dev"]}
+            {"name":"mosquitto","variants":["prod","dev"]},
+            {"name":"helm","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
+HELM_VERSION ?= $(call melange_version,helm/melange.yaml)
 
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
@@ -1307,6 +1308,29 @@ mosquitto: mosquitto-melange
 	@rm -f mosquitto.tar sbom-*.spdx.json
 	@echo "✓ minimal-mosquitto built (source build)"
 
+helm-melange: keygen
+	@echo "Building Helm $(HELM_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build helm/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Helm package built from source"
+
+helm: helm-melange
+	@echo "Assembling minimal-helm image with apko..."
+	apko build helm/apko/helm.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-helm:$(VERSION) \
+		helm.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < helm.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-helm:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-helm:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-helm:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-helm:latest
+	@rm -f helm.tar sbom-*.spdx.json
+	@echo "✓ minimal-helm built (source build)"
+
 #------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
@@ -1958,6 +1982,12 @@ test-mosquitto:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mosquitto:latest" && \
 		mosquitto/test.sh
 	@echo "✓ mosquitto tests passed"
+
+test-helm:
+	@echo "Testing helm image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-helm:latest" && \
+		helm/test.sh
+	@echo "✓ helm tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 46 total
+## Available Images — 47 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -85,6 +85,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 7 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit, tempo |
 | **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
+| **Kubernetes & CI** | 1 | helm |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
 <details>
@@ -142,6 +143,8 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Qdrant | `docker pull ghcr.io/rtvkiz/minimal-qdrant:latest` | No | Vector DB for AI/ML (Rust) |
 | Registry | `docker pull ghcr.io/rtvkiz/minimal-registry:latest` | No | OCI distribution registry (Docker Registry v2), built from source |
 | Consul | `docker pull ghcr.io/rtvkiz/minimal-consul:latest` | No | HashiCorp Consul service discovery + KV (BUSL-1.1) |
+| | | **Kubernetes & CI** | |
+| Helm | `docker pull ghcr.io/rtvkiz/minimal-helm:latest` | No | Helm 3 CLI for Kubernetes chart deployment |
 | | | **Apps** | |
 | Jenkins | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 | Gitea | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Yes | Self-hosted Git service |

--- a/helm/apko/helm-dev.yaml
+++ b/helm/apko/helm-dev.yaml
@@ -1,0 +1,66 @@
+# Development variant of minimal-helm.
+# Same helm binary, plus shell + curl + git + jq for chart-pipeline debugging.
+# Not intended for production CI use — prefer minimal-helm for that.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - helm-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: helm
+      gid: 65532
+  users:
+    - username: helm
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/helm
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HELM_DATA_HOME: /home/helm/.local/share/helm
+  HELM_CONFIG_HOME: /home/helm/.config/helm
+  HELM_CACHE_HOME: /home/helm/.cache/helm
+
+paths:
+  - path: /home/helm
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-helm-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-helm: same helm CLI + shell + curl/git/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/helm"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/helm/apko/helm.yaml
+++ b/helm/apko/helm.yaml
@@ -1,0 +1,65 @@
+# Minimal Helm CLI image - built from source via melange.
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+# Helm is a CLI, not a daemon — the image is meant to be invoked as
+#   docker run --rm -v ~/.kube:/home/helm/.kube minimal-helm install ...
+# in CI pipelines and one-shot installs.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - helm-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: helm
+      gid: 65532
+  users:
+    - username: helm
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/helm
+
+# No default cmd — `docker run minimal-helm` should print helm's usage,
+# which it does via helm's built-in behavior when no subcommand is given.
+
+environment:
+  PATH: /usr/bin:/bin
+  # Helm reads HELM_DATA_HOME / HELM_CONFIG_HOME / HELM_CACHE_HOME. Point them
+  # at writable locations owned by uid 65532 so charts can be pulled without
+  # root privilege.
+  HELM_DATA_HOME: /home/helm/.local/share/helm
+  HELM_CONFIG_HOME: /home/helm/.config/helm
+  HELM_CACHE_HOME: /home/helm/.cache/helm
+
+paths:
+  - path: /home/helm
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-helm"
+  org.opencontainers.image.description: "Hardened shell-less Helm CLI built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/helm"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/helm/melange.yaml
+++ b/helm/melange.yaml
@@ -1,0 +1,80 @@
+# Melange build configuration for minimal Helm CLI.
+# Pure Go from source. Stripped, statically linked. No daemon — this image
+# packages the `helm` binary for use in CI pipelines and one-shot installs.
+# License: Apache-2.0.
+
+package:
+  name: helm-minimal
+  version: 3.21.0
+  epoch: 0
+  description: "Minimal Helm CLI for Kubernetes built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of helm source tarball - updated by update-helm.yml workflow
+  sha256: 5abd5619885f27fe50e8e5b06b2fec575e44a878319f302f09598390c6099705
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify helm source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/helm/helm/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/helm.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/helm.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf helm.tar.gz
+      rm helm.tar.gz
+
+  # Build helm — single static binary, version stamps via helm.sh/helm/v3/internal/version.
+  - runs: |
+      cd /home/build/helm-${{package.version}}
+      BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X helm.sh/helm/v3/internal/version.version=v${{package.version}} \
+          -X helm.sh/helm/v3/internal/version.metadata=source-build \
+          -X helm.sh/helm/v3/internal/version.gitCommit=source-build \
+          -X helm.sh/helm/v3/internal/version.gitTreeState=clean \
+          -X helm.sh/helm/v3/internal/version.buildDate=${BUILD_DATE}" \
+        -o /home/build/helm-bin \
+        ./cmd/helm
+
+  # Install
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/helm-bin "${{targets.destdir}}/usr/bin/helm"
+      chmod 0755 "${{targets.destdir}}/usr/bin/helm"
+
+  # Verify
+  - runs: |
+      echo "Verifying helm build..."
+      "${{targets.destdir}}/usr/bin/helm" version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/helm"
+
+update:
+  enabled: true
+  github:
+    identifier: helm/helm
+    use-tag: true
+    strip-prefix: "v"
+    tag-filter: "v3."

--- a/helm/test-dev.sh
+++ b/helm/test-dev.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Smoke test for minimal-helm-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing helm version (parity with prod)..."
+VERSION_OUT=$(docker run --rm --entrypoint /usr/bin/helm "$IMAGE" version --short)
+echo "$VERSION_OUT"
+echo "$VERSION_OUT" | grep -qE '^v3\.[0-9]+\.[0-9]+'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/jq/git present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && jq --version >/dev/null && git --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "All minimal-helm-dev smoke tests passed"

--- a/helm/test.sh
+++ b/helm/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone (grep closes
+# the pipe early, docker exits 141, pipefail blows the script). Capture to
+# a variable then grep.
+set -eu
+
+echo "Testing helm version..."
+VERSION_OUT=$(docker run --rm --entrypoint /usr/bin/helm "$IMAGE" version --short)
+echo "$VERSION_OUT"
+if ! echo "$VERSION_OUT" | grep -qE '^v3\.[0-9]+\.[0-9]+'; then
+  echo "FAIL: expected v3.x.y in helm version output"
+  exit 1
+fi
+
+echo "Testing helm create + lint roundtrip..."
+# Helm writes the chart to cwd. Use a host bind-mount so create and lint
+# (two separate ephemeral containers) share the workdir. Run as host uid so
+# files end up owned by the test runner — cleanup works without root and CI
+# doesn't have to chmod -R afterwards.
+TMP_VOL=$(mktemp -d)
+trap 'rm -rf "$TMP_VOL"' EXIT
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+docker run --rm --user "${HOST_UID}:${HOST_GID}" --workdir /work --network none \
+  -v "$TMP_VOL:/work" \
+  --entrypoint /usr/bin/helm "$IMAGE" create smoke-chart >/dev/null
+docker run --rm --user "${HOST_UID}:${HOST_GID}" --workdir /work --network none \
+  -v "$TMP_VOL:/work" \
+  --entrypoint /usr/bin/helm "$IMAGE" lint smoke-chart
+echo "helm create + lint OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All helm tests passed!"

--- a/vex/helm.openvex.json
+++ b/vex/helm.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/helm",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-02T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

Adds **minimal-helm** — the Helm 3 CLI built from source as a single static Go binary. First image in a new "Kubernetes & CI" category; kubectl and argocd are the obvious follow-ups in the same lane.

Helm is a CLI, not a daemon, so this image is intended for one-shot use:

```
docker run --rm -v ~/.kube:/home/helm/.kube ghcr.io/rtvkiz/minimal-helm install my-release ./my-chart
```

## What landed

- `helm/melange.yaml` — v3.21.0 (latest 3.x), sha256-pinned tarball, Apache-2.0. Built with `-trimpath -s -w`, version stamps via `helm.sh/helm/v3/internal/version.{version,gitCommit,buildDate,...}`.
- `helm/apko/helm.yaml` — shell-less prod image. Runtime user uid 65532. `HELM_DATA_HOME`/`CONFIG_HOME`/`CACHE_HOME` pointed at `/home/helm/` so charts pull without root.
- `helm/apko/helm-dev.yaml` — dev variant: same helm + busybox/bash/curl/git/jq for chart-pipeline debugging.
- `helm/test.sh` — checks `helm version` reports v3.x.y, then does a full `helm create` + `helm lint` roundtrip via host bind-mount (containers run as host uid so files clean up without root), then asserts no shell.
- `helm/test-dev.sh` — parity on version + dev-toolset presence checks.
- Makefile: new `helm-melange`, `helm`, `test-helm` targets and a `HELM_VERSION` var.
- `.github/workflows/build.yml`: appended `{"name":"helm","variants":["prod","dev"]}` to `MELANGE_IMAGES`.
- `vex/helm.openvex.json` — empty OpenVEX skeleton matching the pattern from #192.
- README: bump 46 → 47, add **Kubernetes & CI** category, helm catalog row.

## Image stats (local build)

```
ghcr.io/rtvkiz/minimal-helm:latest    58.6 MB
```

## Test plan

- [x] `make helm-melange` builds the Wolfi .apk from source
- [x] `make helm` assembles the apko image (58.6 MB)
- [x] `make test-helm` passes (`helm version`, `helm create` + `helm lint`, no-shell check)
- [x] All four YAML files lint clean
- [x] Both shell scripts pass `bash -n`
- [ ] CI green on this PR (build matrix + validate-vex from #192 if merged first)

## Notes

- Pinned to v3.21.0 (latest 3.x) rather than v4.x because v4 just released and most consumers are still on 3.x. A `minimal-helm4` follow-up is reasonable if/when v4 settles.