### PR TITLE
ci(build): harden grype scan against vuln-DB download flakes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,8 +469,42 @@ jobs:
         if: matrix.scan_for_cves
         run: grype version
 
+      # Grype downloads its vulnerability DB on each scan. A connection reset
+      # or 502 from the DB CDN used to fail the entire scheduled rebuild
+      # (nginx scan, 2026-06-17: "connection reset by peer ... failed to load
+      # vulnerability db"; cosign had the same class of flake the day prior).
+      # Isolate the network fetch into a retried, best-effort `db update`
+      # backed by a date-keyed cache, then scan offline (auto-update off):
+      # a transient blip now retries, and a brief outage still scans from the
+      # cached DB, instead of taking down the run for every image.
+      - name: Grype DB cache key
+        if: matrix.scan_for_cves
+        id: grype-db-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Grype DB
+        if: matrix.scan_for_cves
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/grype/db
+          key: grype-db-${{ env.GRYPE_VERSION }}-${{ steps.grype-db-date.outputs.date }}
+          restore-keys: |
+            grype-db-${{ env.GRYPE_VERSION }}-
+
+      - name: Update Grype DB (retried, best-effort)
+        if: matrix.scan_for_cves
+        continue-on-error: true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 20
+          command: grype db update
+
       - name: Scan image for vulnerabilities
         if: matrix.scan_for_cves
+        env:
+          GRYPE_DB_AUTO_UPDATE: "false"
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
           grype "$IMAGE" \
@@ -886,8 +920,42 @@ jobs:
         if: matrix.scan_for_cves
         run: grype version
 
+      # Grype downloads its vulnerability DB on each scan. A connection reset
+      # or 502 from the DB CDN used to fail the entire scheduled rebuild
+      # (nginx scan, 2026-06-17: "connection reset by peer ... failed to load
+      # vulnerability db"; cosign had the same class of flake the day prior).
+      # Isolate the network fetch into a retried, best-effort `db update`
+      # backed by a date-keyed cache, then scan offline (auto-update off):
+      # a transient blip now retries, and a brief outage still scans from the
+      # cached DB, instead of taking down the run for every image.
+      - name: Grype DB cache key
+        if: matrix.scan_for_cves
+        id: grype-db-date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Grype DB
+        if: matrix.scan_for_cves
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/grype/db
+          key: grype-db-${{ env.GRYPE_VERSION }}-${{ steps.grype-db-date.outputs.date }}
+          restore-keys: |
+            grype-db-${{ env.GRYPE_VERSION }}-
+
+      - name: Update Grype DB (retried, best-effort)
+        if: matrix.scan_for_cves
+        continue-on-error: true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 20
+          command: grype db update
+
       - name: Scan image for vulnerabilities
         if: matrix.scan_for_cves
+        env:
+          GRYPE_DB_AUTO_UPDATE: "false"
         run: |
           IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}"
           grype "$IMAGE" \


### PR DESCRIPTION
## Problem

Two scheduled `Build Hardened Images` runs failed in two days on **transient external downloads in the CVE-scan path**, not on any image change:

- **2026-06-16** — `sigstore/cosign-installer` got an HTTP 502 fetching cosign from GitHub's release CDN.
- **2026-06-17** — grype couldn't fetch its vulnerability DB: `unable to download db: read tcp →172.66.171.139:443: connection reset by peer` → `failed to load vulnerability db: database does not exist` (nginx scan), with cascading `Scan report not found` / `Invalid SARIF`.

The scan step ran `grype "$IMAGE"` with **no retry and no DB cache** (only the grype *binary* was cached). A single CDN blip on any one of ~50 prod scans failed the entire run — blocking the dashboard publish and the 6-hourly rebuild for every image.

## Fix

Applied identically to both scan steps (`build-apko` and `build-melange`), reusing the `nick-fields/retry` action already used for apko publish/verify:

1. **Date-keyed cache** of `~/.cache/grype/db` with `restore-keys` falling back to the most recent prior DB.
2. **Retried, best-effort `grype db update`** (5 attempts, 20s backoff, `continue-on-error`) — isolates the only network operation.
3. **Offline scan** with `GRYPE_DB_AUTO_UPDATE=false` so the scan uses the local DB and makes no network call.

### Behavior

| Scenario | Before | After |
|---|---|---|
| Transient reset/502 | run fails | `db update` retries, succeeds |
| Brief outage, DB cached | run fails | scans from cached DB |
| Sustained outage, no cache | run fails | run fails (unchanged worst case) |

## Verification

- `yq` parses the workflow
- `actionlint` reports no new findings (the two pre-existing `attestations` scope warnings at lines 394/811 are an outdated-scope-list false positive, unrelated to this change)
- Both scan blocks confirmed hardened (2/2)
- Workflow-only change — no image build inputs touched (CLAUDE.md exemption)