### PR TITLE
fix(update-versions): make open-pr.sh idempotent for existing PRs

### DIFF
--- a/.github/scripts/open-pr.sh
+++ b/.github/scripts/open-pr.sh
@@ -68,10 +68,25 @@ gh label create "$name" \
   --color ededed \
   --description "Updates to the ${name} image" 2>/dev/null || true
 
-pr_url=$(gh pr create \
-  --title "$title" \
-  --label dependencies --label "$name" \
-  --body "$body")
+# Reuse an existing open PR for this branch instead of creating a duplicate.
+# The bump branch is force-pushed above, so its diff is already current; but
+# `gh pr create` errors out when a PR for the head branch already exists. That
+# failed the whole run whenever an update PR hadn't merged before the next
+# scheduled cron fired (mysql 8.4.10: PR #281 still open → run exited 1).
+# Edit-if-exists, create otherwise — same pattern as patch-deps.yml.
+pr_url=$(gh pr list --head "$branch" --base main --state open --json url --jq '.[0].url // ""')
+if [ -n "$pr_url" ]; then
+  gh pr edit "$pr_url" \
+    --title "$title" \
+    --add-label dependencies --add-label "$name" \
+    --body "$body"
+  echo "Updated existing PR: $pr_url"
+else
+  pr_url=$(gh pr create \
+    --title "$title" \
+    --label dependencies --label "$name" \
+    --body "$body")
+  echo "Created PR: $pr_url"
+fi
 
-echo "Created PR: $pr_url"
 gh pr merge "$pr_url" --auto --squash --delete-branch


### PR DESCRIPTION
## Problem

The 2026-06-18 `update-versions` run failed on the **mysql** row. The 8.4.10 bump itself was correct — sha256 computed, `mysql/melange.yaml` edited, branch `update-mysql-8.4.10` force-pushed — but then:

```
a pull request for branch "update-mysql-8.4.10" into branch "main" already exists:
https://github.com/rtvkiz/minimal/pull/281
##[error]Process completed with exit code 1
```

`open-pr.sh` calls `gh pr create` unconditionally. PR #281 (the prior day's 8.4.10 bump) was still open at run time — it took ~24h to merge, held up by the grype-DB / cosign CI flakes (#282). `gh pr create` exits 1 when a PR already exists for the head branch, failing the whole run.

This is latent for **every** row: any update PR that hasn't merged before the next scheduled cron fires re-pushes its branch and trips the duplicate-create. mysql just happened to be the one whose PR was slow to merge.

## Fix

Mirror the find-existing-then-edit-or-create pattern that `patch-deps.yml` already uses:

```sh
pr_url=$(gh pr list --head "$branch" --base main --state open --json url --jq '.[0].url // ""')
if [ -n "$pr_url" ]; then gh pr edit "$pr_url" ...; else pr_url=$(gh pr create ...); fi
gh pr merge "$pr_url" --auto --squash --delete-branch
```

The branch is force-pushed earlier in the script, so an existing PR's diff is already current; we just refresh its title/labels/body. Auto-merge is (re-)enabled either way and re-enabling is idempotent.

## Verification

- `bash -n` clean
- Same `gh pr list … --jq '.[0].url // ""'` idiom proven in patch-deps.yml
- Script-only change — no image build inputs touched (CLAUDE.md exemption)

Companion to #277 (label self-create) and #282 (grype-DB hardening) — same goal of keeping the scheduled automation from failing on recoverable conditions.