### PR TITLE
ci: harden against transient network flakes (Go proxy + sigstore propagation)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -727,28 +727,37 @@ jobs:
           subject-digest: ${{ steps.publish.outputs.digest }}
           push-to-registry: true
 
+      # Sign/attest publish their results to GHCR + Rekor asynchronously;
+      # verification can race the propagation and report "no signatures found"
+      # for ~30–60s even though the sign step succeeded. nick-fields/retry
+      # rides out the GHCR/sigstore eventual-consistency gap (httpd hit this
+      # in scheduled run #27342089679). Three attempts with 15s backoff is
+      # plenty in practice — once propagation lands, verify is instant.
       - name: Verify attestations are discoverable
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
-        run: |
-          set -e
-          IMAGE="${{ steps.publish.outputs.image }}"
-          # Wait briefly for registry propagation.
-          sleep 5
-          echo "Verifying cosign signature..."
-          cosign verify \
-            --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-            "$IMAGE" > /dev/null
-          echo "Verifying SBOM attestation..."
-          cosign verify-attestation --type spdxjson \
-            --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-            "$IMAGE" > /dev/null
-          echo "Verifying SLSA provenance..."
-          gh attestation verify "oci://$IMAGE" --owner ${{ github.repository_owner }} > /dev/null
-          echo "All attestations verified."
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            set -e
+            IMAGE="${{ steps.publish.outputs.image }}"
+            echo "Verifying cosign signature..."
+            cosign verify \
+              --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+              "$IMAGE" > /dev/null
+            echo "Verifying SBOM attestation..."
+            cosign verify-attestation --type spdxjson \
+              --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+              "$IMAGE" > /dev/null
+            echo "Verifying SLSA provenance..."
+            gh attestation verify "oci://$IMAGE" --owner ${{ github.repository_owner }} > /dev/null
+            echo "All attestations verified."
 
   #----------------------------------------------------------------------------
   # BUILD MELANGE-BASED IMAGES (needs packages from melange-build)
@@ -1118,28 +1127,32 @@ jobs:
           subject-digest: ${{ steps.publish.outputs.digest }}
           push-to-registry: true
 
+      # Same propagation race as build-apko's verify step — see comment there.
       - name: Verify attestations are discoverable
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
-        run: |
-          set -e
-          IMAGE="${{ steps.publish.outputs.image }}"
-          # Wait briefly for registry propagation.
-          sleep 5
-          echo "Verifying cosign signature..."
-          cosign verify \
-            --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-            "$IMAGE" > /dev/null
-          echo "Verifying SBOM attestation..."
-          cosign verify-attestation --type spdxjson \
-            --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-            "$IMAGE" > /dev/null
-          echo "Verifying SLSA provenance..."
-          gh attestation verify "oci://$IMAGE" --owner ${{ github.repository_owner }} > /dev/null
-          echo "All attestations verified."
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: |
+            set -e
+            IMAGE="${{ steps.publish.outputs.image }}"
+            echo "Verifying cosign signature..."
+            cosign verify \
+              --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+              "$IMAGE" > /dev/null
+            echo "Verifying SBOM attestation..."
+            cosign verify-attestation --type spdxjson \
+              --certificate-identity-regexp='https://github.com/rtvkiz/minimal/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+              "$IMAGE" > /dev/null
+            echo "Verifying SLSA provenance..."
+            gh attestation verify "oci://$IMAGE" --owner ${{ github.repository_owner }} > /dev/null
+            echo "All attestations verified."
 
   #----------------------------------------------------------------------------
   # SUMMARY

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -408,7 +408,12 @@ jobs:
             # that don't directly import it. Fixing that needs family-aware
             # bump grouping (golang.org/x/* family at consistent versions) —
             # see Chainguard's wolfi-dev/os/loki-3.7.yaml for the pattern.
-            PATCH_BLOCK="  # patch-go-deps: auto-generated — do not edit manually\n  - runs: |\n      export GOWORK=off\n      for root in ${MODROOT}; do\n        [ -f \"\$root/go.mod\" ] || continue\n        ( cd \"\$root\" \\\\\n          && go get${GO_GETS} \\\\\n          && go mod tidy -e \\\\\n          && { [ ! -d vendor ] || go mod vendor; } )\n      done\n  # end-patch-go-deps\n"
+            # _retry wraps go get with 3 attempts and 5/15/30s backoff to
+            # ride out transient proxy.golang.org HTTP/2 stream errors and
+            # 502s (kubectl x86_64 hit this in run #27361909125). go's own
+            # retry doesn't survive mid-stream INTERNAL_ERROR, and a failed
+            # `go get` aborts the whole melange build.
+            PATCH_BLOCK="  # patch-go-deps: auto-generated — do not edit manually\n  - runs: |\n      export GOWORK=off\n      _retry() { local i; for i in 5 15 30; do \"\$@\" && return 0; echo \"retry: \$* failed, sleeping \${i}s\"; sleep \$i; done; \"\$@\"; }\n      for root in ${MODROOT}; do\n        [ -f \"\$root/go.mod\" ] || continue\n        ( cd \"\$root\" \\\\\n          && _retry go get${GO_GETS} \\\\\n          && go mod tidy -e \\\\\n          && { [ ! -d vendor ] || go mod vendor; } )\n      done\n  # end-patch-go-deps\n"
 
             # Find the marker line and insert before it
             MARKER_LINE=$(grep -n "$MARKER" "$MELANGE_FILE" | head -1 | cut -d: -f1)


### PR DESCRIPTION
## Summary
Two layers of retry for the network-flake classes we hit today:

**Layer 1 — `go get` retry inside the patch-go-deps generated block.**
`proxy.golang.org` HTTP/2 stream errors aborted kubectl x86_64 in scheduled run #27361909125 (`stream error: stream ID 533; INTERNAL_ERROR`). The generated melange step now wraps `go get` in a 3-attempt shell helper with 5/15/30s backoff. Each generated `melange.yaml` patch block automatically gets this on the next patch-go-deps cycle.

**Layer 2 — `nick-fields/retry` around verify steps.**
`cosign verify` / `gh attestation verify` race the GHCR + sigstore propagation gap (httpd hit this in run #27342089679 — sign succeeded, verify ~35s later said `no signatures found`). Both `Verify attestations are discoverable` steps (build-apko and build-melange) now use 3 attempts × 15s backoff — same pattern as the existing `cosign sign` and `cosign attest` retry wrappers.

## What this does *not* do
- Doesn't mask real build/code failures — retries are bounded and only re-attempt the specific step.
- Doesn't add a workflow-level auto-rerun (Layer 3 from the discussion). That's a follow-up after we see how Layers 1+2 perform.

## Test plan
- [x] `yq` validates both YAMLs
- [x] `actionlint` clean (one pre-existing `attestations:` permission warning, not from this PR)
- [x] Simulated PATCH_BLOCK render with `printf '%b'` produces expected shell (`_retry go get pkg@v1 pkg2@v2 …`)
- [ ] On next scheduled `Patch Go Transitive Dependencies` run, confirm at least one generated `melange.yaml` contains the new `_retry()` helper
- [ ] Watch next few `Build Hardened Images` runs for clean greens or visible retry log lines (`retry: … failed, sleeping 5s`)