### PR TITLE
feat(trivy): add minimal Trivy 0.71.2 source-built image

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -143,6 +143,17 @@
     releases: "https://github.com/opentofu/opentofu/releases"
     notes: "https://github.com/opentofu/opentofu/releases/tag/v{version}"
 
+# cron-enabled added once a manual dispatch (gh workflow run update-versions.yml
+# -f only=trivy) is confirmed to produce a clean PR.
+- name: trivy
+  files: [trivy/melange.yaml]
+  source: { type: github-releases-latest, repo: aquasecurity/trivy, strip-v: true, pin-major: 0 }
+  tarball: { url: "https://github.com/aquasecurity/trivy/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/aquasecurity/trivy/releases"
+    notes: "https://github.com/aquasecurity/trivy/releases/tag/v{version}"
+
 # ============================================================================
 # github-tags — hits /repos/<repo>/tags?per_page=100, filters by regex,
 # strips prefix, semver-sorts, takes the highest match. Use this when the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,8 @@ jobs:
             {"name":"kubectl","variants":["prod","dev"]},
             {"name":"telegraf","variants":["prod","dev"]},
             {"name":"mimir","variants":["prod","dev"]},
-            {"name":"opentofu","variants":["prod","dev"]}
+            {"name":"opentofu","variants":["prod","dev"]},
+            {"name":"trivy","variants":["prod","dev"]}
           ]'
           APKO_IMAGES='[
             {"name":"python","grep":"python-[0-9]","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -108,6 +108,7 @@ jobs:
             [telegraf]="/home/build/telegraf-${D}{{package.version}}"
             [mimir]="/home/build/mimir-${D}{{package.version}}"
             [opentofu]="/home/build/opentofu-${D}{{package.version}}"
+            [trivy]="/home/build/trivy-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -140,6 +141,7 @@ jobs:
             [telegraf]="github.com/influxdata/telegraf"
             [mimir]="github.com/grafana/mimir"
             [opentofu]="github.com/opentofu/opentofu"
+            [trivy]="github.com/aquasecurity/trivy"
           )
 
           # Build step markers to insert before
@@ -167,6 +169,7 @@ jobs:
             [telegraf]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [mimir]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [trivy]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 # --- IaC / GitOps ---
 OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
 
+# --- Security tooling ---
+TRIVY_VERSION ?= $(call melange_version,trivy/melange.yaml)
+
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
 HELM_VERSION ?= $(call melange_version,helm/melange.yaml)
@@ -137,6 +140,7 @@ endef
 .PHONY: consul consul-melange consul-dev test-consul test-consul-dev
 .PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
 .PHONY: opentofu opentofu-melange test-opentofu
+.PHONY: trivy trivy-melange test-trivy
 .PHONY: mosquitto mosquitto-melange mosquitto-dev test-mosquitto test-mosquitto-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
@@ -1399,6 +1403,32 @@ opentofu: opentofu-melange
 	@echo "✓ minimal-opentofu built (source build)"
 
 #------------------------------------------------------------------------------
+# TRIVY IMAGE (melange Go source build + apko; vulnerability/IaC/secret scanner)
+#------------------------------------------------------------------------------
+trivy-melange: keygen
+	@echo "Building Trivy $(TRIVY_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build trivy/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Trivy package built from source"
+
+trivy: trivy-melange
+	@echo "Assembling minimal-trivy image with apko..."
+	apko build trivy/apko/trivy.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-trivy:$(VERSION) \
+		trivy.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < trivy.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-trivy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-trivy:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-trivy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-trivy:latest
+	@rm -f trivy.tar sbom-*.spdx.json
+	@echo "✓ minimal-trivy built (source build)"
+
+#------------------------------------------------------------------------------
 # MOSQUITTO IMAGE (melange C source build + apko; Eclipse MQTT broker)
 #------------------------------------------------------------------------------
 mosquitto-melange: keygen
@@ -2129,6 +2159,12 @@ test-opentofu:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-opentofu:latest" && \
 		opentofu/test.sh
 	@echo "✓ opentofu tests passed"
+
+test-trivy:
+	@echo "Testing trivy image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-trivy:latest" && \
+		trivy/test.sh
+	@echo "✓ trivy tests passed"
 
 test-mosquitto:
 	@echo "Testing mosquitto image..."

--- a/trivy/apko/trivy-dev.yaml
+++ b/trivy/apko/trivy-dev.yaml
@@ -1,0 +1,65 @@
+# Development variant of minimal-trivy.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - trivy-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/trivy
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /tmp
+  TRIVY_CACHE_DIR: /tmp/.cache/trivy
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-trivy-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-trivy: same trivy + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/trivy"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/trivy/apko/trivy.yaml
+++ b/trivy/apko/trivy.yaml
@@ -1,0 +1,59 @@
+# Minimal Trivy image - vulnerability/IaC/secret scanner, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - trivy-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/trivy
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/bin:/bin
+  # trivy caches its vuln DB + fanal cache under $HOME/.cache; nonroot has no
+  # home dir, so point it at a writable location.
+  HOME: /tmp
+  TRIVY_CACHE_DIR: /tmp/.cache/trivy
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-trivy"
+  org.opencontainers.image.description: "Hardened shell-less Trivy (vulnerability/IaC/secret scanner) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/trivy"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/trivy/melange.yaml
+++ b/trivy/melange.yaml
@@ -1,0 +1,69 @@
+# Melange build configuration for minimal Trivy
+# Pure Go from source. Single static `trivy` binary.
+# License: Apache-2.0 (Aqua Security).
+
+package:
+  name: trivy-minimal
+  version: 0.71.2
+  epoch: 0
+  description: "Minimal Trivy (vulnerability/IaC/secret scanner) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of trivy source tarball - updated by update-versions.yml workflow
+  sha256: a4f4187644f6bdfba393c3c194b9ef8acc3891933c6faeeac8715a057db33785
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify Trivy source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/aquasecurity/trivy/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/trivy.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/trivy.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf trivy.tar.gz
+      rm trivy.tar.gz
+
+  # Build the trivy binary (static).
+  # Version is reported via pkg/version/app.ver (defaults to "dev").
+  # GOEXPERIMENT=jsonv2 is required: trivy (v0.71+) imports the experimental
+  # encoding/json/v2 + encoding/json/jsontext stdlib packages, which are gated
+  # behind this experiment — without it the build fails with "build constraints
+  # exclude all Go files in .../encoding/json/v2". Matches upstream's
+  # goreleaser.yml, which sets GOEXPERIMENT=jsonv2 for every build target.
+  - runs: |
+      cd /home/build/trivy-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 GOEXPERIMENT=jsonv2 go build \
+        -trimpath \
+        -ldflags="-s -w -X github.com/aquasecurity/trivy/pkg/version/app.ver=${{package.version}}" \
+        -o /home/build/trivy-bin \
+        ./cmd/trivy
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/trivy-bin "${{targets.destdir}}/usr/bin/trivy"
+      chmod 0755 "${{targets.destdir}}/usr/bin/trivy"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying trivy binary..."
+      "${{targets.destdir}}/usr/bin/trivy" --version

--- a/trivy/test-dev.sh
+++ b/trivy/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-trivy-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing trivy version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/trivy "$IMAGE" --version 2>&1 | grep -qiE 'Version: 0\.[0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All trivy-dev smoke tests passed"

--- a/trivy/test.sh
+++ b/trivy/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing trivy version..."
+docker run --rm "$IMAGE" --version 2>&1 | grep -qiE 'Version: 0\.[0-9]'
+
+echo "Testing trivy help (scanners load)..."
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'image|filesystem|config'
+
+echo "Testing trivy config scan on a clean Dockerfile (no DB download needed)..."
+work=$(mktemp -d); chmod 0777 "$work"
+cat > "$work/Dockerfile" <<'DF'
+FROM scratch
+USER 65532
+DF
+chmod 0644 "$work/Dockerfile"
+# misconfig scanning runs offline (policies are embedded); exit 0 = no findings.
+docker run --rm -v "$work:/workspace" "$IMAGE" config --quiet /workspace 2>&1 | tail -3
+rm -rf "$work"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All trivy tests passed!"

--- a/vex/trivy.openvex.json
+++ b/vex/trivy.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/trivy",
+  "author": "rtvkiz",
+  "timestamp": "2026-06-22T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Summary

Third and final pilot image. **Trivy** (vulnerability/IaC/secret scanner) adds a security tool and dogfoods the scanning this repo relies on. Pure Go single static binary, modeled on the opentofu CLI template.

## What's included

**Image** (`trivy/`): `melange.yaml` (`go build ./cmd/trivy`, ldflags `pkg/version/app.ver`), distroless prod + dev apko (nonroot 65532, `HOME=/tmp` + `TRIVY_CACHE_DIR` for the vuln-DB/fanal cache, `/workspace` writable), and `test.sh`/`test-dev.sh`.

**Registrations**: `build.yml`, `Makefile` (+`.PHONY`), `patch-go-deps.yml` three dicts, `versions.yaml` row, `vex/trivy.openvex.json`.

## Build note: GOEXPERIMENT=jsonv2

trivy v0.71+ imports the experimental `encoding/json/v2` + `encoding/json/jsontext` stdlib packages. Without the experiment the build fails with *"build constraints exclude all Go files in .../encoding/json/v2"*. The melange build sets `GOEXPERIMENT=jsonv2`, matching upstream's `goreleaser.yml` (which sets it for every build target). Caught by the local build before CI.

## Local validation (x86_64, per CLAUDE.md)

`make trivy-melange` + `make trivy` + `make test-trivy` all pass — version, help, an offline `trivy config` scan on a Dockerfile (no DB download), and no-shell. Image is **168 MB**.

## CVE posture

grype reports **0 critical, 5 high, 2 medium, 1 low** — clean for a fresh Go image. Registered in `patch-go-deps.yml`; dispatch it after merge to clear the fixable highs.

Completes the pilot batch (opentofu #293, thanos #294, trivy).