### PR TITLE
feat(telegraf): add minimal Telegraf 1.39.0 metrics agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
             {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]},
             {"name":"mosquitto","variants":["prod","dev"]},
             {"name":"helm","variants":["prod","dev"]},
-            {"name":"kubectl","variants":["prod","dev"]}
+            {"name":"kubectl","variants":["prod","dev"]},
+            {"name":"telegraf","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -105,6 +105,7 @@ jobs:
             [mailpit]="/home/build/mailpit-${D}{{package.version}}"
             [registry]="/home/build/distribution-${D}{{package.version}}"
             [tempo]="/home/build/tempo-${D}{{package.version}}"
+            [telegraf]="/home/build/telegraf-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -134,6 +134,7 @@ jobs:
             [mailpit]="github.com/axllent/mailpit"
             [registry]="github.com/distribution/distribution/v3"
             [tempo]="github.com/grafana/tempo"
+            [telegraf]="github.com/influxdata/telegraf"
           )
 
           # Build step markers to insert before
@@ -158,6 +159,7 @@ jobs:
             [mailpit]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [registry]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [tempo]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [telegraf]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ ALERTMANAGER_VERSION ?= $(call melange_version,alertmanager/melange.yaml)
 JAEGER_VERSION ?= $(call melange_version,jaeger/melange.yaml)
 OTELCOL_VERSION ?= $(call melange_version,otelcol/melange.yaml)
 VICTORIA_METRICS_VERSION ?= $(call melange_version,victoria-metrics/melange.yaml)
+TELEGRAF_VERSION ?= $(call melange_version,telegraf/melange.yaml)
 
 # --- DNS/Secrets/IAM ---
 COREDNS_VERSION ?= $(call melange_version,coredns/melange.yaml)
@@ -125,6 +126,7 @@ endef
 .PHONY: cuda-python cuda-python-melange
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
+.PHONY: telegraf telegraf-melange telegraf-dev test-telegraf test-telegraf-dev scan-telegraf
 .PHONY: registry registry-melange registry-dev test-registry test-registry-dev
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
@@ -136,7 +138,7 @@ endef
 all: build scan
 
 # Build all images
-build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java ruby php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus mariadb etcd victoria-metrics jaeger otelcol qdrant deno cuda-python coredns openbao loki fluent-bit keycloak
+build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java ruby php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus mariadb etcd victoria-metrics jaeger otelcol qdrant deno cuda-python coredns openbao loki fluent-bit keycloak telegraf
 
 #------------------------------------------------------------------------------
 # SIGNING KEY (required for melange packages)
@@ -211,6 +213,7 @@ $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,tempo,tempo-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mosquitto,mosquitto-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,telegraf,telegraf-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -640,6 +643,32 @@ prometheus: prometheus-melange
 		$(REGISTRY)/$(OWNER)/minimal-prometheus:latest
 	@rm -f prometheus.tar sbom-*.spdx.json
 	@echo "✓ minimal-prometheus built (source build)"
+
+#------------------------------------------------------------------------------
+# TELEGRAF IMAGE (melange Go source build + apko; metrics agent)
+#------------------------------------------------------------------------------
+telegraf-melange: keygen
+	@echo "Building Telegraf $(TELEGRAF_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build telegraf/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Telegraf package built from source"
+
+telegraf: telegraf-melange
+	@echo "Assembling minimal-telegraf image with apko..."
+	apko build telegraf/apko/telegraf.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-telegraf:$(VERSION) \
+		telegraf.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < telegraf.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-telegraf:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-telegraf:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-telegraf:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-telegraf:latest
+	@rm -f telegraf.tar sbom-*.spdx.json
+	@echo "✓ minimal-telegraf built (source build)"
 
 alertmanager-melange: keygen
 	@echo "Building Alertmanager $(ALERTMANAGER_VERSION) from source via melange..."
@@ -1736,6 +1765,7 @@ $(eval $(call DEV_TEST_RULE,mailpit))
 $(eval $(call DEV_TEST_RULE,consul))
 $(eval $(call DEV_TEST_RULE,tempo))
 $(eval $(call DEV_TEST_RULE,mosquitto))
+$(eval $(call DEV_TEST_RULE,telegraf))
 
 test-python:
 	@echo "Testing Python image..."
@@ -2088,6 +2118,12 @@ test-victoria-metrics:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-victoria-metrics:latest" && \
 		victoria-metrics/test.sh
 	@echo "✓ VictoriaMetrics tests passed"
+
+test-telegraf:
+	@echo "Testing Telegraf image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-telegraf:latest" && \
+		telegraf/test.sh
+	@echo "✓ Telegraf tests passed"
 
 test-jaeger:
 	@echo "Testing Jaeger image..."

--- a/telegraf/apko/telegraf-dev.yaml
+++ b/telegraf/apko/telegraf-dev.yaml
@@ -1,0 +1,78 @@
+# Development variant of minimal-telegraf.
+# Same source-built telegraf + ca-certs, plus shell + curl/openssl/dig
+# + jq for HTTP API debugging.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - telegraf-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: telegraf
+      gid: 65532
+  users:
+    - username: telegraf
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/telegraf
+
+cmd: --config /etc/telegraf/telegraf.conf
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/telegraf
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /etc/telegraf/telegraf.d
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/lib/telegraf
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-telegraf-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-telegraf: same telegraf + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/telegraf"
+  org.opencontainers.image.licenses: "MIT"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/telegraf/apko/telegraf.yaml
+++ b/telegraf/apko/telegraf.yaml
@@ -1,0 +1,65 @@
+# Minimal Telegraf image - built from source via melange
+# CVE patching via daily rebuilds from upstream source
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Our Telegraf (built from source via melange)
+    - telegraf-minimal
+
+    # Certificates (needed for HTTPS scrape inputs and HTTPS outputs)
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: telegraf
+      gid: 65532
+  users:
+    - username: telegraf
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/telegraf
+
+cmd: --config /etc/telegraf/telegraf.conf
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/telegraf
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /etc/telegraf/telegraf.d
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/lib/telegraf
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-telegraf"
+  org.opencontainers.image.description: "Hardened Telegraf metrics agent built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/telegraf"
+  org.opencontainers.image.licenses: "MIT"
+
+archs:
+  - x86_64
+  - aarch64

--- a/telegraf/melange.yaml
+++ b/telegraf/melange.yaml
@@ -1,0 +1,103 @@
+# Melange build configuration for minimal Telegraf
+# Builds Telegraf from source (Go) — all core input/output plugins, no plugin
+# signing. Default agent loop, HTTP/file/cpu/mem/net/disk inputs, file/http/
+# prometheus_client/influxdb outputs all work fully.
+
+package:
+  name: telegraf-minimal
+  version: 1.39.0
+  epoch: 0
+  description: "Minimal Telegraf metrics agent built from source"
+  copyright:
+    - license: MIT
+
+vars:
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
+  sha256: d072c38088df3ed9c6ed737ff34d6411c2796f231dc6ccdc5d7da3df69cc2838
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify Telegraf source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors "https://github.com/influxdata/telegraf/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/telegraf.tar.gz
+
+      # Verify checksum
+      echo "${{vars.sha256}}  /home/build/telegraf.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf telegraf.tar.gz
+      rm telegraf.tar.gz
+
+  # Build Telegraf from source (static binary)
+  - runs: |
+      cd /home/build/telegraf-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X github.com/influxdata/telegraf/internal.Version=${{package.version}} \
+          -X github.com/influxdata/telegraf/internal.Branch=HEAD \
+          -X github.com/influxdata/telegraf/internal.Commit=melange" \
+        -o telegraf \
+        ./cmd/telegraf
+
+  # Install to destdir
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/telegraf-${{package.version}}/telegraf "${{targets.destdir}}/usr/bin/"
+
+      # Default configuration file (minimal: agent + http_listener_v2 disabled, cpu input only)
+      mkdir -p "${{targets.destdir}}/etc/telegraf"
+      cat > "${{targets.destdir}}/etc/telegraf/telegraf.conf" << 'EOF'
+      # Minimal Telegraf configuration. Override at runtime by mounting a
+      # different telegraf.conf or passing --config <url> to the entrypoint.
+      [agent]
+        interval = "10s"
+        round_interval = true
+        metric_batch_size = 1000
+        metric_buffer_limit = 10000
+        collection_jitter = "0s"
+        flush_interval = "10s"
+        flush_jitter = "0s"
+        precision = ""
+        hostname = ""
+        omit_hostname = false
+
+      [[inputs.cpu]]
+        percpu = true
+        totalcpu = true
+        collect_cpu_time = false
+        report_active = false
+
+      [[outputs.file]]
+        files = ["stdout"]
+        data_format = "influx"
+      EOF
+
+  # Verify the build
+  - runs: |
+      echo "Verifying Telegraf build..."
+      "${{targets.destdir}}/usr/bin/telegraf" --version
+      echo "Checking binary size..."
+      ls -lh "${{targets.destdir}}/usr/bin/telegraf"
+
+update:
+  enabled: true
+  github:
+    identifier: influxdata/telegraf
+    use-tag: true
+    tag-filter: "v1."

--- a/telegraf/melange.yaml
+++ b/telegraf/melange.yaml
@@ -95,13 +95,30 @@ pipeline:
       echo "Checking binary size..."
       ls -lh "${{targets.destdir}}/usr/bin/telegraf"
 
-  # Workspace cleanup: telegraf depends on github.com/snowflakedb/gosnowflake,
-  # which drops $HOME/.cache/snowflake at compile time with permissions the
-  # host user cannot read once bwrap exits. Melange's post-build workspace
-  # xattr-export step then fails with EACCES on ARM runners. Fix permissions
-  # before the sandbox tears down.
+  # Diagnostic: dump workspace state before melange's xattr-store step.
+  # Earlier CI runs failed with `failed to store workspace xattrs: open
+  # /tmp/melange-workspace-<id>/.cache/snowflake: permission denied`, and we
+  # need to identify what .cache/snowflake actually is (file/dir/FIFO/socket),
+  # who owns it, and what permissions it has — before guessing at fixes.
   - runs: |
-      chmod -R u+rwX /home/build/.cache 2>/dev/null || true
+      echo "=== DEBUG: workspace state before xattr-store ==="
+      echo "--- whoami / id ---"
+      id
+      echo "--- /home/build top level ---"
+      ls -la /home/build/
+      echo "--- /home/build/.cache (if present) ---"
+      ls -la /home/build/.cache/ 2>&1 || echo "(no .cache dir)"
+      echo "--- recursive find of /home/build/.cache ---"
+      find /home/build/.cache -ls 2>&1 || true
+      echo "--- stat /home/build/.cache/snowflake ---"
+      stat /home/build/.cache/snowflake 2>&1 || echo "(stat failed)"
+      echo "--- file /home/build/.cache/snowflake ---"
+      file /home/build/.cache/snowflake 2>&1 || echo "(file failed)"
+      echo "--- getfacl /home/build/.cache/snowflake ---"
+      getfacl /home/build/.cache/snowflake 2>&1 || echo "(no getfacl)"
+      echo "--- attempt chmod -R u+rwX /home/build/.cache ---"
+      chmod -R u+rwX /home/build/.cache 2>&1 && echo "chmod OK" || echo "chmod FAILED"
+      echo "=== END DEBUG ==="
 
 update:
   enabled: true

--- a/telegraf/melange.yaml
+++ b/telegraf/melange.yaml
@@ -95,30 +95,18 @@ pipeline:
       echo "Checking binary size..."
       ls -lh "${{targets.destdir}}/usr/bin/telegraf"
 
-  # Diagnostic: dump workspace state before melange's xattr-store step.
-  # Earlier CI runs failed with `failed to store workspace xattrs: open
-  # /tmp/melange-workspace-<id>/.cache/snowflake: permission denied`, and we
-  # need to identify what .cache/snowflake actually is (file/dir/FIFO/socket),
-  # who owns it, and what permissions it has — before guessing at fixes.
+  # Workspace cleanup: telegraf imports github.com/snowflakedb/gosnowflake
+  # (via its SQL output plugin). When the verify step above runs
+  # `telegraf --version`, the Go runtime fires gosnowflake's init(), which
+  # calls os.MkdirAll($HOME/.cache/snowflake, 0o700) to set up its OCSP
+  # response cache. The dir ends up at /home/build/.cache/snowflake.
+  #
+  # After bwrap exits, melange's "store workspace xattrs" step (running as
+  # the host runner uid) can't open() a 0700 dir whose owner-uid was
+  # remapped by --unshare-user. Earlier `chmod -R u+rwX` was a no-op since
+  # the owner already had rwx; the host process needed o+rX. Fix with a+rX.
   - runs: |
-      echo "=== DEBUG: workspace state before xattr-store ==="
-      echo "--- whoami / id ---"
-      id
-      echo "--- /home/build top level ---"
-      ls -la /home/build/
-      echo "--- /home/build/.cache (if present) ---"
-      ls -la /home/build/.cache/ 2>&1 || echo "(no .cache dir)"
-      echo "--- recursive find of /home/build/.cache ---"
-      find /home/build/.cache -ls 2>&1 || true
-      echo "--- stat /home/build/.cache/snowflake ---"
-      stat /home/build/.cache/snowflake 2>&1 || echo "(stat failed)"
-      echo "--- file /home/build/.cache/snowflake ---"
-      file /home/build/.cache/snowflake 2>&1 || echo "(file failed)"
-      echo "--- getfacl /home/build/.cache/snowflake ---"
-      getfacl /home/build/.cache/snowflake 2>&1 || echo "(no getfacl)"
-      echo "--- attempt chmod -R u+rwX /home/build/.cache ---"
-      chmod -R u+rwX /home/build/.cache 2>&1 && echo "chmod OK" || echo "chmod FAILED"
-      echo "=== END DEBUG ==="
+      chmod -R a+rX /home/build/.cache 2>/dev/null || true
 
 update:
   enabled: true

--- a/telegraf/melange.yaml
+++ b/telegraf/melange.yaml
@@ -95,6 +95,14 @@ pipeline:
       echo "Checking binary size..."
       ls -lh "${{targets.destdir}}/usr/bin/telegraf"
 
+  # Workspace cleanup: telegraf depends on github.com/snowflakedb/gosnowflake,
+  # which drops $HOME/.cache/snowflake at compile time with permissions the
+  # host user cannot read once bwrap exits. Melange's post-build workspace
+  # xattr-export step then fails with EACCES on ARM runners. Fix permissions
+  # before the sandbox tears down.
+  - runs: |
+      chmod -R u+rwX /home/build/.cache 2>/dev/null || true
+
 update:
   enabled: true
   github:

--- a/telegraf/test-dev.sh
+++ b/telegraf/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-telegraf-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing telegraf binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/telegraf"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All telegraf-dev smoke tests passed"

--- a/telegraf/test.sh
+++ b/telegraf/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Testing Telegraf version..."
+docker run --rm --entrypoint /usr/bin/telegraf "$IMAGE" --version
+
+echo "Testing Telegraf config validation..."
+docker run --rm --entrypoint /usr/bin/telegraf "$IMAGE" \
+  --config /etc/telegraf/telegraf.conf --test --quiet >/dev/null
+
+echo "Testing Telegraf starts, emits metrics, and exits cleanly..."
+# --once: run a single collection cycle and exit. Confirms agent loop,
+# cpu input plugin, and file output plugin all work end-to-end.
+OUT=$(docker run --rm --entrypoint /usr/bin/telegraf "$IMAGE" \
+  --config /etc/telegraf/telegraf.conf --once 2>&1)
+
+if ! echo "$OUT" | grep -q '^cpu,'; then
+  echo "Expected at least one cpu,... line in output, got:"
+  echo "$OUT"
+  exit 1
+fi
+echo "Saw cpu metrics in InfluxDB line protocol output"
+
+echo "✓ Telegraf tests passed"

--- a/vex/telegraf.openvex.json
+++ b/vex/telegraf.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/telegraf",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-10T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary
- New from-source Telegraf image (Go, ~308 MB) — full plugin set, distroless prod + dev variants following the `prometheus/` pattern
- Wires `Makefile` (TELEGRAF_VERSION, build rules, .PHONY, build rollup, DEV_IMAGE_RULE/DEV_TEST_RULE, test-telegraf), `build.yml` MELANGE_IMAGES matrix entry, and `patch-go-deps.yml` MODROOT/BUILD_MARKER so the daily rebuild + Go-CVE patch loop pick it up
- First of an 8-image batch (telegraf, mimir, dex, grafana, temporal, vector, vaultwarden, clickhouse) targeting gaps where Chainguard's free tier doesn't publish

## Test plan
- [x] \`yq\` validation on new YAML files
- [x] \`actionlint\` on modified workflows (clean; pre-existing attestations warnings unrelated)
- [x] \`tools/vex/validate.sh\` passes
- [x] \`make telegraf-melange\` — built telegraf-minimal-1.39.0-r0.apk
- [x] \`make telegraf\` — assembled prod image, loaded into docker
- [x] \`make test-telegraf\` — \`--version\`, config validation, and \`--once\` cycle emit cpu metrics in InfluxDB line protocol
- [x] \`make telegraf-dev\` — assembled dev variant
- [x] \`make test-telegraf-dev\` — shell/bash/apk/curl/openssl/jq/dig/git all present