### PR TITLE
fix(deploy-site): stage files before committing to gh-pages (empty-branch fix)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -139,8 +139,9 @@ jobs:
           test -f CNAME || echo "::warning::CNAME missing from build output"
           git init -q
           git checkout -q -b gh-pages
+          git add -A
           git -c user.name="github-actions[bot]" \
               -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-              commit -q --allow-empty -m "deploy $(date -u +%FT%TZ) · data run ${{ steps.buildrun.outputs.run_id }} · site ${GITHUB_SHA:0:7}"
+              commit -q -m "deploy $(date -u +%FT%TZ) · data run ${{ steps.buildrun.outputs.run_id }} · site ${GITHUB_SHA:0:7}"
+          echo "Committing $(git ls-files | wc -l) files to gh-pages"
           git push -f "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" gh-pages:gh-pages
-          echo "Published to gh-pages ($(find . -type f | wc -l) files)"


### PR DESCRIPTION
Follow-up to #344. The publish step used `commit --allow-empty` but never ran `git add`, so the gh-pages branch got an **empty commit (0 files)** — the site would 404 if Pages were switched to it. (Caught before flipping the Pages source.)

Fix: add `git add -A` before the commit, drop `--allow-empty`, and count `git ls-files` in the log so an empty publish fails loudly. Verified locally that CNAME/.nojekyll/index.html/image pages are staged (66 files).