### PR TITLE
fix(site): replace hero CVE-free stat with SLSA L3 + rebuild cadence

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -32,8 +32,8 @@ gh attestation verify oci://ghcr.io/rtvkiz/minimal-python:latest --owner rtvkiz`
       </div>
       <div class="stats" style="margin-top:36px">
         <div class="stat"><div class="num">{stats.images}</div><div class="lbl">Images</div></div>
-        <div class="stat"><div class="num">{stats.categories}</div><div class="lbl">Categories</div></div>
-        {stats.hasScanData && <div class="stat"><div class="num">{stats.clean}</div><div class="lbl">CVE-free</div></div>}
+        <div class="stat"><div class="num">L3</div><div class="lbl">SLSA provenance</div></div>
+        <div class="stat"><div class="num">6h</div><div class="lbl">Rebuild cadence</div></div>
         <div class="stat"><div class="num">$0</div><div class="lbl">Cost</div></div>
       </div>
     </div>


### PR DESCRIPTION
The homepage hero showed **"39 CVE-free"** (of 57), which implies ~18 images are vulnerable — a bad look for a hardened-image product, and it swings with upstream CVE lag.

Replaces it (and the weak "Categories" stat) with two universally-true, positive stats: **SLSA L3 provenance** and **6h rebuild cadence**. Per-image Clean/advisory status is untouched.

Site-only change → fast CI. Merging this also creates a new commit, which will confirm the same-commit Pages republish diagnosis (the current 57/57 + SBOM data should go live on deploy).