### PR TITLE
feat: supply-chain images (cosign, syft, grype) built from source

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -164,6 +164,24 @@
     releases: "https://github.com/sigstore/cosign/releases"
     notes: "https://github.com/sigstore/cosign/releases/tag/v{version}"
 
+- name: syft
+  files: [syft/melange.yaml]
+  source: { type: github-releases-latest, repo: anchore/syft, strip-v: true, pin-major: 1 }
+  tarball: { url: "https://github.com/anchore/syft/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/anchore/syft/releases"
+    notes: "https://github.com/anchore/syft/releases/tag/v{version}"
+
+- name: grype
+  files: [grype/melange.yaml]
+  source: { type: github-releases-latest, repo: anchore/grype, strip-v: true, pin-major: 0 }
+  tarball: { url: "https://github.com/anchore/grype/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/anchore/grype/releases"
+    notes: "https://github.com/anchore/grype/releases/tag/v{version}"
+
 # cron-enabled added once a manual dispatch (gh workflow run update-versions.yml
 # -f only=thanos) is confirmed to produce a clean PR.
 - name: thanos

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -154,6 +154,16 @@
     releases: "https://github.com/aquasecurity/trivy/releases"
     notes: "https://github.com/aquasecurity/trivy/releases/tag/v{version}"
 
+# cron-enabled omitted until a dispatch check produces a clean PR.
+- name: cosign
+  files: [cosign/melange.yaml]
+  source: { type: github-releases-latest, repo: sigstore/cosign, strip-v: true, pin-major: 3 }
+  tarball: { url: "https://github.com/sigstore/cosign/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/sigstore/cosign/releases"
+    notes: "https://github.com/sigstore/cosign/releases/tag/v{version}"
+
 # cron-enabled added once a manual dispatch (gh workflow run update-versions.yml
 # -f only=thanos) is confirmed to produce a clean PR.
 - name: thanos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
             {"name":"mimir","variants":["prod","dev"]},
             {"name":"opentofu","variants":["prod","dev"]},
             {"name":"trivy","variants":["prod","dev"]},
+            {"name":"cosign","variants":["prod","dev"]},
             {"name":"thanos","variants":["prod","dev"]},
             {"name":"node-exporter","variants":["prod","dev"]},
             {"name":"blackbox-exporter","variants":["prod","dev"]},

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
             {"name":"opentofu","variants":["prod","dev"]},
             {"name":"trivy","variants":["prod","dev"]},
             {"name":"cosign","variants":["prod","dev"]},
+            {"name":"syft","variants":["prod","dev"]},
+            {"name":"grype","variants":["prod","dev"]},
             {"name":"thanos","variants":["prod","dev"]},
             {"name":"node-exporter","variants":["prod","dev"]},
             {"name":"blackbox-exporter","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -119,6 +119,8 @@ jobs:
             [trivy]="/home/build/trivy-${D}{{package.version}}"
             [thanos]="/home/build/thanos-${D}{{package.version}}"
             [cosign]="/home/build/cosign-${D}{{package.version}}"
+            [syft]="/home/build/syft-${D}{{package.version}}"
+            [grype]="/home/build/grype-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -154,6 +156,8 @@ jobs:
             [trivy]="github.com/aquasecurity/trivy"
             [thanos]="github.com/thanos-io/thanos"
             [cosign]="github.com/sigstore/cosign/v3"
+            [syft]="github.com/anchore/syft"
+            [grype]="github.com/anchore/grype"
           )
 
           # Build step markers to insert before
@@ -188,6 +192,8 @@ jobs:
             [trivy]='GOEXPERIMENT=jsonv2 go build'
             [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [cosign]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [syft]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [grype]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -118,6 +118,7 @@ jobs:
             [opentofu]="/home/build/opentofu-${D}{{package.version}}"
             [trivy]="/home/build/trivy-${D}{{package.version}}"
             [thanos]="/home/build/thanos-${D}{{package.version}}"
+            [cosign]="/home/build/cosign-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -152,6 +153,7 @@ jobs:
             [opentofu]="github.com/opentofu/opentofu"
             [trivy]="github.com/aquasecurity/trivy"
             [thanos]="github.com/thanos-io/thanos"
+            [cosign]="github.com/sigstore/cosign/v3"
           )
 
           # Build step markers to insert before
@@ -185,6 +187,7 @@ jobs:
             # block was silently skipped. Match the unique jsonv2 build instead.
             [trivy]='GOEXPERIMENT=jsonv2 go build'
             [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [cosign]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
 
 # --- Security tooling ---
 TRIVY_VERSION ?= $(call melange_version,trivy/melange.yaml)
+COSIGN_VERSION ?= $(call melange_version,cosign/melange.yaml)
 
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
@@ -145,6 +146,7 @@ endef
 .PHONY: tempo tempo-melange tempo-dev test-tempo test-tempo-dev
 .PHONY: opentofu opentofu-melange test-opentofu
 .PHONY: trivy trivy-melange test-trivy
+.PHONY: cosign cosign-melange test-cosign
 .PHONY: thanos thanos-melange test-thanos
 .PHONY: node-exporter node-exporter-melange test-node-exporter
 .PHONY: blackbox-exporter blackbox-exporter-melange test-blackbox-exporter
@@ -1457,6 +1459,32 @@ trivy: trivy-melange
 	@echo "✓ minimal-trivy built (source build)"
 
 #------------------------------------------------------------------------------
+# COSIGN IMAGE (melange Go source build + apko; Sigstore container signing)
+#------------------------------------------------------------------------------
+cosign-melange: keygen
+	@echo "Building Cosign $(COSIGN_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build cosign/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Cosign package built from source"
+
+cosign: cosign-melange
+	@echo "Assembling minimal-cosign image with apko..."
+	apko build cosign/apko/cosign.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-cosign:$(VERSION) \
+		cosign.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < cosign.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-cosign:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-cosign:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-cosign:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-cosign:latest
+	@rm -f cosign.tar sbom-*.spdx.json
+	@echo "✓ minimal-cosign built (source build)"
+
+#------------------------------------------------------------------------------
 # THANOS IMAGE (melange Go source build + apko; HA Prometheus long-term storage)
 #------------------------------------------------------------------------------
 thanos-melange: keygen
@@ -2297,6 +2325,12 @@ test-trivy:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-trivy:latest" && \
 		trivy/test.sh
 	@echo "✓ trivy tests passed"
+
+test-cosign:
+	@echo "Testing cosign image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-cosign:latest" && \
+		cosign/test.sh
+	@echo "✓ cosign tests passed"
 
 test-thanos:
 	@echo "Testing thanos image..."

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ OPENTOFU_VERSION ?= $(call melange_version,opentofu/melange.yaml)
 # --- Security tooling ---
 TRIVY_VERSION ?= $(call melange_version,trivy/melange.yaml)
 COSIGN_VERSION ?= $(call melange_version,cosign/melange.yaml)
+SYFT_VERSION ?= $(call melange_version,syft/melange.yaml)
+GRYPE_VERSION ?= $(call melange_version,grype/melange.yaml)
 
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
@@ -147,6 +149,8 @@ endef
 .PHONY: opentofu opentofu-melange test-opentofu
 .PHONY: trivy trivy-melange test-trivy
 .PHONY: cosign cosign-melange test-cosign
+.PHONY: syft syft-melange test-syft
+.PHONY: grype grype-melange test-grype
 .PHONY: thanos thanos-melange test-thanos
 .PHONY: node-exporter node-exporter-melange test-node-exporter
 .PHONY: blackbox-exporter blackbox-exporter-melange test-blackbox-exporter
@@ -1485,6 +1489,58 @@ cosign: cosign-melange
 	@echo "✓ minimal-cosign built (source build)"
 
 #------------------------------------------------------------------------------
+# SYFT IMAGE (melange Go source build + apko; SBOM generation)
+#------------------------------------------------------------------------------
+syft-melange: keygen
+	@echo "Building Syft $(SYFT_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build syft/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Syft package built from source"
+
+syft: syft-melange
+	@echo "Assembling minimal-syft image with apko..."
+	apko build syft/apko/syft.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-syft:$(VERSION) \
+		syft.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < syft.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-syft:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-syft:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-syft:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-syft:latest
+	@rm -f syft.tar sbom-*.spdx.json
+	@echo "✓ minimal-syft built (source build)"
+
+#------------------------------------------------------------------------------
+# GRYPE IMAGE (melange Go source build + apko; vulnerability scanning)
+#------------------------------------------------------------------------------
+grype-melange: keygen
+	@echo "Building Grype $(GRYPE_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build grype/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Grype package built from source"
+
+grype: grype-melange
+	@echo "Assembling minimal-grype image with apko..."
+	apko build grype/apko/grype.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-grype:$(VERSION) \
+		grype.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < grype.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-grype:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-grype:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-grype:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-grype:latest
+	@rm -f grype.tar sbom-*.spdx.json
+	@echo "✓ minimal-grype built (source build)"
+
+#------------------------------------------------------------------------------
 # THANOS IMAGE (melange Go source build + apko; HA Prometheus long-term storage)
 #------------------------------------------------------------------------------
 thanos-melange: keygen
@@ -2331,6 +2387,18 @@ test-cosign:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-cosign:latest" && \
 		cosign/test.sh
 	@echo "✓ cosign tests passed"
+
+test-syft:
+	@echo "Testing syft image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-syft:latest" && \
+		syft/test.sh
+	@echo "✓ syft tests passed"
+
+test-grype:
+	@echo "Testing grype image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-grype:latest" && \
+		grype/test.sh
+	@echo "✓ grype tests passed"
 
 test-thanos:
 	@echo "Testing thanos image..."

--- a/catalog.json
+++ b/catalog.json
@@ -71,6 +71,9 @@
     { "name": "kubectl", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "kubectl", "upstream_url": "https://kubernetes.io/docs/reference/kubectl/", "summary": "Shell-less kubectl CLI built from source via melange." },
     { "name": "opentofu", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "opentofu", "upstream_url": "https://opentofu.org", "summary": "Shell-less OpenTofu (Terraform-compatible IaC) built from source via melange." },
     { "name": "trivy", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "trivy", "upstream_url": "https://trivy.dev", "summary": "Shell-less Trivy vulnerability, IaC and secret scanner." },
+    { "name": "cosign", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "cosign", "upstream_url": "https://www.sigstore.dev", "summary": "Shell-less Sigstore Cosign container signing & verification, built from source via melange." },
+    { "name": "syft", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "syft", "upstream_url": "https://github.com/anchore/syft", "summary": "Shell-less Syft SBOM generator, built from source via melange." },
+    { "name": "grype", "category": "Kubernetes, CI & IaC", "variants": ["prod", "dev"], "primary_package": "grype", "upstream_url": "https://github.com/anchore/grype", "summary": "Shell-less Grype vulnerability scanner, built from source via melange." },
 
     { "name": "jenkins", "category": "Apps", "variants": ["prod", "dev"], "primary_package": "jenkins", "upstream_url": "https://www.jenkins.io", "summary": "Shell-less Jenkins with jlink custom JRE, built from source via melange." },
     { "name": "gitea", "category": "Apps", "variants": ["prod", "dev"], "primary_package": "gitea", "upstream_url": "https://gitea.io", "summary": "Gitea git hosting built from source via melange." },

--- a/cosign/apko/cosign-dev.yaml
+++ b/cosign/apko/cosign-dev.yaml
@@ -1,0 +1,64 @@
+# Development variant of minimal-cosign.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - cosign-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/cosign
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-cosign-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-cosign: same cosign + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/cosign"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/cosign/apko/cosign.yaml
+++ b/cosign/apko/cosign.yaml
@@ -1,0 +1,58 @@
+# Minimal Cosign image - container signing/verification, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - cosign-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/cosign
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/bin:/bin
+  # cosign caches the Sigstore TUF root under $HOME/.sigstore; nonroot has no
+  # home dir, so point HOME at a writable location.
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-cosign"
+  org.opencontainers.image.description: "Hardened shell-less Sigstore Cosign (container signing & verification) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/cosign"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/cosign/melange.yaml
+++ b/cosign/melange.yaml
@@ -1,0 +1,81 @@
+# Melange build configuration for minimal Cosign
+# Pure Go from source. Single static `cosign` binary (container signing/verify).
+# License: Apache-2.0 (Sigstore authors).
+
+package:
+  name: cosign-minimal
+  version: 3.1.1
+  epoch: 0
+  description: "Minimal Sigstore Cosign (container signing & verification) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of cosign source tarball - updated by update-versions.yml workflow
+  sha256: 2b44374321cd19b0eb27026ee16e519393139edd7ffe01860c2d78d6084c68eb
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify cosign source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/sigstore/cosign/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/cosign.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/cosign.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf cosign.tar.gz
+      rm cosign.tar.gz
+
+  # Version is reported via sigs.k8s.io/release-utils/version.gitVersion.
+  # CGO_ENABLED=0 gives a static binary; the pivkey/pkcs11key build tags
+  # (hardware token support) are intentionally omitted — they require CGO and
+  # are not needed for the core sign/verify/attest workflows.
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/cosign-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+  - runs: |
+      cd /home/build/cosign-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= \
+          -X sigs.k8s.io/release-utils/version.gitVersion=v${{package.version}} \
+          -X sigs.k8s.io/release-utils/version.gitTreeState=clean \
+          -X sigs.k8s.io/release-utils/version.buildDate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        -o /home/build/cosign-bin \
+        ./cmd/cosign
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/cosign-bin "${{targets.destdir}}/usr/bin/cosign"
+      chmod 0755 "${{targets.destdir}}/usr/bin/cosign"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying cosign binary..."
+      "${{targets.destdir}}/usr/bin/cosign" version

--- a/cosign/test-dev.sh
+++ b/cosign/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-cosign-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing cosign version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/cosign "$IMAGE" version 2>&1 | grep -qiE 'GitVersion:[[:space:]]*v?3\.[0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All cosign-dev smoke tests passed"

--- a/cosign/test.sh
+++ b/cosign/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing cosign version..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qiE 'GitVersion:[[:space:]]*v?3\.[0-9]'
+
+echo "Testing cosign help (subcommands load)..."
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'sign|verify|attest'
+
+echo "Testing cosign generate-key-pair (fully offline)..."
+work=$(mktemp -d); chmod 0777 "$work"
+# nonroot (65532) writes the key pair into the bind-mounted workdir; the dir
+# must be world-writable for that to succeed. COSIGN_PASSWORD makes it non-interactive.
+docker run --rm -e COSIGN_PASSWORD=testpassword -v "$work:/workspace" "$IMAGE" generate-key-pair
+if [ -f "$work/cosign.pub" ] && grep -q 'PUBLIC KEY' "$work/cosign.pub"; then
+  echo "cosign generate-key-pair OK"
+else
+  echo "FAIL: cosign did not produce a valid public key"
+  ls -la "$work"; rm -rf "$work"; exit 1
+fi
+rm -rf "$work"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All cosign tests passed!"

--- a/grype/apko/grype-dev.yaml
+++ b/grype/apko/grype-dev.yaml
@@ -1,0 +1,64 @@
+# Development variant of minimal-grype.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - grype-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/grype
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-grype-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-grype: same grype + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/grype"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/grype/apko/grype.yaml
+++ b/grype/apko/grype.yaml
@@ -1,0 +1,58 @@
+# Minimal Grype image - vulnerability scanning, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - grype-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/grype
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/bin:/bin
+  # grype caches its vuln DB under $HOME/.cache/grype; nonroot has no home dir,
+  # so point HOME at a writable location.
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-grype"
+  org.opencontainers.image.description: "Hardened shell-less Grype (vulnerability scanner) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/grype"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/grype/melange.yaml
+++ b/grype/melange.yaml
@@ -1,0 +1,75 @@
+# Melange build configuration for minimal Grype
+# Pure Go from source. Single static `grype` binary (vulnerability scanning).
+# License: Apache-2.0 (Anchore).
+
+package:
+  name: grype-minimal
+  version: 0.115.0
+  epoch: 0
+  description: "Minimal Grype (vulnerability scanner for images & filesystems) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of grype source tarball - updated by update-versions.yml workflow
+  sha256: 146d944636f0d6ebfe21a1287306ef742a2d495e5cf629c1bbd47b7515164165
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify grype source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/anchore/grype/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/grype.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/grype.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf grype.tar.gz
+      rm grype.tar.gz
+
+  # Version is reported via main.version (matches upstream .goreleaser.yaml).
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/grype-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+  - runs: |
+      cd /home/build/grype-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -X main.version=${{package.version}}" \
+        -o /home/build/grype-bin \
+        ./cmd/grype
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/grype-bin "${{targets.destdir}}/usr/bin/grype"
+      chmod 0755 "${{targets.destdir}}/usr/bin/grype"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying grype binary..."
+      "${{targets.destdir}}/usr/bin/grype" version

--- a/grype/test-dev.sh
+++ b/grype/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-grype-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing grype version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/grype "$IMAGE" version 2>&1 | grep -qiE 'Version:[[:space:]]*v?0\.[0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All grype-dev smoke tests passed"

--- a/grype/test.sh
+++ b/grype/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing grype version..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qiE 'Version:[[:space:]]*v?0\.[0-9]'
+
+echo "Testing grype help..."
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'vulnerabilit|scan|db'
+
+# NB: an actual grype scan requires downloading the vuln DB (network), so it is
+# not part of this hermetic smoke test. `grype db status` runs offline and must
+# print DB status text (exit code is non-zero when no DB is installed, which is
+# expected in a fresh image — we only assert it produces the status line).
+echo "Testing grype db status (offline)..."
+docker run --rm "$IMAGE" db status 2>&1 | grep -qiE 'status|location|database' \
+  || { echo "FAIL: grype db status produced no status output"; exit 1; }
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All grype tests passed!"

--- a/syft/apko/syft-dev.yaml
+++ b/syft/apko/syft-dev.yaml
@@ -1,0 +1,64 @@
+# Development variant of minimal-syft.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - syft-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/syft
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-syft-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-syft: same syft + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/syft"
+  org.opencontainers.image.licenses: "Apache-2.0"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/syft/apko/syft.yaml
+++ b/syft/apko/syft.yaml
@@ -1,0 +1,58 @@
+# Minimal Syft image - SBOM generation, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - syft-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/syft
+
+work-dir: /workspace
+
+environment:
+  PATH: /usr/bin:/bin
+  # syft caches under $HOME/.cache; nonroot has no home dir, so point HOME at
+  # a writable location.
+  HOME: /tmp
+
+paths:
+  - path: /workspace
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-syft"
+  org.opencontainers.image.description: "Hardened shell-less Syft (SBOM generation) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/syft"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/syft/melange.yaml
+++ b/syft/melange.yaml
@@ -1,0 +1,75 @@
+# Melange build configuration for minimal Syft
+# Pure Go from source. Single static `syft` binary (SBOM generation).
+# License: Apache-2.0 (Anchore).
+
+package:
+  name: syft-minimal
+  version: 1.46.0
+  epoch: 0
+  description: "Minimal Syft (SBOM generation from images & filesystems) built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of syft source tarball - updated by update-versions.yml workflow
+  sha256: 5545ff8d797fc14d27ae23608ec271609c9038e1732ec13d4ba8042ef542f0ea
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify syft source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/anchore/syft/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/syft.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/syft.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf syft.tar.gz
+      rm syft.tar.gz
+
+  # Version is reported via main.version (matches upstream .goreleaser.yaml).
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/syft-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && _retry go get golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/sys@v0.46.0 golang.org/x/text@v0.38.0 golang.org/x/term@v0.44.0 golang.org/x/time@v0.15.0 golang.org/x/sync@v0.21.0 golang.org/x/tools@v0.47.0 \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+  - runs: |
+      cd /home/build/syft-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -X main.version=${{package.version}}" \
+        -o /home/build/syft-bin \
+        ./cmd/syft
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/syft-bin "${{targets.destdir}}/usr/bin/syft"
+      chmod 0755 "${{targets.destdir}}/usr/bin/syft"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying syft binary..."
+      "${{targets.destdir}}/usr/bin/syft" version

--- a/syft/test-dev.sh
+++ b/syft/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-syft-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing syft version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/syft "$IMAGE" version 2>&1 | grep -qiE 'Version:[[:space:]]*v?1\.[0-9]'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All syft-dev smoke tests passed"

--- a/syft/test.sh
+++ b/syft/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing syft version..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qiE 'Version:[[:space:]]*v?1\.[0-9]'
+
+echo "Testing syft help..."
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'scan|packages|sbom'
+
+echo "Testing syft scan (fully offline, catalogs its own binary)..."
+# syft cataloging a local Go binary needs no network; the binary embeds its
+# module graph, so the SBOM must contain an artifacts array.
+docker run --rm "$IMAGE" scan file:/usr/bin/syft -o json 2>/dev/null | grep -q '"artifacts"'
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All syft tests passed!"

--- a/vex/cosign.openvex.json
+++ b/vex/cosign.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/cosign",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/grype.openvex.json
+++ b/vex/grype.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/grype",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/syft.openvex.json
+++ b/vex/syft.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/syft",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Free hardened, source-built versions of the tools people use to **verify** hardened images — the strongest narrative fit for this catalog. All Apache-2.0 🟢, pure-Go static, distroless/shell-less, nonroot 65532.

Built incrementally on this branch; each image built + smoke-tested locally (`make <x>-melange && make <x> && make test-<x>`) before its commit, per CLAUDE.md.

### cosign (Sigstore) — `v3.1.1` ✅
- CGO_ENABLED=0 static, `release-utils/version` ldflags; pivkey/pkcs11 tags omitted (need CGO).
- Test: `version` + `--help` + **offline `generate-key-pair` round-trip** + no-shell.
- All 8 onboarding points incl. `patch-go-deps.yml` (module `github.com/sigstore/cosign/v3`) and `vex/`.

### syft (Anchore) — `v1.46.0` — _adding_
### grype (Anchore) — `v0.115.0` — _adding_

All `versions.yaml` rows are **cron-disabled** pending per-image dispatch checks.