### PR TITLE
fix(jenkins): make WAR download resilient to dead mirrors

### DIFF
--- a/jenkins/melange.yaml
+++ b/jenkins/melange.yaml
@@ -39,11 +39,27 @@ pipeline:
   # Download and verify Jenkins WAR
   - runs: |
       mkdir -p /home/build/jenkins
-      curl -fsSL --retry 5 --retry-all-errors "https://get.jenkins.io/war-stable/${{package.version}}/jenkins.war" \
-        -o /home/build/jenkins/jenkins.war
+      war=/home/build/jenkins/jenkins.war
+
+      # get.jenkins.io redirects to a community mirror; mirrorbits occasionally
+      # hands out a dead mirror (mirror.xmission.com was unreachable on
+      # 2026-06-21, and with no connect-timeout each of curl's retries hung
+      # ~132s before failing → exit 28, ~13 min wasted, whole build dead).
+      # Cap the connect time so a bad mirror is abandoned in seconds, then fall
+      # back to the directly-hosted archives.jenkins.io (no mirror redirect).
+      ok=0
+      for url in \
+        "https://get.jenkins.io/war-stable/${{package.version}}/jenkins.war" \
+        "https://archives.jenkins.io/war-stable/${{package.version}}/jenkins.war"; do
+        if curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 --retry-all-errors "$url" -o "$war"; then
+          ok=1; break
+        fi
+        echo "WARN: jenkins.war download failed from $url, trying next source"
+      done
+      [ "$ok" = 1 ] || { echo "ERROR: all jenkins.war sources failed"; exit 1; }
 
       # Verify against pinned checksum (stored in repo, not fetched dynamically)
-      echo "${{vars.sha256}}  /home/build/jenkins/jenkins.war" | sha256sum -c -
+      echo "${{vars.sha256}}  $war" | sha256sum -c -
 
   # Create minimal JRE with jlink (only modules Jenkins needs)
   - runs: |


### PR DESCRIPTION
## Problem

The 2026-06-21 05:19 scheduled `Build Hardened Images` run failed on **jenkins** — the melange source build itself, both arches — with `task exited with code 28` (curl timeout):

```
WARN curl: (28) Failed to connect to mirror.xmission.com port 443 after 132731 ms: Could not connect to server
... (×6) ...
ERRO failed to build package: ... task exited with code 28
```

`get.jenkins.io` redirects to a community mirror via mirrorbits, and it handed out `mirror.xmission.com`, which was unreachable. The download had **no `--connect-timeout`**, so each of curl's 5 retries hung ~132s on the dead TCP connect before giving up — ~13 minutes burned, then the whole build died.

## Fix

```sh
for url in get.jenkins.io/...  archives.jenkins.io/...; do
  curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 --retry-all-errors "$url" -o "$war" && break
done
```

- **`--connect-timeout 30`** abandons a dead mirror in seconds, so retries can re-roll to a live mirror instead of hanging 132s each.
- **Fallback to `archives.jenkins.io`**, which serves the WAR directly (verified: HTTP 200, no mirrorbits redirect), if get.jenkins.io still fails.
- Checksum verification is unchanged and **source-independent** — same pinned sha256 regardless of which host served the WAR.

## Verification (local, x86_64 per CLAUDE.md)

- `melange build` succeeds — the new download loop fetched the WAR and `sha256sum -c` passed (either failing aborts the pipeline)
- apko assembly + `test-jenkins` pass: `java -version` (OpenJDK 21.0.11), `jenkins.war --version` → 2.555.3, no shell

Part of the recurring-transient-failure hardening (#277/#282/#283/#290/#291).