### PR TITLE
fix(patch-go-deps): skip trivy docker/cli downgrade that breaks the build

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -338,6 +338,15 @@ jobs:
                 echo "  Skipping incompatible ${IMAGE} module bump: $mod_ver"
                 continue
               fi
+              # trivy ships docker/cli v29.5.2, but advisory GO-2026-4610 reports
+              # its fix as v29.2.0 — a *downgrade* (the advisory is the Windows-only
+              # PrivEsc, already past in 29.5.2), and v29.2.0 conflicts with
+              # trivy's buildkit@v0.28.1 which requires docker/cli v29.2.1, so
+              # `go get docker/cli@v29.2.0` fails the whole build. Skip it.
+              if [ "$IMAGE" = "trivy" ] && [[ "$mod_ver" == github.com/docker/cli@* ]]; then
+                echo "  Skipping incompatible trivy module bump: $mod_ver (advisory fix below installed 29.5.2; conflicts with buildkit's required 29.2.1)"
+                continue
+              fi
               # Telegraf ≤1.39 references rclone's fs.LogOutput, which rclone
               # removed in v1.73. Bumping rclone to grype's fix version breaks
               # `go build ./cmd/telegraf` (PR #265). Chainguard's telegraf image


### PR DESCRIPTION
## Problem

The patch-go-deps auto-PR build fails on **trivy**:

```
go: github.com/moby/buildkit@v0.28.1 requires github.com/docker/cli@v29.2.1+incompatible,
    not github.com/docker/cli@v29.2.0+incompatible
... go get failed (×3 retries) → task exited with code 1
```

patch-go-deps tried to bump `docker/cli` to **v29.2.0** (advisory GO-2026-4610's reported fix), but:
- trivy already ships **v29.5.2** → it's a **downgrade** (the advisory is the Windows-only PrivEsc, already past in 29.5.2 — a false positive)
- v29.2.0 conflicts with trivy's `buildkit@v0.28.1`, which requires **v29.2.1** → inconsistent module graph → `go get` fails

## Fix

Add a per-image skip — same pattern as the existing loki/thanos prometheus and telegraf rclone skips:

```sh
if [ "$IMAGE" = "trivy" ] && [[ "$mod_ver" == github.com/docker/cli@* ]]; then continue; fi
```

trivy's legitimate `containerd/v2 → 2.3.2` bump still applies; only the bad docker/cli downgrade is dropped.

## Verification
- `yq` parses; trivy skip in place
- The 21000-expression-limit fix is preserved (Scan run block still has **0** inline `${{ }}`)
- Workflow-only change

## Follow-up after merge
Re-dispatch `patch-go-deps.yml` to regenerate the trivy patch block cleanly (containerd kept, docker/cli dropped), which unblocks the containerd CVE fix landing.

Note: the separate telegraf-arm64 / victoria-metrics scheduled-run failures are **transient** (both passed in the 12:56 dispatched run; arch-specific, no build error) — no action.