### PR TITLE
ci(build): widen cosign-verify retry window for sigstore TUF blips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -765,8 +765,11 @@ jobs:
       # verification can race the propagation and report "no signatures found"
       # for ~30–60s even though the sign step succeeded. nick-fields/retry
       # rides out the GHCR/sigstore eventual-consistency gap (httpd hit this
-      # in scheduled run #27342089679). Three attempts with 15s backoff is
-      # plenty in practice — once propagation lands, verify is instant.
+      # in scheduled run #27342089679). It also covers transient sigstore TUF
+      # CDN outages: cosign fetches its trusted root from
+      # tuf-repo-cdn.sigstore.dev, and an i/o timeout there fails verify with
+      # "trusted root is required" (loki, scheduled run 2026-06-21). 5 attempts
+      # with 30s backoff widens the window enough to ride out a brief TUF blip.
       - name: Verify attestations are discoverable
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
@@ -774,8 +777,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
+          max_attempts: 5
+          retry_wait_seconds: 30
           command: |
             set -e
             IMAGE="${{ steps.publish.outputs.image }}"
@@ -1203,8 +1206,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           timeout_minutes: 5
-          max_attempts: 3
-          retry_wait_seconds: 15
+          max_attempts: 5
+          retry_wait_seconds: 30
           command: |
             set -e
             IMAGE="${{ steps.publish.outputs.image }}"


### PR DESCRIPTION
## Problem

The 2026-06-21 14:33 scheduled `Build Hardened Images` run failed on **loki**, in the `Verify attestations are discoverable` step:

```
WARNING: Could not fetch trusted_root.json from the TUF repository ...
Get "https://tuf-repo-cdn.sigstore.dev/14.root.json": dial tcp 34.117.62.14:443: i/o timeout
Error: trusted root is required when using new bundle format
```

cosign fetches its trusted root from `tuf-repo-cdn.sigstore.dev` to verify signatures/attestations. That CDN timed out, and the step's retry window (3 attempts, 15s backoff ≈ 45s) was too short to ride it out — all 3 attempts hit the outage. Our signing itself succeeded; only the post-publish *verification* failed. The next scheduled run recovered on its own, confirming transient sigstore infra.

## Fix

Bump both `Verify attestations are discoverable` steps (build-apko + build-melange) from **3 attempts / 15s → 5 attempts / 30s**, widening tolerance from ~45s to ~2.5min — enough for a typical brief TUF CDN blip. Comment updated to record the TUF cause alongside the existing GHCR-propagation rationale.

## Verification

- `yq` parses the workflow; both verify steps confirmed at 5/30 (the 5/20 grype-DB steps from #282 are untouched)
- `actionlint` clean on the change (only the pre-existing `attestations`-scope false positives remain)
- Workflow-only change — no image build inputs touched

Part of the ongoing resilience work (#277 labels, #282 grype-DB, #283 dup-PR, #290 mailpit version-check).