### PR TITLE
chore(alertmanager): bump to 0.33.0

### DIFF
--- a/alertmanager/melange.yaml
+++ b/alertmanager/melange.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: alertmanager-minimal
-  version: 0.32.2
+  version: 0.33.0
   epoch: 0
   description: "Minimal Alertmanager built from source"
   copyright:
@@ -12,7 +12,7 @@ package:
 
 vars:
   # SHA256 of source tarball — updated by .github/versions.yaml row + update-versions workflow
-  sha256: 92151e1b1e0108d4b8ce5795e9a06115954fefb93583c2bcf693f6ba80171dca
+  sha256: 99d24655565e1be74d6fff3ebb3b80d6a0bec2a587c84c3c4690949b82908758
 
 environment:
   contents:


### PR DESCRIPTION
## Summary

Updates alertmanager from `0.32.2` to `0.33.0`.

## Changes

- `alertmanager/melange.yaml` — version + source tarball sha256

## Recovery note

The 2026-06-13 `update-versions` run produced this bump correctly but failed at PR creation: `open-pr.sh` passed `--label alertmanager`, a label that didn't exist in the repo, so `gh pr create` aborted (branch pushed, no PR). The missing label has now been created, and open-pr.sh is being hardened to self-create per-image labels (separate PR).

## Local validation

- sha256 `99d2465…908758` verified against the upstream v0.33.0 tarball
- `make alertmanager-melange` + apko assembly succeed
- `alertmanager/test.sh`: alertmanager + amtool report 0.33.0, HTTP API healthy, amtool config validation SUCCESS

## Image Tag

Once merged: `ghcr.io/rtvkiz/minimal-alertmanager:0.33.0-r0`

---
Recovered manually after the update-versions labeling failure.