### PR TITLE
feat(thanos): add minimal Thanos 0.41.0 source-built image

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -154,6 +154,17 @@
     releases: "https://github.com/aquasecurity/trivy/releases"
     notes: "https://github.com/aquasecurity/trivy/releases/tag/v{version}"
 
+# cron-enabled added once a manual dispatch (gh workflow run update-versions.yml
+# -f only=thanos) is confirmed to produce a clean PR.
+- name: thanos
+  files: [thanos/melange.yaml]
+  source: { type: github-releases-latest, repo: thanos-io/thanos, strip-v: true, pin-major: 0 }
+  tarball: { url: "https://github.com/thanos-io/thanos/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/thanos-io/thanos/releases"
+    notes: "https://github.com/thanos-io/thanos/releases/tag/v{version}"
+
 # ============================================================================
 # github-tags — hits /repos/<repo>/tags?per_page=100, filters by regex,
 # strips prefix, semver-sorts, takes the highest match. Use this when the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,8 @@ jobs:
             {"name":"telegraf","variants":["prod","dev"]},
             {"name":"mimir","variants":["prod","dev"]},
             {"name":"opentofu","variants":["prod","dev"]},
-            {"name":"trivy","variants":["prod","dev"]}
+            {"name":"trivy","variants":["prod","dev"]},
+            {"name":"thanos","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -109,6 +109,7 @@ jobs:
             [mimir]="/home/build/mimir-${D}{{package.version}}"
             [opentofu]="/home/build/opentofu-${D}{{package.version}}"
             [trivy]="/home/build/trivy-${D}{{package.version}}"
+            [thanos]="/home/build/thanos-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -142,6 +143,7 @@ jobs:
             [mimir]="github.com/grafana/mimir"
             [opentofu]="github.com/opentofu/opentofu"
             [trivy]="github.com/aquasecurity/trivy"
+            [thanos]="github.com/thanos-io/thanos"
           )
 
           # Build step markers to insert before
@@ -170,6 +172,7 @@ jobs:
             [mimir]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [trivy]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
 
 # --- Observability (extra) ---
 TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
+THANOS_VERSION ?= $(call melange_version,thanos/melange.yaml)
 
 # --- IaC / GitOps ---
 OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
@@ -141,6 +142,7 @@ endef
 .PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
 .PHONY: opentofu opentofu-melange test-opentofu
 .PHONY: trivy trivy-melange test-trivy
+.PHONY: thanos thanos-melange test-thanos
 .PHONY: mosquitto mosquitto-melange mosquitto-dev test-mosquitto test-mosquitto-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
@@ -1429,6 +1431,32 @@ trivy: trivy-melange
 	@echo "✓ minimal-trivy built (source build)"
 
 #------------------------------------------------------------------------------
+# THANOS IMAGE (melange Go source build + apko; HA Prometheus long-term storage)
+#------------------------------------------------------------------------------
+thanos-melange: keygen
+	@echo "Building Thanos $(THANOS_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build thanos/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Thanos package built from source"
+
+thanos: thanos-melange
+	@echo "Assembling minimal-thanos image with apko..."
+	apko build thanos/apko/thanos.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-thanos:$(VERSION) \
+		thanos.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < thanos.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-thanos:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-thanos:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-thanos:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-thanos:latest
+	@rm -f thanos.tar sbom-*.spdx.json
+	@echo "✓ minimal-thanos built (source build)"
+
+#------------------------------------------------------------------------------
 # MOSQUITTO IMAGE (melange C source build + apko; Eclipse MQTT broker)
 #------------------------------------------------------------------------------
 mosquitto-melange: keygen
@@ -2165,6 +2193,12 @@ test-trivy:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-trivy:latest" && \
 		trivy/test.sh
 	@echo "✓ trivy tests passed"
+
+test-thanos:
+	@echo "Testing thanos image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-thanos:latest" && \
+		thanos/test.sh
+	@echo "✓ thanos tests passed"
 
 test-mosquitto:
 	@echo "Testing mosquitto image..."

--- a/thanos/apko/thanos-dev.yaml
+++ b/thanos/apko/thanos-dev.yaml
@@ -1,0 +1,62 @@
+# Development variant of minimal-thanos.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - thanos-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: thanos
+      gid: 65532
+  users:
+    - username: thanos
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/thanos
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /var/thanos
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-thanos-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-thanos: same thanos + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/thanos"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/thanos/apko/thanos.yaml
+++ b/thanos/apko/thanos.yaml
@@ -1,0 +1,57 @@
+# Minimal Thanos image - HA Prometheus long-term storage, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - thanos-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: thanos
+      gid: 65532
+  users:
+    - username: thanos
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# thanos is multi-command (query, store, sidecar, compact, receive, ...);
+# no single default subcommand, so the entrypoint is the bare binary.
+entrypoint:
+  command: /usr/bin/thanos
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  # Writable data dir for components that persist locally (store, compact, receive).
+  - path: /var/thanos
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+    recursive: true
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-thanos"
+  org.opencontainers.image.description: "Hardened shell-less Thanos (HA Prometheus long-term storage) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/thanos"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/thanos/melange.yaml
+++ b/thanos/melange.yaml
@@ -1,0 +1,69 @@
+# Melange build configuration for minimal Thanos
+# Pure Go from source. Single multi-command `thanos` binary.
+# License: Apache-2.0 (Thanos authors).
+
+package:
+  name: thanos-minimal
+  version: 0.41.0
+  epoch: 0
+  description: "Minimal Thanos (highly-available Prometheus long-term storage) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of thanos source tarball - updated by update-versions.yml workflow
+  sha256: 7566a654e7ed07f0aed194c4c2fee1f60bddfda0bd8d7458ce735ce2e868ffc8
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify thanos source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/thanos-io/thanos/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/thanos.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/thanos.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf thanos.tar.gz
+      rm thanos.tar.gz
+
+  # Build the thanos binary (static).
+  # Version is reported via github.com/prometheus/common/version; build tags
+  # netgo,slicelabels match upstream's .promu.yml release build.
+  - runs: |
+      cd /home/build/thanos-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -tags netgo,slicelabels \
+        -ldflags="-s -w \
+          -X github.com/prometheus/common/version.Version=${{package.version}} \
+          -X github.com/prometheus/common/version.Revision=source-build \
+          -X github.com/prometheus/common/version.Branch=tag-v${{package.version}}" \
+        -o /home/build/thanos-bin \
+        ./cmd/thanos
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/thanos-bin "${{targets.destdir}}/usr/bin/thanos"
+      chmod 0755 "${{targets.destdir}}/usr/bin/thanos"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying thanos binary..."
+      "${{targets.destdir}}/usr/bin/thanos" --version

--- a/thanos/test-dev.sh
+++ b/thanos/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-thanos-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing thanos version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/thanos "$IMAGE" --version 2>&1 | grep -qiE 'thanos.*version [0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All thanos-dev smoke tests passed"

--- a/thanos/test.sh
+++ b/thanos/test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone.
+set -eu
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing thanos version..."
+docker run --rm --entrypoint /usr/bin/thanos "$IMAGE" --version 2>&1 | grep -qiE 'thanos.*version [0-9]'
+
+echo "Testing thanos help (subcommands load)..."
+docker run --rm --entrypoint /usr/bin/thanos "$IMAGE" --help 2>&1 | grep -qiE 'query|sidecar|store'
+
+echo "Testing thanos query starts and serves /-/healthy..."
+docker run -d --name thanos-test \
+  -p 19090:10902 \
+  "$IMAGE" query \
+    --http-address=0.0.0.0:10902 \
+    --grpc-address=0.0.0.0:10901
+sleep 5
+
+if docker ps | grep -q thanos-test; then
+  echo "thanos container is running"
+  docker logs thanos-test 2>&1 | tail -5
+
+  echo "Checking /-/healthy at :19090..."
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://localhost:19090/-/healthy >/dev/null 2>&1; then
+      echo "thanos /-/healthy OK (attempt $i)"
+      break
+    fi
+    if [ "$i" = "10" ]; then
+      echo "FAIL: thanos /-/healthy never returned 200 after 10 attempts"
+      docker logs thanos-test
+      docker stop thanos-test && docker rm thanos-test
+      exit 1
+    fi
+    sleep 2
+  done
+
+  docker stop thanos-test && docker rm thanos-test
+else
+  echo "thanos failed to start, checking logs..."
+  docker logs thanos-test 2>&1 || true
+  docker rm thanos-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All thanos tests passed!"

--- a/vex/thanos.openvex.json
+++ b/vex/thanos.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/thanos",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-22T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

Second pilot image. **Thanos** (highly-available Prometheus long-term storage) complements the existing Prometheus/Mimir/Tempo observability stack. Pure Go single multi-command binary, modeled on the `tempo/` template.

## What's included

**Image** (`thanos/`): `melange.yaml` (`go build ./cmd/thanos`, tags `netgo,slicelabels` + `prometheus/common/version` ldflags to match upstream's `.promu.yml`), distroless prod + dev apko (nonroot 65532, `/var/thanos` writable, bare-binary entrypoint since thanos is subcommand-driven), and `test.sh`/`test-dev.sh`.

**Registrations**: `build.yml`, `Makefile` (+`.PHONY`), `patch-go-deps.yml` three dicts, `versions.yaml` `github-releases-latest` row, `vex/thanos.openvex.json`.

## Local validation (x86_64, per CLAUDE.md)

`make thanos-melange` + `make thanos` + `make test-thanos` all pass — version, help, and `thanos query` serving `/-/healthy` (OK on first attempt), plus no-shell. Image is **97 MB**.

## ⚠️ CVE posture — patch-go-deps dispatch required after merge

grype reports **8 critical + 11 high**, *all* fixable transitive Go deps — dominated by the `golang.org/x/crypto` family (7 criticals, fixed in 0.52.0), plus `x/net`, `go.opentelemetry.io/otel*`, `prometheus/prometheus`→0.311.3, `go-jose/v4`→4.1.4. This is the standard fresh-Go-image state (cf. alertmanager's 24). thanos is **registered in `patch-go-deps.yml`**, which pins the `x/*` family to `@latest` and harmonizes the otel family — exactly this churn.

**Required follow-up:** once merged + first published, run `gh workflow run patch-go-deps.yml` to open the patch PR and clear these. Suggest merging this after #293 so the patch cycle picks up both.

Pilot image 3 (trivy) follows.