### PR TITLE
feat(brand): refresh README logo to match the site monogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 </p>
 
 <p align="center">
+  <a href="https://minimalcontainers.com"><strong>🌐&nbsp; Browse the full catalog at minimalcontainers.com&nbsp; →</strong></a>
+</p>
+
+<p align="center">
   <a href="https://github.com/rtvkiz/minimal/actions/workflows/build.yml"><img src="https://github.com/rtvkiz/minimal/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
   <a href="https://minimalcontainers.com"><img src="https://img.shields.io/badge/Image_Catalog-Live-0d9488" alt="Image Catalog"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,59 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 200" width="600" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 170" width="600" height="170" role="img" aria-label="minimal — hardened container images">
   <defs>
-    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#14b8a6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0d7268;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient id="shieldStroke" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#5eead4;stop-opacity:0.6" />
-      <stop offset="100%" style="stop-color:#0d9488;stop-opacity:0.3" />
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#14b8a6"/>
+      <stop offset="1" stop-color="#0d9488"/>
     </linearGradient>
   </defs>
 
-  <!-- Shield shape -->
-  <path d="M60,28 L108,12 L156,28 L156,90 C156,130 108,160 108,160 C108,160 60,130 60,90 Z"
-        fill="url(#shieldGrad)" stroke="url(#shieldStroke)" stroke-width="2.5"/>
+  <!-- monogram icon (the site's icon.svg, scaled to 92px) -->
+  <g transform="translate(118,39) scale(2.875)">
+    <rect width="32" height="32" rx="8" fill="url(#g)"/>
+    <g fill="none" stroke="#ffffff" stroke-width="1.6" stroke-linejoin="round" stroke-linecap="round">
+      <path d="M16 7 L24 11.5 L16 16 L8 11.5 Z" fill="#ffffff" fill-opacity="0.9" stroke="none"/>
+      <path d="M8 11.5 L16 16 L16 25 L8 20.5 Z" fill="#ffffff" fill-opacity="0.28"/>
+      <path d="M24 11.5 L16 16 L16 25 L24 20.5 Z" fill="#ffffff" fill-opacity="0.12"/>
+      <path d="M16 7 L24 11.5 L24 20.5 L16 25 L8 20.5 L8 11.5 Z"/>
+      <path d="M16 16 L16 25"/>
+      <path d="M8 11.5 L16 16 L24 11.5"/>
+    </g>
+  </g>
 
-  <!-- Inner shield highlight -->
-  <path d="M70,36 L108,22 L146,36 L146,88 C146,122 108,148 108,148 C108,148 70,122 70,88 Z"
-        fill="none" stroke="#5eead4" stroke-width="0.8" opacity="0.3"/>
-
-  <!-- Container/cube icon inside shield -->
-  <!-- Front face -->
-  <path d="M92,70 L108,62 L124,70 L124,95 L108,103 L92,95 Z"
-        fill="none" stroke="#e2e8f0" stroke-width="2" stroke-linejoin="round"/>
-  <!-- Top face -->
-  <path d="M92,70 L108,62 L124,70 L108,78 Z"
-        fill="#5eead4" fill-opacity="0.25" stroke="#e2e8f0" stroke-width="1.5" stroke-linejoin="round"/>
-  <!-- Middle line -->
-  <line x1="108" y1="78" x2="108" y2="103"
-        stroke="#e2e8f0" stroke-width="1.5"/>
-  <!-- Left edge -->
-  <line x1="92" y1="70" x2="108" y2="78"
-        stroke="#e2e8f0" stroke-width="0" opacity="0"/>
-  <!-- Right edge -->
-  <line x1="124" y1="70" x2="108" y2="78"
-        stroke="#e2e8f0" stroke-width="0" opacity="0"/>
-
-  <!-- Small lock accent on cube -->
-  <rect x="104" y="84" width="8" height="6" rx="1"
-        fill="#5eead4" fill-opacity="0.5" stroke="#e2e8f0" stroke-width="1"/>
-  <path d="M106,84 L106,81 C106,79 110,79 110,81 L110,84"
-        fill="none" stroke="#e2e8f0" stroke-width="1" stroke-linecap="round"/>
-
-  <!-- "MINIMAL" text -->
-  <text x="190" y="98" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
-        font-size="52" font-weight="700" letter-spacing="3" fill="#e2e8f0">
-    MINIMAL
-  </text>
-
-  <!-- Tagline -->
-  <text x="192" y="126" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
-        font-size="16" font-weight="400" letter-spacing="4" fill="#94a3b8">
-    HARDENED CONTAINER IMAGES
-  </text>
-
-  <!-- Subtle accent line -->
-  <line x1="190" y1="106" x2="520" y2="106"
-        stroke="#0d9488" stroke-width="1.5" opacity="0.5"/>
+  <!-- wordmark: teal reads on both light and dark GitHub themes -->
+  <text x="232" y="99" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+        font-size="62" font-weight="700" letter-spacing="-2" fill="#0d9488">minimal</text>
+  <text x="235" y="126" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif"
+        font-size="14.5" font-weight="500" letter-spacing="3.5" fill="#5b6270">HARDENED CONTAINER IMAGES</text>
 </svg>


### PR DESCRIPTION
The website's monogram looks much better than the old README logo. This brings the repo in line.

Old `logo.svg`: a busy shield + "MINIMAL" wordmark in light colors that's nearly invisible on GitHub's white theme. New: the site's clean cube monogram + lowercase `minimal` wordmark, in teal so it's legible on **both** light and dark GitHub themes (verified by rendering on both backgrounds).