### PR TITLE
fix(patch-go-deps): stop inline ${{ }} from blowing the 21000 expression limit

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -325,8 +325,13 @@ jobs:
                 echo "  Skipping main-module self-bump: $mod_ver"
                 continue
               fi
-              if [ "$IMAGE" = "loki" ] && [[ "$mod_ver" == github.com/prometheus/prometheus@* ]]; then
-                echo "  Skipping incompatible Loki module bump: $mod_ver"
+              # loki and thanos both import internal prometheus packages from a
+              # pinned fork/older version (e.g. thanos: prometheus/tsdb/errors,
+              # which prometheus removed in newer tags). Bumping
+              # prometheus/prometheus to @latest breaks their build with
+              # "module found (vX) but does not contain package ...". Pin them.
+              if { [ "$IMAGE" = "loki" ] || [ "$IMAGE" = "thanos" ]; } && [[ "$mod_ver" == github.com/prometheus/prometheus@* ]]; then
+                echo "  Skipping incompatible ${IMAGE} module bump: $mod_ver"
                 continue
               fi
               # Telegraf ≤1.39 references rclone's fs.LogOutput, which rclone

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -71,6 +71,14 @@ jobs:
 
       - name: Scan Go images and generate patches
         id: scan
+        # Pass GHA context in via env, not inline ${{ }}. A `run:` block that
+        # contains any ${{ }} is treated by GitHub as a templated scalar and
+        # capped at 21000 chars; this block is ~24KB, so even one inline
+        # expression made the whole workflow fail to parse ("Exceeded max
+        # expression length 21000") once the image list grew. With zero ${{ }}
+        # here the block is a plain literal and can grow freely.
+        env:
+          OWNER: ${{ github.repository_owner }}
         run: |
           # Map of image name -> modroot (melange template vars)
           # Split $ from {{ so GHA doesn't parse them as expressions
@@ -181,7 +189,7 @@ jobs:
 
           for IMAGE in "${!MODROOTS[@]}"; do
             echo "=== Scanning $IMAGE ==="
-            FULL_IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${IMAGE}:latest"
+            FULL_IMAGE="${REGISTRY}/${OWNER}/minimal-${IMAGE}:latest"
             MELANGE_FILE="${IMAGE}/melange.yaml"
             BEFORE_HASH=$(sha256sum "$MELANGE_FILE" | awk '{print $1}')
 


### PR DESCRIPTION
## Problem

`patch-go-deps` stopped running **entirely** after the opentofu/thanos/trivy dicts were added (#293/#294/#295). GitHub rejects the workflow at parse time:

```
(Line: 74, Col: 14): Exceeded max expression length 21000
```

Every trigger fails before any job starts (zero job logs), so transitive-CVE patching is silently disabled **for the entire Go catalog (~23 images)** — not just the new ones.

## Root cause

The `Scan Go images and generate patches` run block (line 74) is **~24 KB** and contained **two inline `${{ }}` expressions** — `${{ env.REGISTRY }}` and `${{ github.repository_owner }}` on the `FULL_IMAGE` line. Any `${{ }}` in a `run:` scalar makes GitHub treat the **whole block** as a templated string, which is capped at 21,000 characters. The block was already just under the cap (~23.9 KB working); the 9 new dict lines pushed it over.

## Fix

Remove all `${{ }}` from the block: pass `github.repository_owner` via the step `env:` (`REGISTRY` is already a global env var) and build `FULL_IMAGE` from bash vars `${REGISTRY}/${OWNER}`. The block now has **zero `${{ }}`**, so GitHub treats it as a plain literal with no length cap — and it can grow freely as more images are onboarded.

## Verification

- `yq` parses; the Scan block confirmed to contain 0 `${{ }}` expressions
- **Dispatch test is the proof**: `gh workflow run patch-go-deps.yml --ref fix/...` **starts a run** on this branch, whereas the same dispatch on `main` returns HTTP 422 with the expression-length error
- Workflow-only change; no image build inputs touched

Unblocks the post-merge patch dispatch for the new images (thanos's 8 criticals especially).