### PR TITLE
feat(mimir): add minimal Grafana Mimir 3.1.0 long-term Prom storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,8 @@ jobs:
             {"name":"mosquitto","variants":["prod","dev"]},
             {"name":"helm","variants":["prod","dev"]},
             {"name":"kubectl","variants":["prod","dev"]},
-            {"name":"telegraf","variants":["prod","dev"]}
+            {"name":"telegraf","variants":["prod","dev"]},
+            {"name":"mimir","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -106,6 +106,7 @@ jobs:
             [registry]="/home/build/distribution-${D}{{package.version}}"
             [tempo]="/home/build/tempo-${D}{{package.version}}"
             [telegraf]="/home/build/telegraf-${D}{{package.version}}"
+            [mimir]="/home/build/mimir-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -136,6 +137,7 @@ jobs:
             [registry]="github.com/distribution/distribution/v3"
             [tempo]="github.com/grafana/tempo"
             [telegraf]="github.com/influxdata/telegraf"
+            [mimir]="github.com/grafana/mimir"
           )
 
           # Build step markers to insert before
@@ -161,6 +163,7 @@ jobs:
             [registry]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [tempo]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [telegraf]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [mimir]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ JAEGER_VERSION ?= $(call melange_version,jaeger/melange.yaml)
 OTELCOL_VERSION ?= $(call melange_version,otelcol/melange.yaml)
 VICTORIA_METRICS_VERSION ?= $(call melange_version,victoria-metrics/melange.yaml)
 TELEGRAF_VERSION ?= $(call melange_version,telegraf/melange.yaml)
+MIMIR_VERSION ?= $(call melange_version,mimir/melange.yaml)
 
 # --- DNS/Secrets/IAM ---
 COREDNS_VERSION ?= $(call melange_version,coredns/melange.yaml)
@@ -127,6 +128,7 @@ endef
 .PHONY: coredns coredns-melange openbao openbao-melange loki loki-melange fluent-bit fluent-bit-melange keycloak keycloak-melange
 .PHONY: gitea gitea-melange
 .PHONY: telegraf telegraf-melange telegraf-dev test-telegraf test-telegraf-dev scan-telegraf
+.PHONY: mimir mimir-melange mimir-dev test-mimir test-mimir-dev scan-mimir
 .PHONY: registry registry-melange registry-dev test-registry test-registry-dev
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
@@ -138,7 +140,7 @@ endef
 all: build scan
 
 # Build all images
-build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java ruby php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus mariadb etcd victoria-metrics jaeger otelcol qdrant deno cuda-python coredns openbao loki fluent-bit keycloak telegraf
+build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java ruby php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus mariadb etcd victoria-metrics jaeger otelcol qdrant deno cuda-python coredns openbao loki fluent-bit keycloak telegraf mimir
 
 #------------------------------------------------------------------------------
 # SIGNING KEY (required for melange packages)
@@ -214,6 +216,7 @@ $(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./package
 $(eval $(call DEV_IMAGE_RULE,tempo,tempo-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mosquitto,mosquitto-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,telegraf,telegraf-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,mimir,mimir-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
 #------------------------------------------------------------------------------
 # JENKINS IMAGE (melange jlink JRE + WAR + apko, shell-less)
@@ -669,6 +672,32 @@ telegraf: telegraf-melange
 		$(REGISTRY)/$(OWNER)/minimal-telegraf:latest
 	@rm -f telegraf.tar sbom-*.spdx.json
 	@echo "✓ minimal-telegraf built (source build)"
+
+#------------------------------------------------------------------------------
+# MIMIR IMAGE (melange Go source build + apko; Grafana long-term Prom storage)
+#------------------------------------------------------------------------------
+mimir-melange: keygen
+	@echo "Building Mimir $(MIMIR_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build mimir/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Mimir package built from source"
+
+mimir: mimir-melange
+	@echo "Assembling minimal-mimir image with apko..."
+	apko build mimir/apko/mimir.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-mimir:$(VERSION) \
+		mimir.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < mimir.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mimir:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mimir:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-mimir:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-mimir:latest
+	@rm -f mimir.tar sbom-*.spdx.json
+	@echo "✓ minimal-mimir built (source build)"
 
 alertmanager-melange: keygen
 	@echo "Building Alertmanager $(ALERTMANAGER_VERSION) from source via melange..."
@@ -1766,6 +1795,7 @@ $(eval $(call DEV_TEST_RULE,consul))
 $(eval $(call DEV_TEST_RULE,tempo))
 $(eval $(call DEV_TEST_RULE,mosquitto))
 $(eval $(call DEV_TEST_RULE,telegraf))
+$(eval $(call DEV_TEST_RULE,mimir))
 
 test-python:
 	@echo "Testing Python image..."
@@ -2124,6 +2154,12 @@ test-telegraf:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-telegraf:latest" && \
 		telegraf/test.sh
 	@echo "✓ Telegraf tests passed"
+
+test-mimir:
+	@echo "Testing Mimir image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mimir:latest" && \
+		mimir/test.sh
+	@echo "✓ Mimir tests passed"
 
 test-jaeger:
 	@echo "Testing Jaeger image..."

--- a/mimir/apko/mimir-dev.yaml
+++ b/mimir/apko/mimir-dev.yaml
@@ -1,0 +1,73 @@
+# Development variant of minimal-mimir.
+# Same source-built mimir + mimirtool + ca-certs, plus shell + curl/openssl/dig
+# + jq for HTTP API debugging.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - mimir-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: mimir
+      gid: 65532
+  users:
+    - username: mimir
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mimir
+
+cmd: -config.file=/etc/mimir/config.yaml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/mimir
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/mimir
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-mimir-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-mimir: same mimir + shell + curl/openssl/dig/jq. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mimir"
+  org.opencontainers.image.licenses: "AGPL-3.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mimir/apko/mimir.yaml
+++ b/mimir/apko/mimir.yaml
@@ -1,0 +1,61 @@
+# Minimal Grafana Mimir image - built from source via melange
+# CVE patching via daily rebuilds from upstream source
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Our Mimir (built from source via melange) — bundles `mimir` daemon
+    # plus `mimirtool` for rules/alerts/config operations.
+    - mimir-minimal
+
+    # Certificates (needed for remote_write/HTTPS object storage, S3, etc.)
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: mimir
+      gid: 65532
+  users:
+    - username: mimir
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/mimir
+
+cmd: -config.file=/etc/mimir/config.yaml
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/mimir
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/mimir
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-mimir"
+  org.opencontainers.image.description: "Hardened Grafana Mimir long-term Prometheus storage built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/mimir"
+  org.opencontainers.image.licenses: "AGPL-3.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/mimir/melange.yaml
+++ b/mimir/melange.yaml
@@ -1,0 +1,180 @@
+# Melange build configuration for minimal Mimir
+# Builds Grafana Mimir from source (Go) — horizontally-scalable, multi-tenant
+# Prometheus long-term storage. Ships `mimir` (the daemon) + `mimirtool`
+# (operational CLI). All core functionality (ingester, distributor, querier,
+# query-frontend, compactor, store-gateway, ruler, alertmanager) works fully.
+
+package:
+  name: mimir-minimal
+  version: 3.1.0
+  epoch: 0
+  description: "Minimal Grafana Mimir long-term Prometheus storage built from source"
+  copyright:
+    - license: AGPL-3.0
+
+vars:
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
+  sha256: 91f0c8321c463f49f8318a5e371a861e9f45ba25532007617e45f28afb7420a1
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify Mimir source. Mimir tags are formatted `mimir-X.Y.Z`
+  # (not `vX.Y.Z`), and the extracted tree is `mimir-mimir-X.Y.Z`.
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors "https://github.com/grafana/mimir/archive/refs/tags/mimir-${{package.version}}.tar.gz" \
+        -o /home/build/mimir.tar.gz
+
+      # Verify checksum
+      echo "${{vars.sha256}}  /home/build/mimir.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf mimir.tar.gz
+      rm mimir.tar.gz
+      # Normalize directory so downstream steps don't have to know about the
+      # double-prefix from the `mimir-X.Y.Z` tag scheme.
+      mv mimir-mimir-${{package.version}} mimir-${{package.version}}
+
+  # Build Mimir + mimirtool from source (static binaries)
+  - runs: |
+      cd /home/build/mimir-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X github.com/grafana/mimir/pkg/util/version.Version=${{package.version}} \
+          -X github.com/grafana/mimir/pkg/util/version.Branch=HEAD \
+          -X github.com/grafana/mimir/pkg/util/version.Revision=melange" \
+        -o mimir \
+        ./cmd/mimir
+
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w \
+          -X main.Version=${{package.version}}" \
+        -o mimirtool \
+        ./cmd/mimirtool
+
+  # Install to destdir
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/mimir-${{package.version}}/mimir "${{targets.destdir}}/usr/bin/"
+      cp /home/build/mimir-${{package.version}}/mimirtool "${{targets.destdir}}/usr/bin/"
+
+      # Minimal monolithic single-binary config: all targets, filesystem
+      # storage at /var/mimir, listen on :8080. Override at runtime by
+      # mounting /etc/mimir/config.yaml or passing -config.file.
+      mkdir -p "${{targets.destdir}}/etc/mimir"
+      cat > "${{targets.destdir}}/etc/mimir/config.yaml" << 'EOF'
+      # Minimal monolithic Mimir config — all components in one process.
+      # Suitable for single-node deployments and dev; for production use a
+      # microservices topology and object storage backend.
+      target: all,alertmanager,overrides-exporter
+
+      # Activity tracker writes a circular log of in-flight work so a crashed
+      # process can be diagnosed post-mortem. Default path is CWD-relative,
+      # which fails as nonroot. Pin under /var/mimir so it's writable.
+      activity_tracker:
+        filepath: /var/mimir/metrics-activity.log
+
+      common:
+        storage:
+          backend: filesystem
+          filesystem:
+            dir: /var/mimir/data
+
+      blocks_storage:
+        backend: filesystem
+        filesystem:
+          dir: /var/mimir/blocks
+        bucket_store:
+          sync_dir: /var/mimir/tsdb-sync
+        tsdb:
+          dir: /var/mimir/tsdb
+
+      compactor:
+        data_dir: /var/mimir/compactor
+        sharding_ring:
+          kvstore:
+            store: memberlist
+
+      distributor:
+        ring:
+          instance_addr: 127.0.0.1
+          kvstore:
+            store: memberlist
+
+      ingester:
+        ring:
+          instance_addr: 127.0.0.1
+          kvstore:
+            store: memberlist
+          replication_factor: 1
+
+      ruler:
+        # rule_path defaults to ./data-ruler/ which is unwritable from
+        # the container root by the nonroot user. Pin under /var/mimir.
+        rule_path: /var/mimir/data-ruler
+
+      ruler_storage:
+        backend: filesystem
+        filesystem:
+          dir: /var/mimir/rules
+
+      alertmanager:
+        # data_dir defaults to ./data-alertmanager/ — same CWD-relative
+        # gotcha as ruler. Pin under /var/mimir.
+        data_dir: /var/mimir/data-alertmanager
+
+      alertmanager_storage:
+        backend: filesystem
+        filesystem:
+          dir: /var/mimir/alertmanager
+
+      server:
+        http_listen_port: 8080
+        grpc_listen_port: 9095
+        log_level: info
+
+      store_gateway:
+        sharding_ring:
+          replication_factor: 1
+      EOF
+
+  # Verify the build. Note: invoking the binaries fires every linked package's
+  # init(), which may create $HOME/.cache/<...> dirs with restrictive perms.
+  # See chmod cleanup step below.
+  - runs: |
+      echo "Verifying Mimir build..."
+      "${{targets.destdir}}/usr/bin/mimir" -version
+      "${{targets.destdir}}/usr/bin/mimirtool" version
+      echo "Checking binary sizes..."
+      ls -lh "${{targets.destdir}}/usr/bin/mimir" "${{targets.destdir}}/usr/bin/mimirtool"
+
+  # Workspace cleanup: if any transitive Go dep created a 0700 cache dir
+  # under $HOME/.cache during the verify step, melange's post-bwrap
+  # xattr-store step would fail to open() it from the host runner uid.
+  # Defensively chmod a+rX so all of .cache stays readable. (Same issue
+  # that bit telegraf via gosnowflake's OCSP cache init.)
+  - runs: |
+      chmod -R a+rX /home/build/.cache 2>/dev/null || true
+
+update:
+  enabled: true
+  github:
+    identifier: grafana/mimir
+    use-tag: true
+    tag-filter: "mimir-"
+    strip-prefix: "mimir-"

--- a/mimir/test-dev.sh
+++ b/mimir/test-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Smoke test for minimal-mimir-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing mimir binary present (parity with prod)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x /usr/bin/mimir && test -x /usr/bin/mimirtool"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq/dig present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null && dig -v 2>&1 | grep -qE '^DiG'"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All mimir-dev smoke tests passed"

--- a/mimir/test.sh
+++ b/mimir/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Testing Mimir version..."
+docker run --rm --entrypoint /usr/bin/mimir "$IMAGE" -version
+
+echo "Testing mimirtool version..."
+docker run --rm --entrypoint /usr/bin/mimirtool "$IMAGE" version
+
+echo "Testing Mimir config validation..."
+# -modules: print the module dependency graph and exit. Also validates the
+# config file end-to-end without binding ports.
+docker run --rm --entrypoint /usr/bin/mimir "$IMAGE" \
+  -config.file=/etc/mimir/config.yaml -modules >/dev/null
+
+echo "Testing Mimir starts, serves /ready, and exits cleanly..."
+docker run -d --name mimir-test \
+  --entrypoint /usr/bin/mimir \
+  "$IMAGE" \
+  -config.file=/etc/mimir/config.yaml
+# Mimir's monolithic mode takes ~15s to bring all components up.
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if docker exec mimir-test wget -q -O - http://localhost:8080/ready 2>/dev/null | grep -q ready; then
+    echo "Mimir is ready"
+    break
+  fi
+  sleep 3
+done
+
+if ! docker ps | grep -q mimir-test; then
+  echo "Mimir failed to stay running, logs:"
+  docker logs mimir-test 2>&1 | tail -30
+  docker rm mimir-test 2>/dev/null || true
+  exit 1
+fi
+docker stop mimir-test >/dev/null && docker rm mimir-test >/dev/null
+
+echo "✓ Mimir tests passed"

--- a/vex/mimir.openvex.json
+++ b/vex/mimir.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/mimir",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-10T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary
- New from-source Mimir image (Go, ~190 MB) — ships `mimir` daemon + `mimirtool` CLI, distroless prod + dev variants following the `prometheus/` pattern
- Config pins `activity_tracker`, `ruler.rule_path`, and `alertmanager.data_dir` under `/var/mimir` — the upstream defaults are CWD-relative (`./data-*`) and fail under uid 65532 in the distroless root `/`
- Wires `Makefile`, `build.yml` MELANGE_IMAGES matrix, and `patch-go-deps.yml` (MODROOTS / MAIN_MODULES / BUILD_MARKERS) so the daily rebuild + Go-CVE patch loop pick it up
- Mimir tag scheme is `mimir-X.Y.Z`, handled by `tag-filter: mimir-` + `strip-prefix: mimir-` in the melange `update:` block

## Test plan
- [x] \`yq\` validation on new YAML files
- [x] \`actionlint\` on modified workflows (pre-existing attestations warnings only)
- [x] \`tools/vex/validate.sh\` passes
- [x] \`make mimir-melange\` — built mimir-minimal-3.1.0-r0.apk
- [x] \`make mimir\` — assembled prod image
- [x] \`make test-mimir\` — \`mimir -version\`, \`mimirtool version\`, \`-modules\` config validation, full startup + /ready healthcheck
- [x] \`make mimir-dev\` — assembled dev variant
- [x] \`make test-mimir-dev\` — shell/bash/apk/curl/openssl/jq/dig/git all present