### PR TITLE
ci(patch-deps): map netty haproxy/resolver-dns/epoll artifacts for keycloak

### DIFF
--- a/.github/patch-deps.yaml
+++ b/.github/patch-deps.yaml
@@ -76,6 +76,9 @@
     netty-codec-dns:     io.netty:netty-codec-dns
     netty-codec-http:    io.netty:netty-codec-http
     netty-codec-http2:   io.netty:netty-codec-http2
+    netty-codec-haproxy: io.netty:netty-codec-haproxy
+    netty-resolver-dns:  io.netty:netty-resolver-dns
+    netty-transport-native-epoll: io.netty:netty-transport-native-epoll
     commons-io:          commons-io:commons-io
     commons-compress:    org.apache.commons:commons-compress
     bcprov-jdk18on:      org.bouncycastle:bcprov-jdk18on


### PR DESCRIPTION
## Summary

Grype reports 11 findings on the keycloak image, all in netty 4.1.133.Final jars with fixes in 4.1.135.Final. The maven patch row already handles netty bumps, but three of the flagged artifacts have no coord-map entry, so the patcher skips them (`Maven-only: skip artifacts without a coord-map entry`).

Adds the three missing group:artifact translations:

- `netty-codec-haproxy` → `io.netty:netty-codec-haproxy`
- `netty-resolver-dns` → `io.netty:netty-resolver-dns`
- `netty-transport-native-epoll` → `io.netty:netty-transport-native-epoll`

## Verification

- `yq` parses the registry cleanly
- All three 4.1.135.Final POMs return HTTP 200 from Maven Central, so the row's verify-url gate passes
- Workflow-config-only change: no image build inputs touched; the actual melange.yaml bump arrives via the next patch-deps cycle as its own CI-gated auto-PR