### PR TITLE
feat(opentofu): add minimal OpenTofu 1.12.3 source-built image

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -132,6 +132,17 @@
     releases: "https://github.com/open-telemetry/opentelemetry-collector/releases"
     notes: "https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v{version}"
 
+# cron-enabled added once a manual dispatch (gh workflow run
+# update-versions.yml -f only=opentofu) is confirmed to produce a clean PR.
+- name: opentofu
+  files: [opentofu/melange.yaml]
+  source: { type: github-releases-latest, repo: opentofu/opentofu, strip-v: true, pin-major: 1 }
+  tarball: { url: "https://github.com/opentofu/opentofu/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/opentofu/opentofu/releases"
+    notes: "https://github.com/opentofu/opentofu/releases/tag/v{version}"
+
 # ============================================================================
 # github-tags — hits /repos/<repo>/tags?per_page=100, filters by regex,
 # strips prefix, semver-sorts, takes the highest match. Use this when the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,8 @@ jobs:
             {"name":"helm","variants":["prod","dev"]},
             {"name":"kubectl","variants":["prod","dev"]},
             {"name":"telegraf","variants":["prod","dev"]},
-            {"name":"mimir","variants":["prod","dev"]}
+            {"name":"mimir","variants":["prod","dev"]},
+            {"name":"opentofu","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -107,6 +107,7 @@ jobs:
             [tempo]="/home/build/tempo-${D}{{package.version}}"
             [telegraf]="/home/build/telegraf-${D}{{package.version}}"
             [mimir]="/home/build/mimir-${D}{{package.version}}"
+            [opentofu]="/home/build/opentofu-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -138,6 +139,7 @@ jobs:
             [tempo]="github.com/grafana/tempo"
             [telegraf]="github.com/influxdata/telegraf"
             [mimir]="github.com/grafana/mimir"
+            [opentofu]="github.com/opentofu/opentofu"
           )
 
           # Build step markers to insert before
@@ -164,6 +166,7 @@ jobs:
             [tempo]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [telegraf]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [mimir]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
 # --- Observability (extra) ---
 TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 
+# --- IaC / GitOps ---
+OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
+
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
 HELM_VERSION ?= $(call melange_version,helm/melange.yaml)
@@ -133,6 +136,7 @@ endef
 .PHONY: mailpit mailpit-melange mailpit-dev test-mailpit test-mailpit-dev
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
 .PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
+.PHONY: opentofu opentofu-melange test-opentofu
 .PHONY: mosquitto mosquitto-melange mosquitto-dev test-mosquitto test-mosquitto-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
@@ -1369,6 +1373,32 @@ tempo: tempo-melange
 	@echo "✓ minimal-tempo built (source build)"
 
 #------------------------------------------------------------------------------
+# OPENTOFU IMAGE (melange Go source build + apko; Terraform-compatible IaC CLI)
+#------------------------------------------------------------------------------
+opentofu-melange: keygen
+	@echo "Building OpenTofu $(OPENTOFU_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build opentofu/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ OpenTofu package built from source"
+
+opentofu: opentofu-melange
+	@echo "Assembling minimal-opentofu image with apko..."
+	apko build opentofu/apko/opentofu.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-opentofu:$(VERSION) \
+		opentofu.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < opentofu.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-opentofu:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-opentofu:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-opentofu:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-opentofu:latest
+	@rm -f opentofu.tar sbom-*.spdx.json
+	@echo "✓ minimal-opentofu built (source build)"
+
+#------------------------------------------------------------------------------
 # MOSQUITTO IMAGE (melange C source build + apko; Eclipse MQTT broker)
 #------------------------------------------------------------------------------
 mosquitto-melange: keygen
@@ -2093,6 +2123,12 @@ test-tempo:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-tempo:latest" && \
 		tempo/test.sh
 	@echo "✓ tempo tests passed"
+
+test-opentofu:
+	@echo "Testing opentofu image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-opentofu:latest" && \
+		opentofu/test.sh
+	@echo "✓ opentofu tests passed"
 
 test-mosquitto:
 	@echo "Testing mosquitto image..."

--- a/opentofu/apko/opentofu-dev.yaml
+++ b/opentofu/apko/opentofu-dev.yaml
@@ -1,0 +1,64 @@
+# Development variant of minimal-opentofu.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - opentofu-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/tofu
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-opentofu-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-opentofu: same tofu + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/opentofu"
+  org.opencontainers.image.licenses: "MPL-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/opentofu/apko/opentofu.yaml
+++ b/opentofu/apko/opentofu.yaml
@@ -1,0 +1,58 @@
+# Minimal OpenTofu image - Terraform-compatible IaC CLI, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - opentofu-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/tofu
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/bin:/bin
+  # tofu writes CLI config + provider plugin cache under $HOME; nonroot has no
+  # home dir, so point it at a writable location.
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-opentofu"
+  org.opencontainers.image.description: "Hardened shell-less OpenTofu (Terraform-compatible IaC) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/opentofu"
+  org.opencontainers.image.licenses: "MPL-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/opentofu/melange.yaml
+++ b/opentofu/melange.yaml
@@ -1,0 +1,66 @@
+# Melange build configuration for minimal OpenTofu
+# Pure Go from source. Single static `tofu` binary.
+# License: MPL-2.0 (OpenTofu / Linux Foundation).
+
+package:
+  name: opentofu-minimal
+  version: 1.12.3
+  epoch: 0
+  description: "Minimal OpenTofu (Terraform-compatible IaC) built from source"
+  copyright:
+    - license: MPL-2.0
+
+vars:
+  # SHA256 of opentofu source tarball - updated by update-versions.yml workflow
+  sha256: 0691d6c4ab43bcfa708120a0c71ece4be43ece4327445a572d91649e4e09af0e
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify OpenTofu source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/opentofu/opentofu/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/opentofu.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/opentofu.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf opentofu.tar.gz
+      rm opentofu.tar.gz
+
+  # Build the tofu binary (static).
+  # version.rawVersion is //go:embed'd from version/VERSION (already correct in
+  # the tag tarball); version.dev defaults to "yes" which appends a "-dev"
+  # prerelease marker, so set it to "no" for a clean release version string.
+  - runs: |
+      cd /home/build/opentofu-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -X github.com/opentofu/opentofu/version.dev=no" \
+        -o /home/build/tofu-bin \
+        ./cmd/tofu
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/tofu-bin "${{targets.destdir}}/usr/bin/tofu"
+      chmod 0755 "${{targets.destdir}}/usr/bin/tofu"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying tofu binary..."
+      "${{targets.destdir}}/usr/bin/tofu" version

--- a/opentofu/test-dev.sh
+++ b/opentofu/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-opentofu-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing tofu version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/tofu "$IMAGE" version 2>&1 | grep -qiE 'OpenTofu v[0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git (for git-sourced modules)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All opentofu-dev smoke tests passed"

--- a/opentofu/test.sh
+++ b/opentofu/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing tofu version..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qiE 'OpenTofu v[0-9]'
+
+echo "Testing tofu help (subcommands load)..."
+docker run --rm "$IMAGE" -help 2>&1 | grep -qiE 'Usage: tofu'
+
+echo "Testing tofu can init a trivial config (no providers)..."
+work=$(mktemp -d)
+# The image runs as nonroot (uid 65532); make the bind-mounted workspace
+# readable/writable by the container user so `tofu init` can read main.tf and
+# write .terraform.lock.hcl. mktemp -d is 0700/owner-only by default.
+chmod 0777 "$work"
+cat > "$work/main.tf" <<'TF'
+terraform {}
+output "ok" { value = "hello" }
+TF
+chmod 0644 "$work/main.tf"
+docker run --rm -v "$work:/workspace" "$IMAGE" init -backend=false 2>&1 | grep -qiE 'has been successfully initialized'
+rm -rf "$work"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All opentofu tests passed!"

--- a/vex/opentofu.openvex.json
+++ b/vex/opentofu.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/opentofu",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-22T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

First image of the pilot batch growing the catalog. **OpenTofu** (Terraform-compatible IaC) fills the GitOps/IaC gap and isn't packaged by Wolfi, so a source build is the only path — a clean fit for the repo's Go-from-source pattern. Pure Go single static `tofu` binary, modeled on the `tempo/` template.

## What's included

**Image** (`opentofu/`): `melange.yaml` (`go build ./cmd/tofu`, `-X .../version.dev=no` for a clean version string), distroless prod + dev apko configs (nonroot 65532, `HOME=/tmp`, writable `/workspace`), and `test.sh`/`test-dev.sh`.

**Registrations** (the full onboarding checklist):
- `build.yml` MELANGE_IMAGES, `Makefile` targets + `.PHONY`
- `patch-go-deps.yml` MODROOTS / MAIN_MODULES / BUILD_MARKERS — so transitive Go CVEs auto-patch (the step alertmanager missed → 24 lingering CVEs)
- `versions.yaml` `github-releases-latest` row (`cron-enabled` to be flipped after a dispatch check)
- `vex/opentofu.openvex.json` empty template

## Local validation (x86_64, per CLAUDE.md)

`make opentofu-melange` + `make opentofu` + `make test-opentofu` all pass — `tofu version`, help, and `tofu init -backend=false` on a trivial config, plus no-shell. Image is **115 MB**.

## CVE posture

grype reports **1 critical + 1 high + 14 medium**, all fixable transitive Go deps (`golang.org/x/net`→0.55.0, `go.opentelemetry.io/otel/sdk`→1.43.0). opentofu is now registered in `patch-go-deps.yml`, so these get auto-patched on the first cron cycle after the image is published. **Follow-up after merge:** dispatch `patch-go-deps.yml` to open the initial patch PR immediately, and a `update-versions.yml -f only=opentofu` dispatch to confirm the version-bump row before enabling its cron.

Pilot images 2 and 3 (thanos, trivy) follow in separate PRs.