### PR TITLE
fix(patch-go-deps): skip incompatible rardecode bump for gitleaks

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -387,6 +387,20 @@ jobs:
                 fi
                 echo "  Telegraf v${TG_VER} no longer references rclone fs.LogOutput — letting bump $mod_ver proceed"
               fi
+              # gitleaks 8.30.x pins mholt/archives v0.1.2, whose rar.go targets
+              # the old rardecode/v2 (<=v2.1.x) reader interface. grype flags a
+              # rardecode CVE fixed in v2.2.0, but v2.2.0 changed that interface
+              # (added WriteTo), so bumping rardecode alone fails `go build` with
+              # "*rardecode.ReadCloser does not implement rarReader (missing
+              # method WriteTo)" (PR #364). mholt/archives v0.1.5 is the release
+              # built against rardecode v2.2.0 — so the clean fix arrives
+              # automatically once gitleaks upstream adopts archives >=v0.1.5
+              # (which pulls rardecode v2.2.0 itself). Until then, skip the lone
+              # rardecode bump. Matches Chainguard's own pin for this pair.
+              if [ "$IMAGE" = "gitleaks" ] && [[ "$mod_ver" == github.com/nwaples/rardecode/v2@* ]]; then
+                echo "  Skipping incompatible gitleaks module bump: $mod_ver (mholt/archives v0.1.2 needs rardecode <=v2.1.x; resolves when gitleaks adopts archives >=v0.1.5)"
+                continue
+              fi
               # Apply +incompatible suffix for known modules that need it.
               mod_path="${mod_ver%@*}"
               for incompat in "${INCOMPAT_MODULES[@]}"; do


### PR DESCRIPTION
## Problem
The scheduled `patch-go-deps` bot opened #364 and bumped `github.com/nwaples/rardecode/v2` v2.1.0 → **v2.2.0** (grype-flagged CVE). But gitleaks 8.30.x pins `mholt/archives v0.1.2`, whose `rar.go` targets the **pre-v2.2.0** rardecode reader interface. v2.2.0 added `WriteTo`, so the standalone bump fails the build:

```
mholt/archives@v0.1.2/rar.go: cannot use *rardecode.ReadCloser as rarReader
  value ... does not implement rarReader (missing method WriteTo)
```

That reddened **#364**, which also blocked **oras's** clean patch bundled in the same PR.

## Why a skip (not a co-bump)
`mholt/archives v0.1.5` is the release wired to `rardecode/v2 v2.2.0` (its go.mod requires it; its rar.go uses the new interface). So the fix arrives **automatically** the moment gitleaks upstream adopts `archives ≥ v0.1.5` — which pulls rardecode v2.2.0 itself, making the bump a no-op. Until then we skip the lone bump, exactly like the existing per-image guards for **telegraf/rclone**, **loki|thanos/prometheus**, and **trivy/docker-cli**. Matches Chainguard's own pin for this pair.

## Effect
Once merged, the next scheduled `patch-go-deps` run regenerates the `patch-go-deps` branch (#364) **without** the rardecode line → it builds green and its oras + gitleaks `x/*` patches can merge.

Workflow-only change; no image build inputs touched.