### PR TITLE
fix(patch-go-deps): match trivy's GOEXPERIMENT build marker

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -179,7 +179,11 @@ jobs:
             [telegraf]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [mimir]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
-            [trivy]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            # trivy's build line carries GOEXPERIMENT=jsonv2 (it imports the
+            # experimental encoding/json/v2), so the generic
+            # "CGO_ENABLED=0 go build" marker doesn't substring-match and the
+            # block was silently skipped. Match the unique jsonv2 build instead.
+            [trivy]='GOEXPERIMENT=jsonv2 go build'
             [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 


### PR DESCRIPTION
## Problem

trivy is registered in patch-go-deps but **silently skipped every cycle**, leaving its 5 fixable `containerd/v2` CVEs (v2.3.1 → 2.3.2) unpatched. Its `BUILD_MARKER` was `GOTOOLCHAIN=local CGO_ENABLED=0 go build`, but trivy's actual build line is `GOTOOLCHAIN=local CGO_ENABLED=0 **GOEXPERIMENT=jsonv2** go build` (trivy imports the experimental `encoding/json/v2`). The marker isn't a substring of the line, so the splice logic hits `could not find build marker` and skips trivy.

## Fix

One-line, per-image: change `BUILD_MARKERS[trivy]` to `GOEXPERIMENT=jsonv2 go build` — unique to trivy's build command (verified: appears on exactly one line, not in comments).

**Blast radius: trivy only.** It's a per-image dict value; the shared patch-block template and every other Go image are untouched. The earlier 21000-expression parse fix is preserved (Scan block still has 0 `${{ }}`).

## Verification (end-to-end, local melange / Go 1.26)

Injected the exact block patch-go-deps would generate — `go get containerd/v2@v2.3.2 && go mod tidy -e` with the experiment **off** in tidy, then the real `GOEXPERIMENT=jsonv2 go build`:
- ✅ builds clean — `tidy` does **not** need GOEXPERIMENT
- ✅ bump sticks — built binary embeds `containerd/v2 v2.3.2` (was v2.3.1)

So no GOEXPERIMENT in the patch block is needed. After merge, the next patch-go-deps run clears trivy's 5 containerd findings; the remaining 3 (trivy-self/cosign no-fix, docker/cli false-positive) are VEX/wait items.