### PR TITLE
fix(update-versions): skip tags whose release asset isn't published yet

### DIFF
--- a/.github/scripts/check-upstream.sh
+++ b/.github/scripts/check-upstream.sh
@@ -82,9 +82,32 @@ fetch_github_tags() {
   if [ -n "$from" ]; then
     tags=$(printf '%s\n' "$tags" | tr "$from" "$to")
   fi
-  tags=$(printf '%s\n' "$tags" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+  tags=$(printf '%s\n' "$tags" | sort -t. -k1,1n -k2,2n -k3,3n)
   [ -n "$tags" ] || { echo "::error::no tags matching /$pattern/ in $repo"; return 1; }
-  printf '%s\n' "$tags"
+
+  # Tags can be created before the release assets are published (keycloak cuts
+  # the tag, then publishes `releases/download/<v>/...` minutes-to-hours later).
+  # When the tarball is a release-download asset, picking the newest tag blindly
+  # makes apply-update.sh 404 on a not-yet-published asset. Probe from newest
+  # down and return the newest tag whose tarball actually exists; tags whose
+  # release is still pending are skipped (a later run picks them up).
+  local tb; tb=$(j '.tarball.url // .tarballs[0].url // empty')
+  if [[ "$tb" == *"/releases/download/"* ]]; then
+    local v url
+    while IFS= read -r v; do
+      [ -n "$v" ] || continue
+      url="${tb//\{version\}/$v}"
+      url="${url//\{major\}/${v%%.*}}"
+      url="${url//\{minor\}/${v%.*}}"
+      if curl -fsSLI -o /dev/null --connect-timeout 20 --retry 2 --retry-all-errors "$url" >/dev/null 2>&1; then
+        printf '%s\n' "$v"; return 0
+      fi
+      echo "::warning::$repo tag $v has no published release asset yet — skipping until it is" >&2
+    done < <(printf '%s\n' "$tags" | tac)
+    echo "::error::no released tag matching /$pattern/ in $repo"; return 1
+  fi
+
+  printf '%s\n' "$tags" | tail -1
 }
 
 # Single URL returning the bare version as text (e.g. jenkins latestCore.txt).


### PR DESCRIPTION
## Problem

The scheduled **Update upstream versions** run failed on keycloak ([run 28231765099](https://github.com/rtvkiz/minimal/actions/runs/28231765099)):

```
current=26.6.3 latest=26.6.4
curl: (22) The requested URL returned error: 404   (×6, all retries)
##[error]Process completed with exit code 1.
```

keycloak creates the git **tag** `26.6.4` minutes-to-hours before it publishes the matching `releases/download/26.6.4/keycloak-26.6.4.tar.gz` asset. `fetch_github_tags` picks the newest matching tag unconditionally, so `apply-update.sh` tried to download a tarball that doesn't exist yet and hard-failed the whole run.

## Fix

In `fetch_github_tags`, when the row's tarball is a `releases/download/` asset (which can lag the tag), probe from the newest matching tag downward and return the newest tag whose asset actually exists (HEAD). Tags with a still-pending release are skipped with a warning; a later scheduled run picks them up once published.

- Verified the HEAD probe distinguishes the cases: `26.6.3 → 200`, `26.6.4 → 404`.
- Simulated the loop against keycloak's tag list → selects `26.6.3` (= current ⇒ no spurious PR, no 404).
- **Only keycloak** hits this path. Every other `github-tags` image pulls `archive/refs/tags/` tarballs (GitHub auto-generates these for any tag, so they always exist) or non-GitHub URLs — all skip the probe and are unaffected.

Workflow-script-only change; no image build inputs touched.