### PR TITLE
ci(vex): reconcile VEX against every scan so suppressions can't go stale

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,6 +539,22 @@ jobs:
               | .vulnerability.name] | unique' "$VEX_FILE")
           fi
 
+          # Reconcile VEX against this fresh scan so suppressions can't silently
+          # rot into false information. drift.stale = a suppressed CVE that's no
+          # longer present; drift.now_fixable = a suppressed CVE that now has a
+          # newer upstream fix (should be patched, not hidden). Surfaced in the
+          # sidecar -> dashboard and warned in the job summary; non-blocking.
+          VEX_DRIFT='{"stale":[],"now_fixable":[]}'
+          if [ -n "$VEX_FILE" ] && [ -f "$GRYPE_REPORT" ]; then
+            VEX_DRIFT=$(bash tools/vex/reconcile.sh --json "$GRYPE_REPORT" "$VEX_FILE" || true)
+            [ -z "$VEX_DRIFT" ] && VEX_DRIFT='{"stale":[],"now_fixable":[]}'
+            NSTALE=$(jq '.stale | length' <<<"$VEX_DRIFT")
+            NFIX=$(jq '.now_fixable | length' <<<"$VEX_DRIFT")
+            if [ "$NSTALE" -gt 0 ] || [ "$NFIX" -gt 0 ]; then
+              echo "::warning title=VEX drift::${{ matrix.name }}: $NSTALE stale, $NFIX now-fixable VEX suppression(s) — see vex/${{ matrix.name }}.openvex.json"
+            fi
+          fi
+
           # Severity counts — raw straight from grype, effective drops any
           # match whose .vulnerability.id is in the suppressed set.
           counts() {
@@ -576,6 +592,7 @@ jobs:
             --argjson effective "$EFF_COUNTS" \
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
+            --argjson drift "$VEX_DRIFT" \
             '{
               name: $name,
               size_bytes: $size,
@@ -584,7 +601,7 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json
@@ -993,6 +1010,22 @@ jobs:
               | .vulnerability.name] | unique' "$VEX_FILE")
           fi
 
+          # Reconcile VEX against this fresh scan so suppressions can't silently
+          # rot into false information. drift.stale = a suppressed CVE that's no
+          # longer present; drift.now_fixable = a suppressed CVE that now has a
+          # newer upstream fix (should be patched, not hidden). Surfaced in the
+          # sidecar -> dashboard and warned in the job summary; non-blocking.
+          VEX_DRIFT='{"stale":[],"now_fixable":[]}'
+          if [ -n "$VEX_FILE" ] && [ -f "$GRYPE_REPORT" ]; then
+            VEX_DRIFT=$(bash tools/vex/reconcile.sh --json "$GRYPE_REPORT" "$VEX_FILE" || true)
+            [ -z "$VEX_DRIFT" ] && VEX_DRIFT='{"stale":[],"now_fixable":[]}'
+            NSTALE=$(jq '.stale | length' <<<"$VEX_DRIFT")
+            NFIX=$(jq '.now_fixable | length' <<<"$VEX_DRIFT")
+            if [ "$NSTALE" -gt 0 ] || [ "$NFIX" -gt 0 ]; then
+              echo "::warning title=VEX drift::${{ matrix.name }}: $NSTALE stale, $NFIX now-fixable VEX suppression(s) — see vex/${{ matrix.name }}.openvex.json"
+            fi
+          fi
+
           # Severity counts — raw straight from grype, effective drops any
           # match whose .vulnerability.id is in the suppressed set.
           counts() {
@@ -1030,6 +1063,7 @@ jobs:
             --argjson effective "$EFF_COUNTS" \
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
+            --argjson drift "$VEX_DRIFT" \
             '{
               name: $name,
               size_bytes: $size,
@@ -1038,7 +1072,7 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json

--- a/tools/dashboard/build.sh
+++ b/tools/dashboard/build.sh
@@ -205,6 +205,17 @@ tr.suppressed td.vex-cell { opacity: 1; text-decoration: none; }
   color: #ffffff;
   font-weight: 500;
 }
+.vex-drift {
+  display: inline-block;
+  font-size: 11px;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--high);
+  color: #ffffff;
+  font-weight: 600;
+  cursor: help;
+}
 .vex-section {
   margin: 24px 0;
   padding: 16px;
@@ -316,6 +327,7 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   META="$REPORTS_DIR/meta-$NAME.json"
   SUPPRESSED_JSON='[]'
   VEX_STMT_COUNT=0
+  VEX_DRIFT_N=0
   if [ -f "$META" ]; then
     SIZE_BYTES=$(jq -r '.size_bytes // 0' "$META")
     BUILT_AT=$(jq -r '.built_at // ""' "$META")
@@ -326,6 +338,9 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     EL=$(jq -r '.effective.low      // 0' "$META")
     SUPPRESSED_JSON=$(jq -c '.vex.suppressed // []' "$META")
     VEX_STMT_COUNT=$(jq -r '.vex.statements // 0' "$META")
+    # VEX drift: count of suppressions that have gone stale or become fixable.
+    # Surfaced so the published effective count can't quietly rest on rotten VEX.
+    VEX_DRIFT_N=$(jq -r '((.vex.drift.stale // []) | length) + ((.vex.drift.now_fixable // []) | length)' "$META")
   else
     SIZE_BYTES=0
     BUILT_AT=""
@@ -365,10 +380,16 @@ for f in "$REPORTS_DIR"/grype-*.json; do
 
   ETCLASS=$([ "$ET" -gt 0 ] && echo "" || echo "zero")
 
+  # VEX drift marker — flags when this image's suppressions have gone stale or
+  # become fixable, so a viewer never trusts an effective count backed by rotten
+  # VEX without seeing the warning.
+  NAME_DISPLAY="$NAME"
+  [ "$VEX_DRIFT_N" -gt 0 ] && NAME_DISPLAY="$NAME <span class=\"vex-drift\" title=\"${VEX_DRIFT_N} VEX suppression(s) stale or now-fixable — needs review\">&#9888; VEX</span>"
+
   # Index row
   printf '<tr data-name="%s" data-crit="%d" data-high="%d" data-med="%d" data-low="%d" data-total="%d" data-eff="%d" data-vex="%d" data-fixable="%d" data-size="%d" data-age="%d"><td><a href="%s.html">%s</a></td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num %s">%d</td><td class="num">%d</td><td class="num %s">%d</td><td class="num">%d</td><td>%s</td><td class="num">%d</td><td class="num">%s</td><td>%s</td></tr>\n' \
     "$NAME" "$C" "$H" "$M" "$L" "$T" "$ET" "$VEX_STMT_COUNT" "$FIXABLE" "$SIZE_BYTES" "$AGE_DAYS" \
-    "$NAME" "$NAME" \
+    "$NAME" "$NAME_DISPLAY" \
     "$CCLASS" "$C" "$HCLASS" "$H" "$MCLASS" "$M" "$LCLASS" "$L" "$T" \
     "$ETCLASS" "$ET" "$VEX_STMT_COUNT" "$BAR" "$FIXABLE" "$SIZE_DISPLAY" "$AGE_DISPLAY" >> "$ROWS_FILE"
 

--- a/tools/vex/reconcile.sh
+++ b/tools/vex/reconcile.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Reconcile a VEX document against a fresh grype scan so suppressions can't go
+# stale and silently feed users false information.
+#
+# For every not_affected/fixed statement in the VEX file, it checks the CVE
+# against the current raw scan and reports two drift conditions:
+#
+#   STALE        the suppressed CVE is no longer in the scan (dep was fixed or
+#                removed). The statement now suppresses nothing; remove it so a
+#                future re-introduction can't be auto-hidden without re-review.
+#
+#   NOW-FIXABLE  the suppressed CVE is still present AND an upstream fix newer
+#                than the installed version now exists. Suppressing a genuinely
+#                fixable CVE is the dishonest case — bump the dep instead.
+#                (Version-compared, so an advisory whose "fix" is <= what we
+#                 ship — e.g. a Windows-only false positive — is NOT flagged.)
+#
+# Usage:  reconcile.sh <grype.json> <vex.openvex.json>
+# Exit:   non-zero if any NOW-FIXABLE drift is found (the integrity gate).
+#         STALE is reported as a warning (exit stays 0 unless --strict).
+set -euo pipefail
+
+STRICT=0; JSON=0
+while [ "${1:-}" = "--strict" ] || [ "${1:-}" = "--json" ]; do
+  [ "$1" = "--strict" ] && STRICT=1
+  [ "$1" = "--json" ] && JSON=1
+  shift
+done
+GRYPE="${1:?grype json required}"
+VEX="${2:?vex file required}"
+IMG=$(basename "$VEX" .openvex.json)
+
+# Suppressing statements: {id} for not_affected | fixed.
+mapfile -t SUP < <(jq -r '.statements[]? | select(.status=="not_affected" or .status=="fixed") | .vulnerability.name' "$VEX" 2>/dev/null || true)
+if [ "${#SUP[@]}" -eq 0 ]; then
+  [ "$JSON" -eq 1 ] && echo '{"stale":[],"now_fixable":[]}' || echo "ok   $IMG: no suppressing VEX statements"
+  exit 0
+fi
+
+# Map of present CVE id -> "installed_version<TAB>fix_version" from the scan.
+SCAN=$(jq -r '.matches[] | "\(.vulnerability.id)\t\(.artifact.version)\t\(.vulnerability.fix.versions[0] // "")"' "$GRYPE" 2>/dev/null || true)
+
+STALE_IDS=(); FIXABLE=()
+ver_gt() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+for id in "${SUP[@]}"; do
+  line=$(awk -F'\t' -v v="$id" '$1==v{print; exit}' <<<"$SCAN")
+  if [ -z "$line" ]; then
+    STALE_IDS+=("$id"); continue
+  fi
+  installed=$(cut -f2 <<<"$line"); fix=$(cut -f3 <<<"$line")
+  # strip a leading v and any +incompatible / pseudo suffix for the compare
+  ic=${installed#v}; ic=${ic%%+*}; fc=${fix#v}; fc=${fc%%+*}
+  if [ -n "$fix" ] && ver_gt "$fc" "$ic"; then
+    FIXABLE+=("$id|$fix|$installed")
+  fi
+done
+
+if [ "$JSON" -eq 1 ]; then
+  jq -nc --args '{stale: $ARGS.positional}' "${STALE_IDS[@]}" > /tmp/.vexstale.$$
+  printf '%s\n' "${FIXABLE[@]}" | jq -Rc 'select(length>0)|split("|")|{id:.[0],fix:.[1],installed:.[2]}' | jq -sc '{now_fixable:.}' > /tmp/.vexfix.$$
+  jq -cs '.[0] * .[1]' /tmp/.vexstale.$$ /tmp/.vexfix.$$; rm -f /tmp/.vexstale.$$ /tmp/.vexfix.$$
+  [ "${#FIXABLE[@]}" -gt 0 ] && exit 1 || exit 0
+fi
+
+for id in "${STALE_IDS[@]}"; do
+  echo "STALE        $IMG: VEX suppresses $id but it is not in the current scan — remove the statement"
+done
+for f in "${FIXABLE[@]}"; do
+  IFS='|' read -r id fix inst <<<"$f"
+  echo "NOW-FIXABLE  $IMG: VEX suppresses $id but fix $fix > installed $inst — bump the dep, don't suppress"
+done
+[ "${#STALE_IDS[@]}" -eq 0 ] && [ "${#FIXABLE[@]}" -eq 0 ] && echo "ok   $IMG: all ${#SUP[@]} VEX suppression(s) still valid"
+{ [ "${#FIXABLE[@]}" -gt 0 ] || { [ "$STRICT" -eq 1 ] && [ "${#STALE_IDS[@]}" -gt 0 ]; }; } && exit 1
+exit 0


### PR DESCRIPTION
## Why

A `not_affected` statement is a point-in-time claim. Left unchecked it rots and **silently feeds users false information** — e.g. when patch-go-deps eventually bumps telegraf's rclone (the self-healing probe), the 4 rclone `not_affected` statements would keep suppressing findings that no longer exist. Until now we had only **schema** validation, no reconciliation against reality.

This implements the principle: *keep VEX honest on every build, or don't suppress at all.*

## What

**`tools/vex/reconcile.sh`** — for each suppressing statement, checks the fresh grype scan:
- **STALE** — suppressed CVE no longer present → remove the statement.
- **NOW-FIXABLE** — suppressed CVE now has a fix **newer than the installed version** → bump the dep, don't hide it.
  - Version-compared, so an advisory whose fix is ≤ what we ship is **not** flagged — e.g. the docker/cli Windows-only false positive (fix 29.2.0 < installed 29.5.2) stays valid.

**`build.yml`** (both scan jobs) — runs reconcile against the just-produced scan, records drift into the meta sidecar (`vex.drift`), and emits a `::warning` in the job summary. **Non-blocking**, consistent with the repo's non-blocking-scan norm.

**`tools/dashboard/build.sh`** — renders a per-image **⚠ VEX** marker when an image has stale/now-fixable suppressions, so a viewer never trusts an effective count resting on rotten VEX.

## Verification
- `reconcile.sh` text + JSON modes on controlled inputs: no-fix → ok, lower-fix → ok (not flagged), real-fix → NOW-FIXABLE, absent → STALE
- dashboard smoke-test renders the ⚠ marker from a synthetic drift sidecar
- `build.yml` + `dashboard/build.sh` parse clean (`yq`, `bash -n`)

Directly answers 'are we updating VEX with every build' — now yes, every scan reconciles and surfaces drift.