### PR TITLE
feat(site): enterprise redesign + logo + partial-data fix

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -51,21 +51,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # Source scan data from the latest successful FULL build. Partial push
-      # builds only scan changed images, so their artifacts are an incomplete
-      # dataset — we deliberately ignore them and use the last schedule/dispatch
-      # run, which builds and scans all images. (This holds for every trigger,
-      # including workflow_run, so a partial build finishing never deploys a
-      # data-thin site over a good one.)
+      # Source scan data from the latest successful FULL build — one that scanned
+      # (nearly) all images. Partial push builds only scan changed images, so we
+      # judge completeness by the vulnerability-report artifact count rather than
+      # the trigger event: any run with >= MIN reports qualifies (full push,
+      # schedule, or dispatch), and thin partial builds are skipped. This keeps a
+      # data-thin build from ever deploying over a complete one.
       - name: Resolve source build run
         id: buildrun
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RID=$(gh api "repos/${{ github.repository }}/actions/workflows/build.yml/runs?status=success&branch=main&per_page=40" \
-                  --jq '[.workflow_runs[] | select(.event=="schedule" or .event=="workflow_dispatch")][0].id')
-          if [ -z "$RID" ] || [ "$RID" = "null" ]; then
-            echo "::error::No successful full build (schedule/dispatch) found to source scan data from."
+          MIN=50   # catalog has 57 images; allow a few flaky scans
+          RID=""
+          for id in $(gh api "repos/${{ github.repository }}/actions/workflows/build.yml/runs?status=success&branch=main&per_page=20" \
+                        --jq '.workflow_runs[].id'); do
+            N=$(gh api "repos/${{ github.repository }}/actions/runs/$id/artifacts" --paginate \
+                  --jq '[.artifacts[].name | select(startswith("vulnerability-report-"))] | length')
+            echo "run $id → $N vulnerability-report artifacts"
+            if [ "${N:-0}" -ge "$MIN" ]; then RID=$id; break; fi
+          done
+          if [ -z "$RID" ]; then
+            echo "::error::No successful build with >= $MIN image reports found to source scan data from."
             exit 1
           fi
           echo "run_id=$RID" >> "$GITHUB_OUTPUT"

--- a/site/public/icon.svg
+++ b/site/public/icon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="minimal">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#14b8a6"/>
+      <stop offset="1" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#g)"/>
+  <!-- isometric container cube -->
+  <g fill="none" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round">
+    <!-- top face (filled subtly) -->
+    <path d="M16 7 L24 11.5 L16 16 L8 11.5 Z" fill="#ffffff" fill-opacity="0.9" stroke="none"/>
+    <!-- left face -->
+    <path d="M8 11.5 L16 16 L16 25 L8 20.5 Z" fill="#ffffff" fill-opacity="0.28"/>
+    <!-- right face -->
+    <path d="M24 11.5 L16 16 L16 25 L24 20.5 Z" fill="#ffffff" fill-opacity="0.12"/>
+    <!-- outer edges -->
+    <path d="M16 7 L24 11.5 L24 20.5 L16 25 L8 20.5 L8 11.5 Z"/>
+    <path d="M16 16 L16 25"/>
+    <path d="M8 11.5 L16 16 L24 11.5"/>
+  </g>
+</svg>

--- a/site/src/components/ImageCard.astro
+++ b/site/src/components/ImageCard.astro
@@ -12,6 +12,5 @@ const { image } = Astro.props;
     <SeverityBar image={image} />
     {image.size && <span>{image.size.human}</span>}
     {image.updatedAgo && <span>· {image.updatedAgo}</span>}
-    {image.degraded && <span class="badge-degraded" title={image.notes.join('; ')}>partial data</span>}
   </div>
 </article>

--- a/site/src/components/Layout.astro
+++ b/site/src/components/Layout.astro
@@ -21,19 +21,22 @@ const year = new Date().getFullYear();
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
-  <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;550;600;640;680;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
 </head>
 <body>
   <header class="site-header">
     <div class="container">
       <a href="/" class="brand">
-        <img src="/logo.svg" alt="" class="logo" />
-        <span>Minimal Containers</span>
+        <img src="/icon.svg" alt="" class="logo" width="26" height="26" />
+        <span class="brand-name">minimal</span>
       </a>
       <nav class="nav">
         <a href="/images">Images</a>
         <a href="/about">Verify</a>
-        <a href="https://github.com/rtvkiz/minimal" rel="noopener">GitHub</a>
+        <a href="https://github.com/rtvkiz/minimal" rel="noopener" class="nav-cta">GitHub ↗</a>
       </nav>
     </div>
   </header>

--- a/site/src/pages/images/[name].astro
+++ b/site/src/pages/images/[name].astro
@@ -23,8 +23,7 @@ const sevOrder = ['critical', 'high', 'medium', 'low'] as const;
       <p style="margin:0 0 6px"><a href="/images" class="small muted">← All images</a></p>
       <h1>
         {image.name}
-        <span class="cat" style="font-size:0.8rem">{image.category}</span>
-        {image.degraded && <span class="badge-degraded">partial data</span>}
+        <span class="cat">{image.category}</span>
       </h1>
       <p class="summary">{image.summary}</p>
       <div class="quickfacts">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,11 +19,12 @@ gh attestation verify oci://ghcr.io/rtvkiz/minimal-python:latest --owner rtvkiz`
 <Layout>
   <section class="hero">
     <div class="container">
-      <h1>Free, hardened container images</h1>
+      <span class="eyebrow">Open source · MIT licensed</span>
+      <h1>Hardened container images</h1>
       <p class="lead">
-        Small, MIT-licensed images built from source with Wolfi packages and rebuilt every
-        six hours. Every image is cosign-signed, ships an SPDX SBOM, and carries SLSA Level 3
-        provenance — verifiable without an account.
+        Free. Signed. Verifiable. Small images built from source and rebuilt every six hours —
+        each one cosign-signed with an SPDX SBOM and SLSA Level 3 provenance. No account, no
+        rate limits.
       </p>
       <div class="cta">
         <a class="btn btn-primary" href="/images">Browse {stats.images} images →</a>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,141 +1,167 @@
+/* Minimal Containers — light, corporate-clean design system */
+
 :root {
+  /* surfaces */
   --bg: #ffffff;
-  --bg-alt: #f6f8fa;
-  --bg-code: #0f172a;
-  --fg: #1f2328;
-  --muted: #656d76;
-  --border: #d0d7de;
-  --link: #0969da;
+  --bg-subtle: #fafafa;
+  --bg-muted: #f4f5f7;
+  --surface: #ffffff;
+  --code-bg: #0d1117;
 
-  --brand: #0d9488;
-  --brand-strong: #0d7268;
-  --brand-light: #14b8a6;
-  --brand-bg: #f0fdfa;
+  /* text */
+  --fg: #111318;
+  --fg-strong: #0a0c10;
+  --muted: #5b6270;
+  --subtle: #8b909c;
 
-  --critical: #d1242f;
-  --high: #bc4c00;
-  --medium: #bf8700;
-  --low: #6e7781;
-  --negligible: #8c959f;
-  --clean: #1a7f37;
+  /* lines */
+  --border: #e8eaed;
+  --border-strong: #d7dae0;
 
-  --radius: 8px;
-  --shadow: 0 1px 3px rgba(16, 24, 40, 0.08), 0 1px 2px rgba(16, 24, 40, 0.04);
-  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-}
+  /* brand */
+  --accent: #0d9488;
+  --accent-hover: #0f766e;
+  --accent-soft: #f0fdfa;
+  --accent-line: #99f6e4;
+  --accent-ink: #0b4f47;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0d1117;
-    --bg-alt: #161b22;
-    --fg: #e6edf3;
-    --muted: #8b949e;
-    --border: #30363d;
-    --link: #58a6ff;
-    --brand-bg: #0b2a26;
-  }
+  /* severity */
+  --critical: #dc2626;
+  --high: #ea580c;
+  --medium: #ca8a04;
+  --low: #64748b;
+  --clean: #16a34a;
+
+  --radius: 12px;
+  --radius-sm: 8px;
+  --radius-xs: 6px;
+  --shadow-sm: 0 1px 2px rgba(10, 12, 16, 0.04);
+  --shadow: 0 1px 2px rgba(10, 12, 16, 0.04), 0 8px 24px -12px rgba(10, 12, 16, 0.12);
+  --shadow-lg: 0 1px 3px rgba(10, 12, 16, 0.05), 0 20px 40px -20px rgba(10, 12, 16, 0.18);
+
+  --sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  --maxw: 1160px;
 }
 
 * { box-sizing: border-box; }
-
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
 
 body {
   margin: 0;
   font-family: var(--sans);
   color: var(--fg);
   background: var(--bg);
-  line-height: 1.55;
+  line-height: 1.6;
+  font-size: 16px;
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-a { color: var(--link); text-decoration: none; }
-a:hover { text-decoration: underline; }
+a { color: var(--accent-hover); text-decoration: none; }
+a:hover { color: var(--accent); }
 
-.container { max-width: 1120px; margin: 0 auto; padding: 0 24px; }
-.container-narrow { max-width: 820px; margin: 0 auto; padding: 0 24px; }
+h1, h2, h3, h4 { color: var(--fg-strong); font-weight: 640; line-height: 1.2; letter-spacing: -0.02em; margin: 0; }
 
-h1, h2, h3 { line-height: 1.25; font-weight: 700; }
+code, pre, kbd { font-family: var(--mono); }
 
-code, pre, kbd { font-family: var(--mono); font-size: 0.85em; }
+.container { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+.container-narrow { max-width: 780px; margin: 0 auto; padding: 0 24px; }
 
 .muted { color: var(--muted); }
 .small { font-size: 0.85rem; }
+.eyebrow { font-size: 0.72rem; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent); }
 
-/* --- header --- */
+/* ---------- header ---------- */
 .site-header {
+  position: sticky; top: 0; z-index: 40;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: saturate(180%) blur(12px);
   border-bottom: 1px solid var(--border);
-  background: var(--bg);
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  backdrop-filter: saturate(180%) blur(6px);
 }
-.site-header .container { display: flex; align-items: center; gap: 24px; height: 60px; }
-.brand { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 1.05rem; color: var(--fg); }
-.brand:hover { text-decoration: none; }
-.brand .logo { width: 26px; height: 26px; }
-.nav { display: flex; gap: 20px; margin-left: auto; align-items: center; }
-.nav a { color: var(--muted); font-weight: 500; font-size: 0.92rem; }
-.nav a:hover { color: var(--fg); text-decoration: none; }
+.site-header .container { display: flex; align-items: center; gap: 28px; height: 62px; }
+.brand { display: inline-flex; align-items: center; gap: 9px; color: var(--fg-strong); font-weight: 650; font-size: 1.02rem; letter-spacing: -0.01em; }
+.brand:hover { color: var(--fg-strong); }
+.brand .logo { width: 26px; height: 26px; border-radius: 7px; display: block; }
+.brand .brand-name { font-weight: 650; }
+.nav { display: flex; gap: 26px; margin-left: auto; align-items: center; }
+.nav a { color: var(--muted); font-weight: 500; font-size: 0.92rem; letter-spacing: -0.01em; }
+.nav a:hover { color: var(--fg-strong); }
+.nav a.nav-cta {
+  color: var(--fg-strong); border: 1px solid var(--border-strong); padding: 7px 15px;
+  border-radius: 8px; font-weight: 550;
+}
+.nav a.nav-cta:hover { border-color: var(--accent); color: var(--accent-hover); background: var(--accent-soft); }
 
-/* --- hero --- */
-.hero { padding: 72px 0 48px; text-align: center; background: linear-gradient(180deg, var(--brand-bg), transparent); }
-.hero h1 { font-size: clamp(2rem, 5vw, 3.1rem); margin: 0 0 16px; letter-spacing: -0.02em; }
-.hero p.lead { font-size: 1.2rem; color: var(--muted); max-width: 680px; margin: 0 auto 28px; }
+/* ---------- buttons ---------- */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px; cursor: pointer;
+  padding: 11px 20px; border-radius: 10px; font-weight: 560; font-size: 0.94rem;
+  letter-spacing: -0.01em; border: 1px solid transparent; transition: all 0.15s ease;
+}
+.btn-primary { background: var(--accent); color: #fff; box-shadow: var(--shadow-sm); }
+.btn-primary:hover { background: var(--accent-hover); color: #fff; transform: translateY(-1px); box-shadow: var(--shadow); }
+.btn-ghost { background: var(--surface); color: var(--fg-strong); border-color: var(--border-strong); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent-hover); background: var(--accent-soft); }
+
+/* ---------- hero ---------- */
+.hero { position: relative; padding: 96px 0 64px; text-align: center; overflow: hidden; }
+.hero::before {
+  content: ""; position: absolute; inset: 0; z-index: -1;
+  background:
+    radial-gradient(60% 55% at 50% -8%, var(--accent-soft), transparent 70%),
+    linear-gradient(180deg, #fcfefe, transparent 40%);
+}
+.hero .eyebrow { margin-bottom: 18px; display: inline-block; }
+.hero h1 { font-size: clamp(2.4rem, 5.5vw, 3.6rem); letter-spacing: -0.035em; font-weight: 680; margin: 0 0 20px; }
+.hero p.lead { font-size: 1.2rem; color: var(--muted); max-width: 640px; margin: 0 auto 32px; line-height: 1.55; }
 .hero .cta { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
 
-.btn {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 10px 20px; border-radius: var(--radius); font-weight: 600; font-size: 0.95rem;
-  border: 1px solid transparent; cursor: pointer;
-}
-.btn-primary { background: var(--brand); color: #fff; }
-.btn-primary:hover { background: var(--brand-strong); text-decoration: none; }
-.btn-ghost { background: var(--bg); color: var(--fg); border-color: var(--border); }
-.btn-ghost:hover { background: var(--bg-alt); text-decoration: none; }
+/* ---------- stats ---------- */
+.stats { display: flex; gap: 0; justify-content: center; flex-wrap: wrap; margin-top: 52px; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; max-width: 720px; margin-left: auto; margin-right: auto; box-shadow: var(--shadow-sm); }
+.stat { flex: 1; min-width: 130px; padding: 22px 20px; text-align: center; border-right: 1px solid var(--border); background: var(--surface); }
+.stat:last-child { border-right: none; }
+.stat .num { font-size: 1.9rem; font-weight: 680; color: var(--fg-strong); letter-spacing: -0.03em; }
+.stat .lbl { font-size: 0.74rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 4px; font-weight: 550; }
 
-/* --- stats strip --- */
-.stats { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin-top: 8px; }
-.stat { background: var(--bg-alt); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px 22px; text-align: center; min-width: 120px; }
-.stat .num { font-size: 1.7rem; font-weight: 700; color: var(--brand); }
-.stat .lbl { font-size: 0.8rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+/* ---------- sections ---------- */
+section { padding: 56px 0; }
+.section-title { font-size: 1.55rem; letter-spacing: -0.025em; margin: 0 0 8px; }
+.section-sub { color: var(--muted); margin: 0 0 28px; font-size: 1.02rem; }
 
-/* --- section --- */
-section { padding: 40px 0; }
-.section-title { font-size: 1.4rem; margin: 0 0 6px; }
-.section-sub { color: var(--muted); margin: 0 0 24px; }
-
-/* --- directory --- */
-.controls { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; margin-bottom: 20px; }
+/* ---------- directory ---------- */
+.controls { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; margin-bottom: 16px; }
 .controls input[type="search"] {
-  flex: 1; min-width: 220px; padding: 10px 14px; font-size: 0.95rem;
-  border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); color: var(--fg);
+  flex: 1; min-width: 240px; padding: 12px 16px; font-size: 0.95rem; font-family: inherit;
+  border: 1px solid var(--border-strong); border-radius: 10px; background: var(--surface); color: var(--fg);
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
+.controls input[type="search"]:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 .facets { display: flex; gap: 8px; flex-wrap: wrap; }
 .facet {
-  padding: 6px 12px; border: 1px solid var(--border); border-radius: 999px; background: var(--bg);
-  color: var(--muted); font-size: 0.85rem; cursor: pointer; user-select: none;
+  padding: 7px 14px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface);
+  color: var(--muted); font-size: 0.85rem; font-weight: 500; cursor: pointer; user-select: none; transition: all 0.12s;
 }
-.facet[aria-pressed="true"] { background: var(--brand); border-color: var(--brand); color: #fff; }
+.facet:hover { border-color: var(--border-strong); color: var(--fg); }
+.facet[aria-pressed="true"] { background: var(--fg-strong); border-color: var(--fg-strong); color: #fff; }
 
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(310px, 1fr)); gap: 16px; }
 
 .card {
-  border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg);
-  padding: 18px; display: flex; flex-direction: column; gap: 10px; box-shadow: var(--shadow);
-  transition: border-color 0.15s, transform 0.15s;
+  position: relative; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface);
+  padding: 20px; display: flex; flex-direction: column; gap: 10px; transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
 }
-.card:hover { border-color: var(--brand); transform: translateY(-2px); }
-.card a.card-title { font-size: 1.1rem; font-weight: 700; color: var(--fg); }
-.card a.card-title:hover { color: var(--brand); text-decoration: none; }
-.card .cat { font-size: 0.75rem; color: var(--brand); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
-.card .desc { color: var(--muted); font-size: 0.9rem; flex: 1; }
+.card:hover { border-color: var(--border-strong); box-shadow: var(--shadow); transform: translateY(-2px); }
+.card .cat { font-size: 0.72rem; color: var(--muted); font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+.card a.card-title { font-size: 1.12rem; font-weight: 640; color: var(--fg-strong); letter-spacing: -0.02em; }
+.card a.card-title::after { content: ""; position: absolute; inset: 0; }
+.card:hover a.card-title { color: var(--accent-hover); }
+.card .desc { color: var(--muted); font-size: 0.9rem; flex: 1; line-height: 1.5; }
 .card .meta-row { display: flex; gap: 12px; flex-wrap: wrap; font-size: 0.8rem; color: var(--muted); align-items: center; }
 
-/* --- severity --- */
-.sevbar { display: flex; height: 8px; border-radius: 999px; overflow: hidden; background: var(--bg-alt); min-width: 90px; }
+/* ---------- severity ---------- */
+.sevbar { display: inline-flex; height: 6px; border-radius: 999px; overflow: hidden; background: var(--bg-muted); min-width: 84px; }
 .sevbar span { display: block; height: 100%; }
 .sev-critical { background: var(--critical); }
 .sev-high { background: var(--high); }
@@ -143,77 +169,83 @@ section { padding: 40px 0; }
 .sev-low { background: var(--low); }
 .sev-clean { background: var(--clean); }
 
-.pill { display: inline-flex; align-items: center; gap: 5px; padding: 2px 9px; border-radius: 999px; font-size: 0.78rem; font-weight: 600; }
-.pill.critical { background: rgba(209,36,47,0.12); color: var(--critical); }
-.pill.high { background: rgba(188,76,0,0.12); color: var(--high); }
-.pill.medium { background: rgba(191,135,0,0.14); color: var(--medium); }
-.pill.low { background: rgba(110,119,129,0.14); color: var(--low); }
-.pill.clean { background: rgba(26,127,55,0.12); color: var(--clean); }
-.pill.neutral { background: var(--bg-alt); color: var(--muted); }
+.pill { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 999px; font-size: 0.76rem; font-weight: 600; letter-spacing: 0.01em; }
+.pill.critical { background: #fef2f2; color: var(--critical); }
+.pill.high { background: #fff7ed; color: var(--high); }
+.pill.medium { background: #fefce8; color: #a16207; }
+.pill.low { background: #f1f5f9; color: var(--low); }
+.pill.clean { background: #f0fdf4; color: var(--clean); }
+.pill.neutral { background: var(--bg-muted); color: var(--muted); }
 
-.badge-degraded { background: rgba(191,135,0,0.14); color: var(--medium); border: 1px solid rgba(191,135,0,0.3); padding: 2px 8px; border-radius: 6px; font-size: 0.72rem; font-weight: 600; }
-
-/* --- code / copy --- */
-.codeblock { position: relative; background: var(--bg-code); border-radius: var(--radius); overflow: hidden; }
-.codeblock pre { margin: 0; padding: 14px 48px 14px 16px; overflow-x: auto; color: #e6edf3; font-size: 0.82rem; line-height: 1.6; }
+/* ---------- code ---------- */
+.codeblock { position: relative; background: var(--code-bg); border-radius: var(--radius-sm); overflow: hidden; border: 1px solid rgba(255,255,255,0.06); }
+.codeblock pre { margin: 0; padding: 16px 52px 16px 18px; overflow-x: auto; color: #e6edf3; font-size: 0.82rem; line-height: 1.65; }
 .copy-btn {
-  position: absolute; top: 8px; right: 8px; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);
-  color: #e6edf3; border-radius: 6px; padding: 4px 10px; font-size: 0.75rem; cursor: pointer;
+  position: absolute; top: 9px; right: 9px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14);
+  color: #e6edf3; border-radius: 6px; padding: 5px 11px; font-size: 0.74rem; font-weight: 500; cursor: pointer; transition: background 0.12s;
 }
-.copy-btn:hover { background: rgba(255,255,255,0.2); }
+.copy-btn:hover { background: rgba(255,255,255,0.18); }
 
-/* --- detail page --- */
-.detail-head { padding: 32px 0 12px; border-bottom: 1px solid var(--border); }
-.detail-head h1 { font-size: 2rem; margin: 0 0 6px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
-.detail-head .summary { color: var(--muted); font-size: 1.05rem; margin: 0 0 14px; }
-.quickfacts { display: flex; gap: 20px; flex-wrap: wrap; font-size: 0.88rem; color: var(--muted); }
-.quickfacts b { color: var(--fg); font-weight: 600; }
+/* ---------- detail ---------- */
+.detail-head { padding: 40px 0 0; }
+.detail-head h1 { font-size: 2.1rem; letter-spacing: -0.03em; margin: 0 0 8px; display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.detail-head .cat { font-size: 0.72rem; color: var(--muted); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; padding: 3px 9px; border: 1px solid var(--border); border-radius: 6px; }
+.detail-head .summary { color: var(--muted); font-size: 1.1rem; margin: 0 0 18px; max-width: 720px; }
+.quickfacts { display: flex; gap: 24px; flex-wrap: wrap; font-size: 0.88rem; color: var(--muted); padding-bottom: 4px; }
+.quickfacts b { color: var(--fg-strong); font-weight: 600; margin-right: 5px; font-weight: 550; }
 
-.tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin: 24px 0 0; flex-wrap: wrap; }
+.tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--border); margin-top: 28px; flex-wrap: wrap; }
 .tab {
-  padding: 10px 16px; border: none; background: none; color: var(--muted); font-size: 0.95rem; font-weight: 600;
-  cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px;
+  padding: 12px 16px; border: none; background: none; color: var(--muted); font-size: 0.94rem; font-weight: 550;
+  font-family: inherit; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; letter-spacing: -0.01em; transition: color 0.12s;
 }
-.tab[aria-selected="true"] { color: var(--brand); border-bottom-color: var(--brand); }
-.tab:hover { color: var(--fg); }
-.tabpanel { padding: 28px 0; }
+.tab[aria-selected="true"] { color: var(--accent-hover); border-bottom-color: var(--accent); }
+.tab:hover { color: var(--fg-strong); }
+.tabpanel { padding: 32px 0; }
 .tabpanel[hidden] { display: none; }
 
-.variant-toggle { display: inline-flex; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; margin-bottom: 20px; }
-.variant-toggle button { padding: 6px 16px; border: none; background: var(--bg); color: var(--muted); cursor: pointer; font-weight: 600; font-size: 0.85rem; }
-.variant-toggle button[aria-pressed="true"] { background: var(--brand); color: #fff; }
+.variant-toggle { display: inline-flex; border: 1px solid var(--border-strong); border-radius: 9px; overflow: hidden; margin-bottom: 22px; background: var(--bg-muted); padding: 3px; gap: 3px; }
+.variant-toggle button { padding: 6px 16px; border: none; background: transparent; color: var(--muted); cursor: pointer; font-weight: 560; font-size: 0.84rem; font-family: inherit; border-radius: 6px; transition: all 0.12s; }
+.variant-toggle button[aria-pressed="true"] { background: var(--surface); color: var(--fg-strong); box-shadow: var(--shadow-sm); }
 
-/* --- tables --- */
+/* ---------- tables ---------- */
 table.data { width: 100%; border-collapse: collapse; font-size: 0.88rem; }
-table.data th, table.data td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border); }
-table.data th { color: var(--muted); font-weight: 600; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.03em; }
-table.data tbody tr:hover, table.data tr:hover { background: var(--bg-alt); }
-table.data td.mono { font-family: var(--mono); font-size: 0.82rem; }
+table.data th, table.data td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--border); }
+table.data thead th { color: var(--subtle); font-weight: 600; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.05em; }
+table.data tbody tr { transition: background 0.1s; }
+table.data tbody tr:hover, table.data tr:hover { background: var(--bg-subtle); }
+table.data td.mono { font-family: var(--mono); font-size: 0.82rem; color: var(--fg); }
 
-.spec-grid { display: grid; grid-template-columns: 180px 1fr; gap: 0; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
-.spec-grid dt { padding: 12px 16px; background: var(--bg-alt); font-weight: 600; font-size: 0.85rem; border-bottom: 1px solid var(--border); }
-.spec-grid dd { padding: 12px 16px; margin: 0; font-size: 0.88rem; border-bottom: 1px solid var(--border); overflow-wrap: anywhere; }
+.spec-grid { display: grid; grid-template-columns: 200px 1fr; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+.spec-grid dt { padding: 14px 18px; background: var(--bg-subtle); font-weight: 600; font-size: 0.85rem; color: var(--fg-strong); border-bottom: 1px solid var(--border); }
+.spec-grid dd { padding: 14px 18px; margin: 0; font-size: 0.88rem; border-bottom: 1px solid var(--border); overflow-wrap: anywhere; }
 .spec-grid dt:last-of-type, .spec-grid dd:last-of-type { border-bottom: none; }
 .kv-mono { font-family: var(--mono); font-size: 0.82rem; }
 
-.notice { border: 1px solid var(--border); background: var(--bg-alt); border-radius: var(--radius); padding: 16px; color: var(--muted); font-size: 0.9rem; }
-.notice.warn { border-color: rgba(191,135,0,0.3); background: rgba(191,135,0,0.06); }
+.notice { border: 1px solid var(--border); background: var(--bg-subtle); border-radius: var(--radius-sm); padding: 16px 18px; color: var(--muted); font-size: 0.9rem; }
+.notice.warn { border-color: #fde68a; background: #fffbeb; color: #92650a; }
 
 .tag-list { display: flex; flex-wrap: wrap; gap: 8px; }
-.tag-chip { font-family: var(--mono); font-size: 0.8rem; padding: 4px 10px; background: var(--bg-alt); border: 1px solid var(--border); border-radius: 6px; }
+.tag-chip { font-family: var(--mono); font-size: 0.79rem; padding: 5px 11px; background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 7px; color: var(--fg); }
 
-/* --- footer --- */
-.site-footer { border-top: 1px solid var(--border); margin-top: 48px; padding: 32px 0; color: var(--muted); font-size: 0.88rem; }
+/* ---------- features ---------- */
+.verify-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+.feature { border: 1px solid var(--border); border-radius: var(--radius); padding: 22px; background: var(--surface); transition: border-color 0.15s, box-shadow 0.15s; }
+.feature:hover { border-color: var(--border-strong); box-shadow: var(--shadow-sm); }
+.feature h3 { margin: 0 0 8px; font-size: 1.02rem; letter-spacing: -0.02em; }
+.feature p { margin: 0; color: var(--muted); font-size: 0.9rem; line-height: 1.5; }
+
+/* ---------- footer ---------- */
+.site-footer { border-top: 1px solid var(--border); margin-top: 40px; padding: 40px 0; color: var(--muted); font-size: 0.88rem; background: var(--bg-subtle); }
 .site-footer .container { display: flex; gap: 24px; flex-wrap: wrap; justify-content: space-between; align-items: center; }
 .site-footer a { color: var(--muted); }
-.site-footer a:hover { color: var(--fg); }
+.site-footer a:hover { color: var(--fg-strong); }
 
-/* --- misc --- */
-.verify-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 16px; }
-.feature { border: 1px solid var(--border); border-radius: var(--radius); padding: 18px; }
-.feature h3 { margin: 0 0 8px; font-size: 1rem; }
-.feature p { margin: 0; color: var(--muted); font-size: 0.9rem; }
-@media (max-width: 600px) {
+/* ---------- responsive ---------- */
+@media (max-width: 640px) {
   .spec-grid { grid-template-columns: 1fr; }
-  .spec-grid dt { border-bottom: none; }
+  .spec-grid dt { border-bottom: none; padding-bottom: 4px; }
+  .hero { padding: 64px 0 40px; }
+  .nav { gap: 16px; }
+  .nav a:not(.nav-cta) { display: none; }
 }


### PR DESCRIPTION
Polish pass on the catalog site based on review feedback.

## Design
Reworked into a **light, corporate-clean** design system (Inter + JetBrains Mono, refined spacing, precise 1px borders, teal used sparingly). Restyled hero, stats strip, cards, tabs, tables, spec grids, and code blocks. Screenshots verified locally (home / directory / detail).

## Logo
The old `logo.svg` was a 600×200 wordmark in light colors being crammed into a 26px header box on white — a squished, near-invisible blob. Replaced with a proper square **monogram** (`icon.svg`): a teal isometric-cube mark that reads cleanly at favicon/header sizes, plus a lowercase `minimal` wordmark.

## "Partial data" fix
Two parts:
- **Display:** removed the alarming "partial data" badges from directory cards and detail headers; kept the honest, subtle per-tab notice only where a data source is genuinely missing.
- **Root cause:** `deploy-site.yml` now sources scan data by **completeness** (≥ 50 image reports) rather than trigger event. The full rebuild that runs on merge is a `push` event, which the old resolver skipped — so "partial" wouldn't clear until the next scheduled build. Now any complete build clears it.

## After merge
`deploy-site` redeploys automatically; once the in-flight full build finishes, all 57 images (incl. exporters) and SBOM-backed package lists populate.