### PR TITLE
ci(patch-go-deps): self-healing skip for telegraf rclone bump

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -309,6 +309,25 @@ jobs:
                 echo "  Skipping incompatible Loki module bump: $mod_ver"
                 continue
               fi
+              # Telegraf ≤1.39 references rclone's fs.LogOutput, which rclone
+              # removed in v1.73. Bumping rclone to grype's fix version breaks
+              # `go build ./cmd/telegraf` (PR #265). Chainguard's telegraf image
+              # carries the same CVEs (CVE-2026-41176/41179) at rclone v1.69.3
+              # for this reason — there is no clean fix until telegraf upstream
+              # catches up. Self-healing probe: skip only as long as the broken
+              # call site still exists upstream. The day telegraf removes the
+              # fs.LogOutput call, the probe returns "not found" and the bump
+              # proceeds automatically on the next cycle.
+              if [ "$IMAGE" = "telegraf" ] && [[ "$mod_ver" == github.com/rclone/rclone@* ]]; then
+                TG_VER=$(awk '/^package:/{p=1} p && /^  version:/{print $2; exit}' "$MELANGE_FILE" | tr -d '"')
+                PROBE_URL="https://raw.githubusercontent.com/influxdata/telegraf/v${TG_VER}/plugins/outputs/remotefile/remotefile.go"
+                PROBE=$(curl -fsSL --max-time 10 "$PROBE_URL" 2>/dev/null || true)
+                if [ -z "$PROBE" ] || echo "$PROBE" | grep -q "fs\.LogOutput"; then
+                  echo "  Skipping incompatible Telegraf module bump: $mod_ver (rclone fs.LogOutput still referenced at telegraf v${TG_VER}; matches Chainguard's pin)"
+                  continue
+                fi
+                echo "  Telegraf v${TG_VER} no longer references rclone fs.LogOutput — letting bump $mod_ver proceed"
+              fi
               # Apply +incompatible suffix for known modules that need it.
               mod_path="${mod_ver%@*}"
               for incompat in "${INCOMPAT_MODULES[@]}"; do


### PR DESCRIPTION
## Summary
- Telegraf 1.39 calls `fs.LogOutput`, which rclone removed in v1.73. Grype's suggested rclone bump breaks `go build ./cmd/telegraf` (this is what failed PR #265).
- Chainguard's telegraf image carries the same CVEs (CVE-2026-41176 / CVE-2026-41179) at rclone v1.69.3 for the same reason — no clean fix until telegraf upstream catches up.
- Adds a per-image skip gated by an upstream-source probe: each patch-go-deps cycle fetches telegraf's `plugins/outputs/remotefile/remotefile.go` at the pinned version and checks whether `fs.LogOutput` is still referenced.

## Why self-healing (not a static skip)
A static skip rots — we'd never remember to remove it. The probe means the day telegraf upstream removes the `fs.LogOutput` call site, the skip stops triggering and the bump goes through automatically on the next cycle.

## Test plan
- [x] `yq eval . .github/workflows/patch-go-deps.yml` passes
- [x] `actionlint` clean
- [ ] Closes PR #265 (next patch-go-deps schedule will open a clean PR without the rclone bump)
- [ ] On next run, confirm log line: `Skipping incompatible Telegraf module bump: github.com/rclone/rclone@vX.Y.Z (rclone fs.LogOutput still referenced at telegraf vN.NN.0; matches Chainguard's pin)`