### PR TITLE
fix(update-versions): self-create per-image label in open-pr.sh

### DIFF
--- a/.github/scripts/open-pr.sh
+++ b/.github/scripts/open-pr.sh
@@ -57,6 +57,17 @@ This PR was automatically created by the [update-versions](${GITHUB_SERVER_URL:-
 EOF
 )
 
+# Ensure the per-image label exists before referencing it. `gh pr create`
+# aborts the *entire* PR creation (not just labeling) if --label names a
+# label the repo doesn't have — which is exactly what happens the first time
+# a newly-added image gets a version bump (alertmanager hit this: branch
+# pushed, no PR, run failed). Create-if-missing only: gh exits non-zero when
+# the label already exists, which `|| true` swallows, so existing labels'
+# color/description are never overwritten (no --force).
+gh label create "$name" \
+  --color ededed \
+  --description "Updates to the ${name} image" 2>/dev/null || true
+
 pr_url=$(gh pr create \
   --title "$title" \
   --label dependencies --label "$name" \


### PR DESCRIPTION
## Summary

The 2026-06-13 `update-versions` run failed on the alertmanager row. `open-pr.sh` passes `--label "$name"` (e.g. `alertmanager`) to `gh pr create`, but that label didn't exist in the repo. **gh aborts the entire PR creation — not just labeling — when handed an unknown label**, so the bump branch was pushed but no PR opened, and the job exited 1 (`could not add label: 'alertmanager' not found`).

This is a latent trap for every newly-added image: the first time it gets a version bump, the run breaks until someone manually creates a matching label. alertmanager, added in d4b3a77, was the first to trip it.

## Fix

Create the label if missing immediately before `gh pr create`. `gh label create` exits non-zero when the label already exists, which `|| true` swallows — so existing labels are never modified (deliberately no `--force`, which would rewrite color/description on every run).

## Verification

- `bash -n` clean
- I audited all 29 update-versions rows against existing repo labels: `alertmanager` was the only gap. I created it manually so the recovered bump (#276) could open, and this change prevents recurrence for the next new image.

---
Related: #276 (the alertmanager 0.33.0 bump this failure blocked).