### PR TITLE
vex: suppress telegraf rclone-rc criticals + trivy docker/cli false positive

### DIFF
--- a/vex/telegraf.openvex.json
+++ b/vex/telegraf.openvex.json
@@ -2,8 +2,45 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/telegraf",
   "author": "rtvkiz",
-  "timestamp": "2026-06-10T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-25T00:06:08Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2026-4964" },
+      "products": [
+        { "@id": "pkg:oci/minimal-telegraf?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "All four rclone CVEs are unauthenticated RCE/auth-bypass in rclone's remote-control HTTP server (`rclone rcd --rc-serve`, the rc/options/operations/fsinfo endpoints). Telegraf links rclone only as a library — the fs backend used by the remotefile output plugin — and never starts the rc daemon or exposes its HTTP API, so the vulnerable code path is unreachable. Bumping rclone to the fixed 1.73+ is not possible: telegraf references rclone's removed fs.LogOutput, so we pin 1.69.3 (matches Chainguard's telegraf)."
+    },
+    {
+      "vulnerability": { "name": "GHSA-25qr-6mpr-f7qx" },
+      "products": [
+        { "@id": "pkg:oci/minimal-telegraf?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "rclone rc `options/set` unauthenticated auth bypass. Telegraf uses rclone's fs library for the remotefile output plugin and never starts the rc remote-control server where this lives, so the code path is unreachable."
+    },
+    {
+      "vulnerability": { "name": "GHSA-jfwf-28xr-xw6q" },
+      "products": [
+        { "@id": "pkg:oci/minimal-telegraf?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "rclone rc `operations/fsinfo` unauthenticated backend instantiation + command execution. Reachable only via rclone's rc HTTP server, which telegraf never starts; telegraf only calls rclone's fs library for the remotefile output."
+    },
+    {
+      "vulnerability": { "name": "GHSA-qw24-gh76-8rvv" },
+      "products": [
+        { "@id": "pkg:oci/minimal-telegraf?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Unauthenticated command execution in `rclone rcd --rc-serve` via inline remote instantiation. The rc daemon is never started by telegraf, which links rclone only as the fs library for the remotefile output plugin."
+    }
+  ]
 }

--- a/vex/trivy.openvex.json
+++ b/vex/trivy.openvex.json
@@ -2,8 +2,18 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://github.com/rtvkiz/minimal/vex/trivy",
   "author": "rtvkiz",
-  "timestamp": "2026-06-22T00:00:00Z",
-  "version": 1,
+  "timestamp": "2026-06-25T00:06:08Z",
+  "version": 2,
   "tooling": "tools/vex/validate.sh",
-  "statements": []
+  "statements": [
+    {
+      "vulnerability": { "name": "GO-2026-4610" },
+      "products": [
+        { "@id": "pkg:oci/minimal-trivy?repository_url=ghcr.io/rtvkiz" }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "GO-2026-4610 is a Windows-only uncontrolled-search-path local privilege escalation in docker/cli plugins; this is a Linux image so the code path does not exist. It is also already fixed: the advisory's fix is v29.2.0+incompatible and trivy ships docker/cli v29.5.2+incompatible (grype mis-ranks the +incompatible pseudo-version and flags it anyway)."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Two defensible `not_affected` VEX additions — clears **4 criticals + 1 high** (5 effective).

### telegraf — 4 rclone criticals → not_affected
`GO-2026-4964`, `GHSA-25qr-6mpr-f7qx`, `GHSA-jfwf-28xr-xw6q`, `GHSA-qw24-gh76-8rvv` are **all unauthenticated RCE / auth-bypass in rclone's remote-control HTTP server** (`rclone rcd --rc-serve`; the `rc/options/operations/fsinfo` endpoints). Telegraf links rclone **only as the `fs` library** for the remotefile output plugin and never starts the rc daemon, so the vulnerable code path is unreachable (`vulnerable_code_not_in_execute_path`). rclone can't be bumped to the fixed 1.73+ (telegraf references rclone's removed `fs.LogOutput`; we pin 1.69.3 — same as Chainguard's telegraf).

### trivy — docker/cli → not_affected
`GO-2026-4610` is a **Windows-only** docker/cli plugin PrivEsc (not present on a Linux image) and is **already fixed**: advisory fix is 29.2.0, trivy ships docker/cli 29.5.2 (grype mis-ranks the `+incompatible` pseudo-version). `vulnerable_code_not_present`.

## Verification
- `tools/vex/validate.sh` passes both files
- IDs match what grype reports (per the dashboard detail pages)
- Conservative on the rest: thanos/loki prometheus, python, opensearch `bc-fips` are *not* VEX'd — they need reachability I can't confidently assert, and the repo rule is 'an unbacked not_affected is worse than none'.

Companion to the fixes landed: trivy's containerd fix (patch-go-deps, clean after the docker/cli skip) and the opensearch/deno paywall-escapes.