### PR TITLE
fix(ci): dedupe github-pages artifact so deploy survives partial re-runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1306,7 +1306,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
-      actions: read
+      actions: write   # delete stale github-pages artifacts from earlier attempts
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -1335,6 +1335,22 @@ jobs:
           export RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           export VEX_DIR="src/vex"
           bash src/tools/dashboard/build.sh reports site
+
+      # On a partial re-run (`gh run rerun --failed`), this job runs again in a
+      # new attempt, but the "github-pages" artifact uploaded by the earlier
+      # attempt is retained for the run. deploy-pages then aborts with
+      # "Multiple artifacts named github-pages were unexpectedly found". Delete
+      # any pre-existing ones so the upload below is the only one that remains.
+      - name: Remove stale Pages artifacts from earlier attempts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+                  --paginate --jq '.artifacts[] | select(.name=="github-pages") | .id')
+          for id in $ids; do
+            echo "Deleting stale github-pages artifact $id"
+            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$id" || true
+          done
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1


### PR DESCRIPTION
## Problem

In the scheduled build [run 28299870036](https://github.com/rtvkiz/minimal/actions/runs/28299870036), two images failed on transient upstream blips (jenkins.war mirror TLS error; opensearch OIDC token timeout). Re-running the failed jobs (`gh run rerun --failed`) cleared those — **but the final dashboard step then failed**:

```
##[error]Error: Multiple artifacts named "github-pages" were unexpectedly found
for this workflow run. Artifact count is 2.
```

`publish-vuln-report` runs with `if: always()`, so it ran on attempt 1 (publishing a partial dashboard) **and** again on attempt 2 (the re-run). GitHub retains artifacts across attempts, so by the deploy step there were two artifacts both named `github-pages`, and `actions/deploy-pages` hard-errors when it finds more than one. Net effect: every image built/published/signed fine, but the dashboard wouldn't deploy — and this recurs on **any** `rerun --failed` that reaches the dashboard job.

## Fix

Before uploading the Pages artifact, delete any `github-pages` artifact already present for the run (left over from an earlier attempt), so `deploy-pages` only ever sees the one this attempt uploads. Requires `actions: write` (artifact deletion) — bumped from `actions: read`.

- First run: nothing to delete → upload → deploy (unchanged).
- Re-run: delete attempt-N−1's artifact → upload fresh → deploy succeeds.

Validated: `yq` parses the `publish-vuln-report` permissions block, `actionlint` is clean on the change (only the two pre-existing `attestations` scope warnings remain), ruby YAML loads the file.

Workflow-only change; no image build inputs touched.