### PR TITLE
feat(kubectl): add kubectl CLI built from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,8 @@ jobs:
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
             {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]},
             {"name":"mosquitto","variants":["prod","dev"]},
-            {"name":"helm","variants":["prod","dev"]}
+            {"name":"helm","variants":["prod","dev"]},
+            {"name":"kubectl","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
 HELM_VERSION ?= $(call melange_version,helm/melange.yaml)
+KUBECTL_VERSION ?= $(call melange_version,kubectl/melange.yaml)
 
 # --- AI/ML ---
 CUDA_VERSION ?= 12.9.0
@@ -1331,6 +1332,29 @@ helm: helm-melange
 	@rm -f helm.tar sbom-*.spdx.json
 	@echo "✓ minimal-helm built (source build)"
 
+kubectl-melange: keygen
+	@echo "Building kubectl $(KUBECTL_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build kubectl/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ kubectl package built from source"
+
+kubectl: kubectl-melange
+	@echo "Assembling minimal-kubectl image with apko..."
+	apko build kubectl/apko/kubectl.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-kubectl:$(VERSION) \
+		kubectl.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < kubectl.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-kubectl:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-kubectl:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-kubectl:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-kubectl:latest
+	@rm -f kubectl.tar sbom-*.spdx.json
+	@echo "✓ minimal-kubectl built (source build)"
+
 #------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
@@ -1988,6 +2012,12 @@ test-helm:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-helm:latest" && \
 		helm/test.sh
 	@echo "✓ helm tests passed"
+
+test-kubectl:
+	@echo "Testing kubectl image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-kubectl:latest" && \
+		kubectl/test.sh
+	@echo "✓ kubectl tests passed"
 
 test-opensearch:
 	@echo "Testing OpenSearch image..."

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 47 total
+## Available Images — 48 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -85,7 +85,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
 | **Observability** | 7 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit, tempo |
 | **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
-| **Kubernetes & CI** | 1 | helm |
+| **Kubernetes & CI** | 2 | helm, kubectl |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
 <details>
@@ -145,6 +145,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Consul | `docker pull ghcr.io/rtvkiz/minimal-consul:latest` | No | HashiCorp Consul service discovery + KV (BUSL-1.1) |
 | | | **Kubernetes & CI** | |
 | Helm | `docker pull ghcr.io/rtvkiz/minimal-helm:latest` | No | Helm 3 CLI for Kubernetes chart deployment |
+| kubectl | `docker pull ghcr.io/rtvkiz/minimal-kubectl:latest` | No | kubectl CLI for Kubernetes cluster operations |
 | | | **Apps** | |
 | Jenkins | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Yes | CI/CD automation |
 | Gitea | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Yes | Self-hosted Git service |

--- a/kubectl/apko/kubectl-dev.yaml
+++ b/kubectl/apko/kubectl-dev.yaml
@@ -1,0 +1,70 @@
+# Development variant of minimal-kubectl.
+# Same kubectl binary, plus shell + curl + git + jq for cluster-debug workflows.
+# Not intended for production CI use — prefer minimal-kubectl for that.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - kubectl-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: kubectl
+      gid: 65532
+  users:
+    - username: kubectl
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/kubectl
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /home/kubectl
+  KUBECONFIG: /home/kubectl/.kube/config
+
+paths:
+  - path: /home/kubectl
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/kubectl/.kube
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-kubectl-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-kubectl: same kubectl CLI + shell + curl/git/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/kubectl"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/kubectl/apko/kubectl.yaml
+++ b/kubectl/apko/kubectl.yaml
@@ -1,0 +1,66 @@
+# Minimal kubectl CLI image - built from source via melange.
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+# kubectl is a CLI, not a daemon — the image is meant to be invoked as
+#   docker run --rm -v ~/.kube:/home/kubectl/.kube minimal-kubectl get pods
+# in CI pipelines and one-shot cluster operations.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - kubectl-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: kubectl
+      gid: 65532
+  users:
+    - username: kubectl
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/kubectl
+
+# No default cmd — `docker run minimal-kubectl` prints kubectl's usage.
+
+environment:
+  PATH: /usr/bin:/bin
+  # kubectl reads KUBECONFIG and falls back to $HOME/.kube/config.
+  HOME: /home/kubectl
+  KUBECONFIG: /home/kubectl/.kube/config
+
+paths:
+  - path: /home/kubectl
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /home/kubectl/.kube
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-kubectl"
+  org.opencontainers.image.description: "Hardened shell-less kubectl CLI built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/kubectl"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/kubectl/melange.yaml
+++ b/kubectl/melange.yaml
@@ -1,0 +1,91 @@
+# Melange build configuration for minimal kubectl CLI.
+# Pure Go from source (Kubernetes monorepo, ./cmd/kubectl).
+# Statically linked, version stamps injected via -ldflags. No daemon — this
+# image packages the `kubectl` binary for use in CI pipelines and one-shot
+# cluster ops.
+# License: Apache-2.0.
+
+package:
+  name: kubectl-minimal
+  version: 1.36.1
+  epoch: 0
+  description: "Minimal kubectl CLI for Kubernetes built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of kubernetes source tarball - updated by update-kubectl.yml workflow
+  sha256: 1ebfa65cc95fbeb2ef4aad6832a3fae4edb88516e43b6437b69a40895803e0e8
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify kubernetes source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/kubernetes/kubernetes/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/k8s.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/k8s.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf k8s.tar.gz
+      rm k8s.tar.gz
+
+  # Build kubectl — single static binary. Kubernetes' Makefile invokes a custom
+  # hack/ pipeline (git-derived version stamps, codegen) that doesn't work in
+  # the bwrap sandbox without git history. We set ldflags directly to the
+  # k8s.io/{client-go,component-base}/version.* fields the binary surfaces via
+  # `kubectl version --client`.
+  - runs: |
+      cd /home/build/kubernetes-${{package.version}}
+      BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+      LDFLAGS="-s -w"
+      for pkg in k8s.io/client-go/pkg/version k8s.io/component-base/version; do
+        LDFLAGS="$LDFLAGS \
+          -X $pkg.gitVersion=v${{package.version}} \
+          -X $pkg.gitCommit=source-build \
+          -X $pkg.gitTreeState=clean \
+          -X $pkg.buildDate=$BUILD_DATE \
+          -X $pkg.gitMajor=1 \
+          -X $pkg.gitMinor=36"
+      done
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="$LDFLAGS" \
+        -o /home/build/kubectl-bin \
+        ./cmd/kubectl
+
+  # Install
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/kubectl-bin "${{targets.destdir}}/usr/bin/kubectl"
+      chmod 0755 "${{targets.destdir}}/usr/bin/kubectl"
+
+  # Verify
+  - runs: |
+      echo "Verifying kubectl build..."
+      "${{targets.destdir}}/usr/bin/kubectl" version --client
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/kubectl"
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/kubernetes
+    use-tag: true
+    strip-prefix: "v"
+    tag-filter: "v1."

--- a/kubectl/test-dev.sh
+++ b/kubectl/test-dev.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Smoke test for minimal-kubectl-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing kubectl version (parity with prod)..."
+VERSION_OUT=$(docker run --rm --entrypoint /usr/bin/kubectl "$IMAGE" version --client -o yaml)
+echo "$VERSION_OUT" | grep -qE 'gitVersion: v1\.[0-9]+\.[0-9]+'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/jq/git present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && jq --version >/dev/null && git --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "All minimal-kubectl-dev smoke tests passed"

--- a/kubectl/test.sh
+++ b/kubectl/test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone (grep closes
+# the pipe early, docker exits 141, pipefail blows the script). Capture to
+# a variable then grep.
+set -eu
+
+echo "Testing kubectl version --client..."
+VERSION_OUT=$(docker run --rm --entrypoint /usr/bin/kubectl "$IMAGE" version --client -o yaml)
+echo "$VERSION_OUT" | head -8
+if ! echo "$VERSION_OUT" | grep -qE 'gitVersion: v1\.[0-9]+\.[0-9]+'; then
+  echo "FAIL: expected gitVersion v1.x.y in kubectl version output"
+  exit 1
+fi
+
+echo "Testing kubectl create --dry-run (offline manifest generation)..."
+# --dry-run=client never touches a cluster, so this is a pure CLI smoke test.
+# --network none ensures we'd fail loudly if kubectl tried to reach a cluster.
+MANIFEST=$(docker run --rm --network none --entrypoint /usr/bin/kubectl "$IMAGE" \
+  create namespace smoke-test --dry-run=client -o yaml)
+echo "$MANIFEST" | head -6
+echo "$MANIFEST" | grep -qE 'kind:\s*Namespace'
+echo "$MANIFEST" | grep -qE 'name:\s*smoke-test'
+echo "kubectl create --dry-run OK"
+
+echo "Testing kubectl create configmap --dry-run (additional client-side path)..."
+# Different resource + flag surface than the namespace test — exercises the
+# configmap generator and --from-literal parsing, also fully offline.
+CM=$(docker run --rm --network none --entrypoint /usr/bin/kubectl "$IMAGE" \
+  create configmap smoke-cm --from-literal=key=value --dry-run=client -o yaml)
+echo "$CM" | head -6
+echo "$CM" | grep -qE 'kind:\s*ConfigMap'
+echo "$CM" | grep -qE 'key:\s*value'
+echo "kubectl create configmap OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All kubectl tests passed!"

--- a/vex/kubectl.openvex.json
+++ b/vex/kubectl.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/kubectl",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-03T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

Adds **minimal-kubectl** — the kubectl CLI built from source as a single static Go binary, sourced from `kubernetes/kubernetes` v1.36.1. Pairs with `minimal-helm` (#195) to round out the Kubernetes & CI category.

Like helm, kubectl is a CLI not a daemon, so the image is meant for one-shot invocation:

```
docker run --rm -v ~/.kube:/home/kubectl/.kube ghcr.io/rtvkiz/minimal-kubectl get pods
```

## What landed

- `kubectl/melange.yaml` — v1.36.1 (latest stable), sha256-pinned tarball, Apache-2.0. Built with `-trimpath -s -w`, version stamps injected directly into `k8s.io/{client-go,component-base}/version.*` since the upstream `hack/` build pipeline needs git history we don't have in the bwrap sandbox.
- `kubectl/apko/kubectl.yaml` — shell-less prod image. `HOME` + `KUBECONFIG` env vars pointed at `/home/kubectl/.kube/config` so kubeconfig mounts land in the expected place under uid 65532.
- `kubectl/apko/kubectl-dev.yaml` — dev variant with bash/curl/git/jq for cluster-debug workflows.
- `kubectl/test.sh` — `kubectl version --client` (asserts v1.x.y stamp), then two client-only paths (`create namespace --dry-run`, `create configmap --from-literal --dry-run`) under `--network none` so any API-call regression fails loudly. No-shell check at end.
- `kubectl/test-dev.sh` — parity on version + dev-toolset presence.
- Makefile: `kubectl-melange`, `kubectl`, `test-kubectl` targets, `KUBECTL_VERSION` var.
- `.github/workflows/build.yml`: appended `{"name":"kubectl","variants":["prod","dev"]}`.
- `vex/kubectl.openvex.json` — empty OpenVEX skeleton.
- README: 47 → 48, Kubernetes & CI category 1 → 2, catalog row added.

## Image stats (local build)

```
ghcr.io/rtvkiz/minimal-kubectl:latest    59.9 MB
```

## Note on `kubectl explain`

`kubectl explain` was the obvious "offline schema introspection" smoke test, but as of k8s 1.36 it requires a live API server (the built-in OpenAPI fallback was removed). Test substitutes `create configmap --from-literal --dry-run` instead — different generator code path than the namespace test, fully offline.

## Test plan

- [x] `make kubectl-melange` builds the Wolfi .apk from source
- [x] `make kubectl` assembles the apko image (59.9 MB)
- [x] `make test-kubectl` passes (version, two dry-run paths, no-shell)
- [x] All four YAML files lint clean
- [x] Both shell scripts pass `bash -n`
- [x] `tools/vex/validate.sh` accepts `vex/kubectl.openvex.json`
- [ ] CI green on this PR