### PR TITLE
docs(readme): link the live catalog from Available Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ It's probably not the right fit if you need a vendor contract, FedRAMP or STIG a
 | **Kubernetes, CI & IaC** | 4 | helm, kubectl, opentofu, trivy |
 | **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
 
+Browse every image — with live CVE scans, all tags, SBOMs, and build provenance — at **[minimalcontainers.com](https://minimalcontainers.com)**, or expand the full pull-command list below.
+
 <details>
 <summary><strong>Full image catalog with pull commands</strong></summary>
 


### PR DESCRIPTION
Light touch, per request — keep the README as-is and just place a clear link to the live catalog where it's most useful.

Adds one line above the pull-command table:
> Browse every image — with live CVE scans, all tags, SBOMs, and build provenance — at **minimalcontainers.com**, or expand the full pull-command list below.

(Complements the top callout + 'Image Catalog' badge already merged in #346.) No content removed.