### PR TITLE
vex: suppress aws-sdk-go s3crypto and openbao pseudo-version false positives

### DIFF
--- a/vex/loki.openvex.json
+++ b/vex/loki.openvex.json
@@ -2,8 +2,27 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/loki",
   "author": "rtvkiz",
-  "timestamp": "2026-06-02T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-12T23:33:10Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2022-0646" },
+      "products": [
+        { "@id": "pkg:oci/minimal-loki?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). grafana/loki contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    },
+    {
+      "vulnerability": { "name": "GO-2022-0635" },
+      "products": [
+        { "@id": "pkg:oci/minimal-loki?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). grafana/loki contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    }
+  ]
 }

--- a/vex/openbao.openvex.json
+++ b/vex/openbao.openvex.json
@@ -2,8 +2,90 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/openbao",
   "author": "rtvkiz",
-  "timestamp": "2026-06-02T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-12T23:33:10Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2025-3858" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit a14053c9679d is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...a14053c9679d reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250806 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3857" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit 9b0b5d4f345f is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...9b0b5d4f345f reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250806 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3859" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit c52795c1ef74 is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...c52795c1ef74 reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250807 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3853" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit 183891f8d535 is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...183891f8d535 reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250806 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3855" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit c52795c1ef74 is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...c52795c1ef74 reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250807 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3856" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit 8340a6918f6c is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...8340a6918f6c reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250807 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2025-3854" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Fix commit 4d9b5d3d6486 is an ancestor of the openbao v2.5.4 tag we build from (GitHub compare v2.5.4...4d9b5d3d6486 reports 'behind'), so the patched code ships in this image. govulndb records the fix only as a 0.0.0-20250806 pseudo-version because the openbao module path lacks a /v2 suffix, which makes version-range matchers treat every v2.x tag as affected."
+    },
+    {
+      "vulnerability": { "name": "GO-2022-0646" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). openbao/openbao contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    },
+    {
+      "vulnerability": { "name": "GO-2022-0635" },
+      "products": [
+        { "@id": "pkg:oci/minimal-openbao?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). openbao/openbao contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    }
+  ]
 }

--- a/vex/prometheus.openvex.json
+++ b/vex/prometheus.openvex.json
@@ -2,8 +2,27 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/prometheus",
   "author": "rtvkiz",
-  "timestamp": "2026-06-02T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-12T23:33:10Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2022-0646" },
+      "products": [
+        { "@id": "pkg:oci/minimal-prometheus?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). prometheus/prometheus contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    },
+    {
+      "vulnerability": { "name": "GO-2022-0635" },
+      "products": [
+        { "@id": "pkg:oci/minimal-prometheus?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). prometheus/prometheus contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    }
+  ]
 }

--- a/vex/registry.openvex.json
+++ b/vex/registry.openvex.json
@@ -2,8 +2,27 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/registry",
   "author": "rtvkiz",
-  "timestamp": "2026-06-02T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-12T23:33:10Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2022-0646" },
+      "products": [
+        { "@id": "pkg:oci/minimal-registry?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). distribution/distribution contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    },
+    {
+      "vulnerability": { "name": "GO-2022-0635" },
+      "products": [
+        { "@id": "pkg:oci/minimal-registry?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "The advisory affects only aws-sdk-go v1's S3 encryption client (service/s3/s3crypto). distribution/distribution contains zero references to s3crypto, and Go links only imported packages into the binary, so the vulnerable code is not present. No fixed aws-sdk-go v1 release exists or is planned (fixed only in aws-sdk-go-v2)."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

15 `not_affected` statements across four images, all verified false positives.

### aws-sdk-go v1 — GO-2022-0646, GO-2022-0635 (prometheus, loki, registry, openbao)

Both advisories affect only the `service/s3/s3crypto` encryption client, which will never be fixed in aws-sdk-go v1 (fixed only in v2). GitHub code search shows **zero** `s3crypto` references in prometheus/prometheus, grafana/loki, distribution/distribution, and openbao/openbao — and Go links only imported packages, so the vulnerable code is not present in any of the binaries. Justification: `vulnerable_code_not_present`.

### openbao — GO-2025-3853 through GO-2025-3859

govulndb records these fixes only as `0.0.0-2025080x` commit pseudo-versions because the openbao module path lacks a `/v2` suffix, so version-range matchers flag every v2.x tag forever. All six distinct fix commits are **verified ancestors of the v2.5.4 tag** this image builds from:

| Advisory | Fix commit | compare v2.5.4...commit |
|---|---|---|
| GO-2025-3858 (Critical) | a14053c9679d | behind (389) |
| GO-2025-3857 | 9b0b5d4f345f | behind |
| GO-2025-3859 / GO-2025-3855 | c52795c1ef74 | behind |
| GO-2025-3853 | 183891f8d535 | behind |
| GO-2025-3856 | 8340a6918f6c | behind |
| GO-2025-3854 | 4d9b5d3d6486 | behind |

## Impact

VEX-effective dashboard count drops by 13 findings (incl. openbao's only critical: GO-2025-3858). No build inputs touched — statements are consumed at scan time only.

## Verification

- `tools/vex/validate.sh` passes on all four files (also gated in CI)
- Statement `vulnerability.name` values use the exact grype-reported IDs, matching the `.vulnerability.id` suppression logic in build.yml
- Document `version` bumped 1→2, `timestamp` updated per tools/vex/README.md