### PR TITLE
fix(mailpit): don't let version update-check fail the smoke test

### DIFF
--- a/mailpit/test.sh
+++ b/mailpit/test.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 echo "Testing mailpit version..."
-docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version
+# `mailpit version` prints the version, then phones GitHub to check for a
+# newer release; that check exits non-zero on any network hiccup (e.g. a 403
+# when the runner IP is rate-limited), which under `set -e` failed the whole
+# job even though the binary works. Capture output and assert the version
+# string instead of trusting the exit code.
+ver_out=$(docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version 2>&1 || true)
+echo "$ver_out"
+echo "$ver_out" | grep -qiE 'mailpit v[0-9]' || { echo "FAIL: mailpit version not reported"; exit 1; }
 
 echo "Testing mailpit server starts..."
 docker run -d --name mailpit-test \


### PR DESCRIPTION
## Problem

The 2026-06-20 04:42 scheduled `Build Hardened Images` run failed on **mailpit** — the only failing build job. The test's first line:

```sh
docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version
```

`mailpit version` prints the version **and then queries GitHub for a newer release**. That check got a **403** (runner IP rate-limited) and exits non-zero, so under `set -euo pipefail` the whole job failed:

```
Testing mailpit version...
/usr/bin/mailpit v1.30.1 compiled with go1.26.4 on linux/amd64   ← worked
Error checking for latest release: failed to download file: received status code 403
exit 1
```

The image was healthy — it reported v1.30.1 and never reached the server-start / `/livez` / SMTP-banner checks. The next scheduled run (09:44) passed mailpit, confirming it was transient. But the test is *structurally* dependent on an online release check unrelated to whether the image works, so it'll keep flaking whenever GitHub rate-limits.

## Fix

Capture the `version` output and assert the version string, tolerating the exit code:

```sh
ver_out=$(docker run --rm --entrypoint /usr/bin/mailpit "$IMAGE" version 2>&1 || true)
echo "$ver_out"
echo "$ver_out" | grep -qiE 'mailpit v[0-9]' || { echo "FAIL: mailpit version not reported"; exit 1; }
```

Still verifies the binary runs and reports a version; the bundled update-check can no longer fail the test.

## Verification

Local `make mailpit` + `make test-mailpit` pass end-to-end — version reported, server start, HTTP `/livez`, SMTP banner, and no-shell all green.

Same theme as #277 / #282 / #283: keep a recoverable external-network condition from failing the scheduled rebuild.