### PR TITLE
feat(observability): add node-exporter, blackbox-exporter, pushgateway

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -165,6 +165,33 @@
     releases: "https://github.com/thanos-io/thanos/releases"
     notes: "https://github.com/thanos-io/thanos/releases/tag/v{version}"
 
+- name: node-exporter
+  files: [node-exporter/melange.yaml]
+  source: { type: github-releases-latest, repo: prometheus/node_exporter, strip-v: true, pin-major: 1 }
+  tarball: { url: "https://github.com/prometheus/node_exporter/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/prometheus/node_exporter/releases"
+    notes: "https://github.com/prometheus/node_exporter/releases/tag/v{version}"
+
+- name: blackbox-exporter
+  files: [blackbox-exporter/melange.yaml]
+  source: { type: github-releases-latest, repo: prometheus/blackbox_exporter, strip-v: true, pin-major: 0 }
+  tarball: { url: "https://github.com/prometheus/blackbox_exporter/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/prometheus/blackbox_exporter/releases"
+    notes: "https://github.com/prometheus/blackbox_exporter/releases/tag/v{version}"
+
+- name: pushgateway
+  files: [pushgateway/melange.yaml]
+  source: { type: github-releases-latest, repo: prometheus/pushgateway, strip-v: true, pin-major: 1 }
+  tarball: { url: "https://github.com/prometheus/pushgateway/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/prometheus/pushgateway/releases"
+    notes: "https://github.com/prometheus/pushgateway/releases/tag/v{version}"
+
 # ============================================================================
 # github-tags — hits /repos/<repo>/tags?per_page=100, filters by regex,
 # strips prefix, semver-sorts, takes the highest match. Use this when the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,9 @@ jobs:
             {"name":"opentofu","variants":["prod","dev"]},
             {"name":"trivy","variants":["prod","dev"]},
             {"name":"thanos","variants":["prod","dev"]},
+            {"name":"node-exporter","variants":["prod","dev"]},
+            {"name":"blackbox-exporter","variants":["prod","dev"]},
+            {"name":"pushgateway","variants":["prod","dev"]},
             {"name":"deno","variants":["prod","dev"]},
             {"name":"opensearch","variants":["prod","dev"]}
           ]'

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ CONSUL_VERSION ?= $(call melange_version,consul/melange.yaml)
 # --- Observability (extra) ---
 TEMPO_VERSION ?= $(call melange_version,tempo/melange.yaml)
 THANOS_VERSION ?= $(call melange_version,thanos/melange.yaml)
+NODE_EXPORTER_VERSION ?= $(call melange_version,node-exporter/melange.yaml)
+BLACKBOX_EXPORTER_VERSION ?= $(call melange_version,blackbox-exporter/melange.yaml)
+PUSHGATEWAY_VERSION ?= $(call melange_version,pushgateway/melange.yaml)
 
 # --- IaC / GitOps ---
 OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
@@ -143,6 +146,9 @@ endef
 .PHONY: opentofu opentofu-melange test-opentofu
 .PHONY: trivy trivy-melange test-trivy
 .PHONY: thanos thanos-melange test-thanos
+.PHONY: node-exporter node-exporter-melange test-node-exporter
+.PHONY: blackbox-exporter blackbox-exporter-melange test-blackbox-exporter
+.PHONY: pushgateway pushgateway-melange test-pushgateway
 .PHONY: mosquitto mosquitto-melange mosquitto-dev test-mosquitto test-mosquitto-dev
 .PHONY: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-etcd scan-victoria-metrics scan-jaeger scan-otelcol scan-qdrant scan-deno scan-cuda-python scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
 .PHONY: test-python test-python-dev test-jenkins test-go test-go-dev test-node-slim test-node-slim-dev test-nginx test-httpd test-redis-slim test-redis-slim-dev test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-postgres-slim-dev test-bun test-bun-dev test-sqlite test-dotnet test-dotnet-dev test-java test-java-dev test-ruby test-ruby-dev test-php test-php-dev test-rails test-rails-dev test-deno test-deno-dev test-mariadb test-mariadb-dev test-valkey test-valkey-dev test-memcached-dev test-sqlite-dev test-opensearch-dev test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-etcd test-victoria-metrics test-jaeger test-otelcol test-qdrant test-deno test-cuda-python test-coredns test-openbao test-loki test-fluent-bit test-keycloak
@@ -1477,6 +1483,84 @@ thanos: thanos-melange
 	@echo "✓ minimal-thanos built (source build)"
 
 #------------------------------------------------------------------------------
+# NODE-EXPORTER IMAGE (melange Go source build + apko; Prometheus host metrics)
+#------------------------------------------------------------------------------
+node-exporter-melange: keygen
+	@echo "Building node_exporter $(NODE_EXPORTER_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build node-exporter/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ node_exporter package built from source"
+
+node-exporter: node-exporter-melange
+	@echo "Assembling minimal-node-exporter image with apko..."
+	apko build node-exporter/apko/node-exporter.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-node-exporter:$(VERSION) \
+		node-exporter.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < node-exporter.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-node-exporter:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-node-exporter:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-node-exporter:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-node-exporter:latest
+	@rm -f node-exporter.tar sbom-*.spdx.json
+	@echo "✓ minimal-node-exporter built (source build)"
+
+#------------------------------------------------------------------------------
+# BLACKBOX-EXPORTER IMAGE (melange Go source build + apko; Prometheus probing)
+#------------------------------------------------------------------------------
+blackbox-exporter-melange: keygen
+	@echo "Building blackbox_exporter $(BLACKBOX_EXPORTER_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build blackbox-exporter/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ blackbox_exporter package built from source"
+
+blackbox-exporter: blackbox-exporter-melange
+	@echo "Assembling minimal-blackbox-exporter image with apko..."
+	apko build blackbox-exporter/apko/blackbox-exporter.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:$(VERSION) \
+		blackbox-exporter.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < blackbox-exporter.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:latest
+	@rm -f blackbox-exporter.tar sbom-*.spdx.json
+	@echo "✓ minimal-blackbox-exporter built (source build)"
+
+#------------------------------------------------------------------------------
+# PUSHGATEWAY IMAGE (melange Go source build + apko; Prometheus push gateway)
+#------------------------------------------------------------------------------
+pushgateway-melange: keygen
+	@echo "Building pushgateway $(PUSHGATEWAY_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build pushgateway/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ pushgateway package built from source"
+
+pushgateway: pushgateway-melange
+	@echo "Assembling minimal-pushgateway image with apko..."
+	apko build pushgateway/apko/pushgateway.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-pushgateway:$(VERSION) \
+		pushgateway.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < pushgateway.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-pushgateway:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-pushgateway:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-pushgateway:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-pushgateway:latest
+	@rm -f pushgateway.tar sbom-*.spdx.json
+	@echo "✓ minimal-pushgateway built (source build)"
+
+#------------------------------------------------------------------------------
 # MOSQUITTO IMAGE (melange C source build + apko; Eclipse MQTT broker)
 #------------------------------------------------------------------------------
 mosquitto-melange: keygen
@@ -2219,6 +2303,24 @@ test-thanos:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-thanos:latest" && \
 		thanos/test.sh
 	@echo "✓ thanos tests passed"
+
+test-node-exporter:
+	@echo "Testing node-exporter image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-node-exporter:latest" && \
+		node-exporter/test.sh
+	@echo "✓ node-exporter tests passed"
+
+test-blackbox-exporter:
+	@echo "Testing blackbox-exporter image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-blackbox-exporter:latest" && \
+		blackbox-exporter/test.sh
+	@echo "✓ blackbox-exporter tests passed"
+
+test-pushgateway:
+	@echo "Testing pushgateway image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-pushgateway:latest" && \
+		pushgateway/test.sh
+	@echo "✓ pushgateway tests passed"
 
 test-mosquitto:
 	@echo "Testing mosquitto image..."

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
   <a href="https://rtvkiz.github.io/minimal/"><img src="https://img.shields.io/badge/CVE_Dashboard-Live-0d9488" alt="CVE Dashboard"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-46-0d9488" alt="Images: 46">
+  <img src="https://img.shields.io/badge/Images-57-0d9488" alt="Images: 57">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures">
 </p>
 
 <p align="center">
   <a href="https://rtvkiz.github.io/minimal/">Live CVE dashboard</a> ·
   <a href="#pull-and-verify-in-30-seconds">Verify an image</a> ·
-  <a href="#available-images--46-total">All 46 images</a> ·
+  <a href="#available-images--57-total">All 57 images</a> ·
   <a href="https://news.ycombinator.com/item?id=46840178">HN discussion</a>
 </p>
 
@@ -75,7 +75,7 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 - No shell where possible — most images don't ship `/bin/sh`.
 - A six-hour rebuild cadence, so Wolfi CVE patches land in hours, not days.
 
-## Available Images — 48 total
+## Available Images — 57 total
 
 | Category | Count | Highlights |
 |---|---|---|
@@ -83,9 +83,9 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Databases** | 5 | mysql, mariadb, postgres-slim, sqlite, opensearch |
 | **Caches, queues, messaging** | 7 | redis-slim, valkey, memcached, kafka, rabbitmq, nats, mosquitto |
 | **Web servers & proxies** | 6 | nginx, httpd, caddy, haproxy, traefik, envoy |
-| **Observability** | 7 | prometheus, victoria-metrics, jaeger, loki, otelcol, fluent-bit, tempo |
+| **Observability** | 14 | prometheus, alertmanager, victoria-metrics, thanos, mimir, jaeger, loki, tempo, otelcol, fluent-bit, telegraf, node-exporter, blackbox-exporter, pushgateway |
 | **Infrastructure** | 7 | coredns, etcd, openbao, keycloak, qdrant, registry, consul |
-| **Kubernetes & CI** | 2 | helm, kubectl |
+| **Kubernetes, CI & IaC** | 4 | helm, kubectl, opentofu, trivy |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
 <details>
@@ -135,6 +135,9 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | Tempo | `docker pull ghcr.io/rtvkiz/minimal-tempo:latest` | No | Distributed tracing backend (Grafana Labs, AGPL) |
 | OTel Collector | `docker pull ghcr.io/rtvkiz/minimal-otelcol:latest` | No | OpenTelemetry Collector core |
 | Fluent Bit | `docker pull ghcr.io/rtvkiz/minimal-fluent-bit:latest` | No | Lightweight log processor |
+| Node Exporter | `docker pull ghcr.io/rtvkiz/minimal-node-exporter:latest` | No | Prometheus host hardware & OS metrics |
+| Blackbox Exporter | `docker pull ghcr.io/rtvkiz/minimal-blackbox-exporter:latest` | No | Prometheus endpoint probing (HTTP/DNS/TCP/ICMP) |
+| Pushgateway | `docker pull ghcr.io/rtvkiz/minimal-pushgateway:latest` | No | Prometheus metrics push for batch jobs |
 | | | **Infrastructure** | |
 | CoreDNS | `docker pull ghcr.io/rtvkiz/minimal-coredns:latest` | No | Kubernetes default DNS |
 | etcd | `docker pull ghcr.io/rtvkiz/minimal-etcd:latest` | No | Distributed key-value store |
@@ -264,7 +267,7 @@ docker run -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-<image>:latest-dev
 
 Dev variants share the prod image's signing, SBOM, and SLSA provenance pipeline. They are **not tracked on the public CVE dashboard** — they intentionally ship a larger attack surface. See [`.github/SECURITY.md`](.github/SECURITY.md#dev-variants--dev-tags) for the policy and [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md) for the package composition rules.
 
-**Shipping today:** 46 of 46 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
+**Shipping today:** 57 of 57 dev variants — every image in the catalog now ships a `:latest-dev` companion built from the same source as prod.
 
 <details>
 <summary><strong>Per-image dev variant status</strong></summary>
@@ -313,6 +316,9 @@ Categories follow the three templates in [`docs/dev-variants/templates/`](docs/d
 | otelcol | server | in-house | ✅ |
 | loki | server | in-house | ✅ |
 | fluent-bit | server | in-house | ✅ |
+| node-exporter | server | in-house | ✅ |
+| blackbox-exporter | server | in-house | ✅ |
+| pushgateway | server | in-house | ✅ |
 | coredns | server | in-house | ✅ |
 | gitea | server | in-house | ✅ |
 | jenkins | server | in-house | ✅ |

--- a/blackbox-exporter/apko/blackbox-exporter-dev.yaml
+++ b/blackbox-exporter/apko/blackbox-exporter-dev.yaml
@@ -1,0 +1,58 @@
+# Development variant of minimal-blackbox-exporter.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - blackbox-exporter-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: blackbox-exporter
+      gid: 65532
+  users:
+    - username: blackbox-exporter
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/blackbox_exporter
+
+cmd: --config.file=/etc/blackbox_exporter/config.yml
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+paths:
+  - path: /etc/blackbox_exporter
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-blackbox-exporter-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-blackbox-exporter: same blackbox_exporter + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/blackbox-exporter"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/blackbox-exporter/apko/blackbox-exporter.yaml
+++ b/blackbox-exporter/apko/blackbox-exporter.yaml
@@ -1,0 +1,51 @@
+# Minimal Prometheus blackbox_exporter image - endpoint probing, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - blackbox-exporter-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: blackbox-exporter
+      gid: 65532
+  users:
+    - username: blackbox-exporter
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Listens on :9115; own metrics at /metrics, probes at /probe?target=...&module=...
+entrypoint:
+  command: /usr/bin/blackbox_exporter
+
+cmd: --config.file=/etc/blackbox_exporter/config.yml
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/blackbox_exporter
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-blackbox-exporter"
+  org.opencontainers.image.description: "Hardened shell-less Prometheus blackbox_exporter (endpoint probing) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/blackbox-exporter"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/blackbox-exporter/melange.yaml
+++ b/blackbox-exporter/melange.yaml
@@ -1,0 +1,95 @@
+# Melange build configuration for minimal Prometheus blackbox_exporter
+# Pure Go from source. Single `blackbox_exporter` binary for probing endpoints
+# over HTTP(S), DNS, TCP, ICMP and gRPC.
+# License: Apache-2.0 (Prometheus authors).
+
+package:
+  name: blackbox-exporter-minimal
+  version: 0.28.0
+  epoch: 0
+  description: "Minimal Prometheus blackbox_exporter (endpoint probing) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of blackbox_exporter source tarball - updated by update-versions.yml workflow
+  sha256: 07c7c16a7b3448d2ede630356f1321f80ed8a46ca321ee3ce5e149cf1c7a7d2f
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify blackbox_exporter source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/prometheus/blackbox_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/blackbox_exporter.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/blackbox_exporter.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf blackbox_exporter.tar.gz
+      rm blackbox_exporter.tar.gz
+
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/blackbox_exporter-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+
+  # Build the blackbox_exporter binary (static).
+  - runs: |
+      cd /home/build/blackbox_exporter-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -tags netgo \
+        -ldflags="-s -w \
+          -X github.com/prometheus/common/version.Version=${{package.version}} \
+          -X github.com/prometheus/common/version.Revision=source-build \
+          -X github.com/prometheus/common/version.Branch=HEAD \
+          -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+          -X github.com/prometheus/common/version.BuildUser=melange" \
+        -o /home/build/blackbox_exporter-bin \
+        .
+
+  # Install binary + default config
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/blackbox_exporter-bin "${{targets.destdir}}/usr/bin/blackbox_exporter"
+      chmod 0755 "${{targets.destdir}}/usr/bin/blackbox_exporter"
+
+      # blackbox_exporter refuses to start without a config file. Ship a minimal
+      # default with the standard http_2xx module; users mount their own over it.
+      mkdir -p "${{targets.destdir}}/etc/blackbox_exporter"
+      cat > "${{targets.destdir}}/etc/blackbox_exporter/config.yml" << 'EOF'
+      modules:
+        http_2xx:
+          prober: http
+          timeout: 5s
+          http:
+            preferred_ip_protocol: ip4
+      EOF
+
+  # Verify the build
+  - runs: |
+      echo "Verifying blackbox_exporter binary..."
+      "${{targets.destdir}}/usr/bin/blackbox_exporter" --version

--- a/blackbox-exporter/test-dev.sh
+++ b/blackbox-exporter/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-blackbox-exporter-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing blackbox_exporter version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/blackbox_exporter "$IMAGE" --version 2>&1 | grep -qiE 'blackbox_exporter.*version [0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All blackbox-exporter-dev smoke tests passed"

--- a/blackbox-exporter/test.sh
+++ b/blackbox-exporter/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone.
+set -eu
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing blackbox_exporter version..."
+docker run --rm --entrypoint /usr/bin/blackbox_exporter "$IMAGE" --version 2>&1 | grep -qiE 'blackbox_exporter.*version [0-9]'
+
+echo "Testing blackbox_exporter help..."
+docker run --rm --entrypoint /usr/bin/blackbox_exporter "$IMAGE" --help 2>&1 | grep -qiE 'config.file|web.listen-address'
+
+echo "Testing blackbox_exporter starts (default config) and serves /metrics..."
+docker run -d --name blackbox-exporter-test \
+  -p 19115:9115 \
+  "$IMAGE" --config.file=/etc/blackbox_exporter/config.yml --web.listen-address=0.0.0.0:9115
+sleep 3
+
+if docker ps | grep -q blackbox-exporter-test; then
+  echo "blackbox_exporter container is running"
+  docker logs blackbox-exporter-test 2>&1 | tail -5
+
+  echo "Checking /metrics at :19115 exposes blackbox_ series..."
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://localhost:19115/metrics 2>/dev/null | grep -q '^blackbox_'; then
+      echo "blackbox_exporter /metrics OK (attempt $i)"
+      break
+    fi
+    if [ "$i" = "10" ]; then
+      echo "FAIL: blackbox_exporter /metrics never exposed blackbox_ series after 10 attempts"
+      docker logs blackbox-exporter-test
+      docker stop blackbox-exporter-test && docker rm blackbox-exporter-test
+      exit 1
+    fi
+    sleep 2
+  done
+
+  docker stop blackbox-exporter-test && docker rm blackbox-exporter-test
+else
+  echo "blackbox_exporter failed to start, checking logs..."
+  docker logs blackbox-exporter-test 2>&1 || true
+  docker rm blackbox-exporter-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All blackbox_exporter tests passed!"

--- a/docs/dev-variants/CONVENTIONS.md
+++ b/docs/dev-variants/CONVENTIONS.md
@@ -85,7 +85,7 @@ across the catalog.
 
 ## Category-specific additions
 
-The three templates in `./templates/` map our 40 images to one of
+The three templates in `./templates/` map our 57 images to one of
 three categories. Pick the template that matches and customize the
 language/daemon-specific layer.
 

--- a/node-exporter/apko/node-exporter-dev.yaml
+++ b/node-exporter/apko/node-exporter-dev.yaml
@@ -1,0 +1,49 @@
+# Development variant of minimal-node-exporter.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - node-exporter-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: node-exporter
+      gid: 65532
+  users:
+    - username: node-exporter
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/node_exporter
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-node-exporter-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-node-exporter: same node_exporter + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/node-exporter"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/node-exporter/apko/node-exporter.yaml
+++ b/node-exporter/apko/node-exporter.yaml
@@ -1,0 +1,42 @@
+# Minimal Prometheus node_exporter image - host metrics, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - node-exporter-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: node-exporter
+      gid: 65532
+  users:
+    - username: node-exporter
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Listens on :9100 and serves host metrics at /metrics.
+entrypoint:
+  command: /usr/bin/node_exporter
+
+environment:
+  PATH: /usr/bin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-node-exporter"
+  org.opencontainers.image.description: "Hardened shell-less Prometheus node_exporter (host metrics) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/node-exporter"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/node-exporter/melange.yaml
+++ b/node-exporter/melange.yaml
@@ -1,0 +1,83 @@
+# Melange build configuration for minimal Prometheus node_exporter
+# Pure Go from source. Single `node_exporter` binary exposing host metrics.
+# License: Apache-2.0 (Prometheus authors).
+
+package:
+  name: node-exporter-minimal
+  version: 1.11.1
+  epoch: 0
+  description: "Minimal Prometheus node_exporter (host hardware & OS metrics) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of node_exporter source tarball - updated by update-versions.yml workflow
+  sha256: d2b5a7740b7526543429b41a5d741bc530277f406f7b121fc64cb3ca583f7387
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify node_exporter source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/prometheus/node_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/node_exporter.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/node_exporter.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf node_exporter.tar.gz
+      rm node_exporter.tar.gz
+
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/node_exporter-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+
+  # Build the node_exporter binary (static).
+  # Version is reported via github.com/prometheus/common/version.
+  - runs: |
+      cd /home/build/node_exporter-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -tags netgo \
+        -ldflags="-s -w \
+          -X github.com/prometheus/common/version.Version=${{package.version}} \
+          -X github.com/prometheus/common/version.Revision=source-build \
+          -X github.com/prometheus/common/version.Branch=HEAD \
+          -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+          -X github.com/prometheus/common/version.BuildUser=melange" \
+        -o /home/build/node_exporter-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/node_exporter-bin "${{targets.destdir}}/usr/bin/node_exporter"
+      chmod 0755 "${{targets.destdir}}/usr/bin/node_exporter"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying node_exporter binary..."
+      "${{targets.destdir}}/usr/bin/node_exporter" --version

--- a/node-exporter/test-dev.sh
+++ b/node-exporter/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-node-exporter-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing node_exporter version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/node_exporter "$IMAGE" --version 2>&1 | grep -qiE 'node_exporter.*version [0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All node-exporter-dev smoke tests passed"

--- a/node-exporter/test.sh
+++ b/node-exporter/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone.
+set -eu
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing node_exporter version..."
+docker run --rm --entrypoint /usr/bin/node_exporter "$IMAGE" --version 2>&1 | grep -qiE 'node_exporter.*version [0-9]'
+
+echo "Testing node_exporter help..."
+docker run --rm --entrypoint /usr/bin/node_exporter "$IMAGE" --help 2>&1 | grep -qiE 'web.listen-address|collector'
+
+echo "Testing node_exporter starts and serves /metrics..."
+docker run -d --name node-exporter-test \
+  -p 19100:9100 \
+  "$IMAGE" --web.listen-address=0.0.0.0:9100
+sleep 3
+
+if docker ps | grep -q node-exporter-test; then
+  echo "node_exporter container is running"
+  docker logs node-exporter-test 2>&1 | tail -5
+
+  echo "Checking /metrics at :19100 exposes node_ series..."
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://localhost:19100/metrics 2>/dev/null | grep -q '^node_'; then
+      echo "node_exporter /metrics OK (attempt $i)"
+      break
+    fi
+    if [ "$i" = "10" ]; then
+      echo "FAIL: node_exporter /metrics never exposed node_ series after 10 attempts"
+      docker logs node-exporter-test
+      docker stop node-exporter-test && docker rm node-exporter-test
+      exit 1
+    fi
+    sleep 2
+  done
+
+  docker stop node-exporter-test && docker rm node-exporter-test
+else
+  echo "node_exporter failed to start, checking logs..."
+  docker logs node-exporter-test 2>&1 || true
+  docker rm node-exporter-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All node_exporter tests passed!"

--- a/pushgateway/apko/pushgateway-dev.yaml
+++ b/pushgateway/apko/pushgateway-dev.yaml
@@ -1,0 +1,49 @@
+# Development variant of minimal-pushgateway.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - pushgateway-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: pushgateway
+      gid: 65532
+  users:
+    - username: pushgateway
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/pushgateway
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-pushgateway-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-pushgateway: same pushgateway + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/pushgateway"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/pushgateway/apko/pushgateway.yaml
+++ b/pushgateway/apko/pushgateway.yaml
@@ -1,0 +1,42 @@
+# Minimal Prometheus pushgateway image - metrics push for batch jobs, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - pushgateway-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: pushgateway
+      gid: 65532
+  users:
+    - username: pushgateway
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Listens on :9091; scrape at /metrics, push API under /metrics/job/...
+entrypoint:
+  command: /usr/bin/pushgateway
+
+environment:
+  PATH: /usr/bin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-pushgateway"
+  org.opencontainers.image.description: "Hardened shell-less Prometheus pushgateway (metrics push for batch jobs) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/pushgateway"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/pushgateway/melange.yaml
+++ b/pushgateway/melange.yaml
@@ -1,0 +1,85 @@
+# Melange build configuration for minimal Prometheus pushgateway
+# Pure Go from source. Single `pushgateway` binary that accepts pushed metrics
+# from short-lived/batch jobs and exposes them for scraping.
+# License: Apache-2.0 (Prometheus authors).
+
+package:
+  name: pushgateway-minimal
+  version: 1.11.3
+  epoch: 0
+  description: "Minimal Prometheus pushgateway (metrics push for batch jobs) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of pushgateway source tarball - updated by update-versions.yml workflow
+  sha256: 5bcd6e57a012c303e68e2c1c84d6d86ae8c9cad8c948ee2538e6200390c0eff9
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify pushgateway source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/prometheus/pushgateway/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/pushgateway.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/pushgateway.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf pushgateway.tar.gz
+      rm pushgateway.tar.gz
+
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/pushgateway-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+
+  # Build the pushgateway binary (static). The upstream release build embeds a
+  # web UI; we build without the `builtinassets` tag for a minimal footprint —
+  # the /metrics and push API endpoints are fully functional.
+  - runs: |
+      cd /home/build/pushgateway-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -tags netgo \
+        -ldflags="-s -w \
+          -X github.com/prometheus/common/version.Version=${{package.version}} \
+          -X github.com/prometheus/common/version.Revision=source-build \
+          -X github.com/prometheus/common/version.Branch=HEAD \
+          -X github.com/prometheus/common/version.BuildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+          -X github.com/prometheus/common/version.BuildUser=melange" \
+        -o /home/build/pushgateway-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/pushgateway-bin "${{targets.destdir}}/usr/bin/pushgateway"
+      chmod 0755 "${{targets.destdir}}/usr/bin/pushgateway"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying pushgateway binary..."
+      "${{targets.destdir}}/usr/bin/pushgateway" --version

--- a/pushgateway/test-dev.sh
+++ b/pushgateway/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-pushgateway-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing pushgateway version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/pushgateway "$IMAGE" --version 2>&1 | grep -qiE 'pushgateway.*version [0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All pushgateway-dev smoke tests passed"

--- a/pushgateway/test.sh
+++ b/pushgateway/test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# NB: no -o pipefail — `docker run | grep -q` is SIGPIPE-prone.
+set -eu
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing pushgateway version..."
+docker run --rm --entrypoint /usr/bin/pushgateway "$IMAGE" --version 2>&1 | grep -qiE 'pushgateway.*version [0-9]'
+
+echo "Testing pushgateway help..."
+docker run --rm --entrypoint /usr/bin/pushgateway "$IMAGE" --help 2>&1 | grep -qiE 'web.listen-address|persistence.file'
+
+echo "Testing pushgateway starts and serves /-/healthy + /metrics..."
+docker run -d --name pushgateway-test \
+  -p 19091:9091 \
+  "$IMAGE" --web.listen-address=0.0.0.0:9091
+sleep 3
+
+if docker ps | grep -q pushgateway-test; then
+  echo "pushgateway container is running"
+  docker logs pushgateway-test 2>&1 | tail -5
+
+  echo "Checking /-/healthy at :19091..."
+  for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf http://localhost:19091/-/healthy >/dev/null 2>&1; then
+      echo "pushgateway /-/healthy OK (attempt $i)"
+      break
+    fi
+    if [ "$i" = "10" ]; then
+      echo "FAIL: pushgateway /-/healthy never returned 200 after 10 attempts"
+      docker logs pushgateway-test
+      docker stop pushgateway-test && docker rm pushgateway-test
+      exit 1
+    fi
+    sleep 2
+  done
+
+  echo "Checking a pushed metric round-trips through /metrics..."
+  # Pushgateway requires Prometheus text exposition format with a trailing newline.
+  printf 'smoke_test_metric 42\n' | curl -sf --data-binary @- http://localhost:19091/metrics/job/smoke >/dev/null
+  if curl -sf http://localhost:19091/metrics 2>/dev/null | grep -q 'smoke_test_metric'; then
+    echo "pushgateway push round-trip OK"
+  else
+    echo "FAIL: pushed metric not visible on /metrics"
+    docker logs pushgateway-test
+    docker stop pushgateway-test && docker rm pushgateway-test
+    exit 1
+  fi
+
+  docker stop pushgateway-test && docker rm pushgateway-test
+else
+  echo "pushgateway failed to start, checking logs..."
+  docker logs pushgateway-test 2>&1 || true
+  docker rm pushgateway-test 2>/dev/null || true
+  exit 1
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All pushgateway tests passed!"


### PR DESCRIPTION
Adds three Prometheus-family exporters, built from upstream source via melange, distroless with dev variants — following the `thanos` recipe pattern.

## Images
| Image | Version | Port | Notes |
|---|---|---|---|
| `node-exporter` | 1.11.1 | 9100 | host hardware & OS metrics |
| `blackbox-exporter` | 0.28.0 | 9115 | endpoint probing; ships a minimal default `config.yml` |
| `pushgateway` | 1.11.3 | 9091 | metrics push for batch jobs |

Each is wired into the Makefile, the `build.yml` matrix (prod+dev), and the `versions.yaml` auto-bump registry.

## Local validation (per CLAUDE.md)
All three pass `make <img>-melange` / `make <img>` / `make test-<img>`:
- node-exporter: `:9100/metrics` exposes `node_` series
- blackbox-exporter: default config loads, `:9115/metrics` exposes `blackbox_` series
- pushgateway: `/-/healthy` OK + pushed metric round-trips through `/metrics`

## Docs
Reconciles the catalog image count to **57** across README (badge, heading, TOC anchor, dev-variant count, category table) and `docs/dev-variants/CONVENTIONS.md`. The docs had drifted (badge said 46, heading 48) and omitted several already-shipping images (alertmanager, mimir, telegraf, thanos, opentofu, trivy) alongside the three added here.

Note: the detailed pull-command `<details>` catalog still omits those 6 older images (counts are now correct, but rows are missing) — can be added in a follow-up.