### PR TITLE
docs: authoritative image onboarding standard (docs/onboarding.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,27 @@ Install the following tools locally:
 
 ## Adding a New Image
 
-Adding an image is mechanical. The work splits across 3–5 files depending on
-how much automation you want:
+> **📋 The complete, authoritative checklist is [`docs/onboarding.md`](docs/onboarding.md).**
+> This section is a quick intro; that file is the source of truth and covers every
+> registration point (including the CI-enforced ones — `catalog.json` and `vex/` —
+> and the build/test patterns, versions.yaml conventions, and gotchas). Onboard
+> from the checklist, not from memory: two past incidents (the "frozen-8" and the
+> catalog-drift PR failure) were skipped-step bugs.
+
+Adding an image is mechanical. Every registration point:
 
 | File | When you need it |
 |---|---|
-| `<name>/apko/<name>.yaml` + `<name>/test.sh` | always |
-| `<name>/melange.yaml` | only when building from source (rare — try Wolfi first) |
-| Build-list entry in `.github/workflows/build.yml` | always |
-| Row in `.github/versions.yaml` | if you want CI to auto-open PRs for new upstream releases |
-| Row in `.github/patch-deps.yaml` | if your image has Ruby/Rust/Maven deps and you want auto-CVE patches |
-| `<name>/apko/<name>-dev.yaml` | recommended — see [dev variant conventions](docs/dev-variants/CONVENTIONS.md) |
+| `<name>/apko/<name>.yaml` + `<name>/test.sh` (`chmod +x`) | always |
+| `<name>/apko/<name>-dev.yaml` + `<name>/test-dev.sh` | recommended — see [dev variant conventions](docs/dev-variants/CONVENTIONS.md) |
+| `vex/<name>.openvex.json` | always (CI-validated) |
+| Entry in `.github/workflows/build.yml` matrix | always (CI-enforced) |
+| Entry in `catalog.json` | always — **`validate-catalog` fails the PR without it** |
+| `Makefile` version var + `.PHONY` + build/test targets | always |
+| `<name>/melange.yaml` | only when building from source (try Wolfi first) |
+| Row in `.github/versions.yaml` | source-built — to auto-bump the app version |
+| Three dicts in `.github/workflows/patch-go-deps.yml`, **or** `SKIP_IMAGES` | source-built **Go** — transitive CVE patching (or a documented exclusion) |
+| Row in `.github/patch-deps.yaml` | source-built Ruby/Rust/Maven |
 
 ### 1. Create the directory structure
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -370,10 +370,10 @@ image to `SKIP_IMAGES` instead** and build from pure upstream source (no patch
 block). It stays current via its §9 version bump (upstream bumps their own deps
 each release) + the base rebuild; reachable gap CVEs get a **manual** targeted bump
 or a **VEX** `not_affected`. This mirrors Wolfi's own `HOW_TO_PATCH_CVES.md`
-("hand-resolve tangled graphs locally") and Chainguard's practice. See
-[`project` memory / this decision on PR #383]. Note: `patch-go-deps` opens **one
-shared PR** — one image's build failure blocks every image's patches, so a tangled
-graph left in the bot poisons the whole batch.
+("hand-resolve tangled graphs locally") and Chainguard's practice (trivy was moved
+to this model in PR #383). Note: `patch-go-deps` opens **one shared PR** — one
+image's build failure blocks every image's patches, so a tangled graph left in the
+bot poisons the whole batch.
 
 ### Ruby / Rust / Maven images — `.github/patch-deps.yaml`
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,423 @@
+# Image Onboarding Standard
+
+The authoritative, complete checklist for adding a new hardened image. If you
+follow this end to end, your image will build on both arches, pass CI, auto-update
+its version, get its transitive CVEs patched (or be a documented exception), and
+appear on the catalog site — with nothing silently skipped.
+
+> `CONTRIBUTING.md` is the friendly intro. **This file is the source of truth.**
+> When they disagree, this file wins. Two related deep-dives:
+> [`version-management.md`](version-management.md) (the two-loop update model) and
+> [`dev-variants/CONVENTIONS.md`](dev-variants/CONVENTIONS.md) (the `-dev` image).
+
+---
+
+## 0. The prime directive — never push a failing image
+
+Any change touching an image's `melange.yaml`, `apko/*.yaml`, `test*.sh`, or its
+Makefile targets **MUST** be built and tested locally before commit/push:
+
+```
+make <name>-melange   # only if the image has a melange.yaml
+make <name>           # assembles the apko image
+make test-<name>      # runs the per-image smoke test
+```
+
+If any step fails, fix the root cause and re-run. Do **not** rely on CI to find
+breakage a one-line `make` would have caught, and do **not** disable a failing
+test to go green. A red build on `main` blocks the every-6h scheduled rebuild for
+**every** image. (Exceptions: pure docs and workflow-only changes that don't
+affect any image's build inputs.)
+
+Local `make <name>-melange` builds **x86_64 only**. The aarch64 build runs on CI's
+native ARM runners. Some builds (jlink JREs, QEMU-less cross-compiles) *only* work
+on x86_64 locally — that's expected; CI covers ARM.
+
+---
+
+## 1. Pick the image type
+
+| Type | You write | Version tracked by | Example |
+|---|---|---|---|
+| **apko-only** (preferred) | assembles a Wolfi pre-built apk | Wolfi (via 6-hourly rebuild) | `httpd`, `nginx`, `go`, `python` |
+| **source-built** | compiles from upstream source via melange | `versions.yaml` row | `cosign`, `kafka`, `trivy` |
+
+**Try apko-only first.** Only build from source when Wolfi doesn't ship the
+package, or you need a version/build Wolfi doesn't provide. Source-built images
+carry more registration and maintenance (everything in §2 below).
+
+---
+
+## 2. The complete registration checklist
+
+Tick every box. The ones marked **⛔ CI-enforced** will fail your PR if missing.
+
+### Files to create
+
+- [ ] `<name>/apko/<name>.yaml` — production image (§3)
+- [ ] `<name>/apko/<name>-dev.yaml` — dev variant ([conventions](dev-variants/CONVENTIONS.md))
+- [ ] `<name>/test.sh` — prod smoke test, **`chmod +x`** (§5)
+- [ ] `<name>/test-dev.sh` — dev smoke test, **`chmod +x`**
+- [ ] `vex/<name>.openvex.json` — VEX statements file (§8) — every image has one
+- [ ] `<name>/melange.yaml` — **source-built only** (§4)
+
+### Files to edit (register the image)
+
+- [ ] **`Makefile`** — version var + `.PHONY` + build/test targets (§6)
+- [ ] **`.github/workflows/build.yml`** — add to `MELANGE_IMAGES` or `APKO_IMAGES` (§7) **⛔**
+- [ ] **`catalog.json`** — one entry (§7) **⛔ validate-catalog fails the PR without it**
+- [ ] **`.github/versions.yaml`** — auto-bump row — **source-built only** (§9)
+- [ ] **transitive-dep patching** — source-built only (§10):
+      Go → three dicts in `patch-go-deps.yml` **or** add to `SKIP_IMAGES`;
+      Ruby/Rust/Maven → `.github/patch-deps.yaml`
+
+> **Why the checklist matters:** the "frozen-8" incident (8 source-built images
+> silently never getting version updates) and the #355 catalog-drift failure both
+> happened because a registration point was skipped from memory. Don't onboard
+> from memory — onboard from this list.
+
+---
+
+## 3. The apko config (`<name>/apko/<name>.yaml`)
+
+Model on an existing image (`python/apko/python.yaml`, or `cosign/apko/cosign.yaml`
+for a source-built one). Required shape:
+
+```yaml
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - wolfi-baselayout
+    - <name>-minimal          # source-built: your melange package. apko-only: the Wolfi apk.
+    - ca-certificates-bundle  # always, for TLS
+
+accounts:
+  groups: [{ groupname: nonroot, gid: 65532 }]
+  users:  [{ username: nonroot, uid: 65532, gid: 65532 }]
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/<binary>
+
+work-dir: /workspace            # or /app; use a writable dir the app needs
+environment:
+  PATH: /usr/bin:/bin
+  # If the tool writes cache/config under $HOME and nonroot has none, set HOME=/tmp
+  HOME: /tmp
+
+paths:
+  - { path: /workspace, type: directory, uid: 65532, gid: 65532, permissions: 0o755 }
+  - { path: /tmp, type: directory, uid: 65532, gid: 65532, permissions: 0o1777 }
+
+annotations:
+  org.opencontainers.image.title: "minimal-<name>"
+  org.opencontainers.image.description: "Hardened shell-less <Name> ..."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/<name>"
+  org.opencontainers.image.licenses: "<SPDX id>"
+
+archs: [x86_64, aarch64]
+```
+
+**Rules**
+- Minimum packages. Fewer packages = fewer CVEs.
+- No shell in prod (no `busybox`/`bash`) unless the service genuinely needs it.
+- `run-as: 65532` (nonroot) unless upstream mandates a fixed UID.
+- Create `/var/*` runtime dirs here with `paths:`, **not** in the melange pipeline
+  (the SBOM step runs as the host user after the sandbox exits and can't mkdir into
+  the root-owned destdir).
+
+The `-dev.yaml` adds a shell + debugging tools (`busybox bash curl openssl
+bind-tools jq git …`) on top of the same package. See the dev-variant conventions.
+
+---
+
+## 4. The melange source build (`<name>/melange.yaml`)
+
+Model on `cosign/melange.yaml` (Go) or `mosquitto/melange.yaml` (C). Skeleton:
+
+```yaml
+package:
+  name: <name>-minimal
+  version: X.Y.Z
+  epoch: 0
+  copyright: [{ license: <SPDX id> }]
+
+vars:
+  sha256: <tarball sha256>     # updated by update-versions.yml
+
+environment:
+  contents:
+    packages: [busybox, ca-certificates-bundle, curl, build-base, go, git]  # go: for Go apps
+
+pipeline:
+  - runs: |                    # download + verify + extract
+      mkdir -p /home/build/<name>-${{package.version}}
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/<owner>/<repo>/archive/refs/tags/v${{package.version}}.tar.gz" -o /home/build/src.tgz
+      echo "${{vars.sha256}}  /home/build/src.tgz" | sha256sum -c -
+      tar xzf /home/build/src.tgz -C /home/build/<name>-${{package.version}} --strip-components=1
+```
+
+### Go build pattern (static, shell-less)
+
+```bash
+cd /home/build/<name>-${{package.version}}
+GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+  -trimpath \
+  -ldflags="-s -w -buildid= -X <version-var-path>=${{package.version}}" \
+  -o /home/build/<name>-bin \
+  ./cmd/<name>
+```
+
+- `CGO_ENABLED=0` → static binary, no glibc/shell dependency.
+- Find `<version-var-path>` from upstream's `.goreleaser.yml`/Makefile `-X` flag
+  (e.g. `main.Version`, `github.com/.../version.Version`). Wrong path = empty
+  version string (your test's version grep will catch it).
+- Some projects need extra flags: `GOEXPERIMENT=jsonv2` (trivy: `encoding/json/v2`),
+  build tags, etc. Match upstream's release build.
+
+### melange gotchas (each cost a debugging session)
+
+- **`--strip-components=1` into a name you control** when the archive's top-level
+  dir ≠ image name. The dir is `<reponame>-<version>` — e.g. `smallstep/cli` →
+  `cli-0.30.6`, not `step-cli-0.30.6`. Normalise it so `MODROOT` is predictable.
+- **Relative symlinks only** in the destdir (`ln -sf ../lib/.../java`, not an
+  absolute path) — absolute symlinks are dangling during the melange verify step.
+- **C apps: disable optional features that pull dev deps.** Un-freezing a C app
+  across a minor bump often adds build deps. mosquitto 2.1 turned on `WITH_EDITLINE`
+  (→ editline), `WITH_HTTP_API` (→ libmicrohttpd), `WITH_SQLITE` (→ sqlite3); all
+  disabled with `=no` for a minimal broker. Read the new version's `config.mk`.
+
+---
+
+## 5. The smoke tests (`test.sh`, `test-dev.sh`)
+
+```bash
+#!/bin/bash
+set -eu     # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing <name> version...";  docker run --rm "$IMAGE" version 2>&1 | grep -qiE 'X\.Y'
+echo "Testing <name> help...";     docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'sub|commands'
+echo "Testing <name> offline...";  # an image-specific functional check that needs NO network
+echo "Verifying no shell...";      docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo x" 2>/dev/null \
+  && echo "FAIL: shell found" && exit 1 || echo "No shell (as expected)"
+echo "All <name> tests passed!"
+```
+
+Every test must cover: **version**, **help/subcommands load**, **one offline
+functional check** (proves the binary actually works — cosign generates a keypair,
+opa evaluates `1+1`, gitleaks scans a clean dir, mosquitto does a pub/sub
+round-trip), and **no-shell**.
+
+### test gotchas
+
+- **`chmod +x test.sh test-dev.sh`** — else `make test-<name>` dies with `Permission denied`.
+- **Bind-mounted workdirs must be world-writable.** The container runs as uid
+  65532; `mktemp -d` is 0700-owned-by-you, so the container can't write. Do
+  `work=$(mktemp -d); chmod 0777 "$work"` before `-v "$work:/workspace"`.
+- **Files the container writes are owned by 65532**, often `0600`, so the host
+  user can't read them. Verify with `[ -s "$work/out" ]` (stat, needs only the
+  0777 dir), **not** `grep` (needs read). (cosign's pubkey happens to be 0644, so
+  its grep works; step-cli's keypair is 0600, so use `-s`.)
+
+---
+
+## 6. Makefile registration
+
+```makefile
+# version var (top of file, near the other *_VERSION lines)
+<NAME>_VERSION ?= $(call melange_version,<name>/melange.yaml)
+
+# .PHONY (with the other .PHONY lines)
+.PHONY: <name> <name>-melange test-<name>
+
+# build targets — copy an existing source-built block (e.g. cosign) verbatim,
+# renaming: <name>-melange (melange build), <name> (apko assemble + docker load + tag)
+# test target
+test-<name>:
+	@export IMAGE="$(REGISTRY)/$(OWNER)/minimal-<name>:latest" && <name>/test.sh
+```
+
+apko-only images skip the `-melange` target (there's no melange build).
+
+---
+
+## 7. build.yml matrix + catalog.json (both CI-enforced together)
+
+`validate-catalog` asserts **`catalog.json` names == the build.yml matrix names,
+exactly**. Add to both or the PR fails fast.
+
+**build.yml** — one line in the right JSON array inside the *Detect changes* step:
+
+```jsonc
+// source-built:
+MELANGE_IMAGES='[ ... {"name":"<name>","variants":["prod","dev"]} ]'
+// apko-only (the "grep" is the Wolfi apk-name regex that triggers a rebuild):
+APKO_IMAGES='[ ... {"name":"<name>","grep":"<apk-name>","variants":["prod","dev"]} ]'
+```
+Add `"apko":"<path>"` if the config isn't at `<name>/apko/<name>.yaml`; drop `dev`
+if there's no `-dev.yaml`.
+
+**catalog.json** — one object in `.images` (single-line style, match neighbours):
+
+```jsonc
+{ "name":"<name>", "category":"<one of the categories below>", "variants":["prod","dev"],
+  "primary_package":"<name>", "upstream_url":"https://...", "summary":"Shell-less <Name> ..." }
+```
+Valid `category` values (must match exactly):
+`Languages & Runtimes` · `Databases` · `Caches, Queues & Messaging` ·
+`Web Servers & Proxies` · `Observability` · `Infrastructure` ·
+`Kubernetes, CI & IaC` · `Apps`.
+
+---
+
+## 8. VEX (`vex/<name>.openvex.json`)
+
+Every image gets one. Start empty:
+
+```json
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/<name>",
+  "author": "rtvkiz",
+  "timestamp": "<UTC ISO8601>",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}
+```
+
+VEX is how we tell scanners a reported CVE **doesn't apply** (`not_affected`,
+justification e.g. `vulnerable_code_not_present`) — this is Chainguard's own
+first-class alternative to force-patching (see §10). Use it for false-positives
+and unreachable CVEs. Tooling: `tools/vex/{validate,reconcile}.sh`.
+
+---
+
+## 9. versions.yaml auto-bump (source-built only)
+
+The `update-versions.yml` cron advances the **app version** (see
+[version-management.md](version-management.md) for the full two-loop model). Add a
+row. Full schema + examples are at the top of `.github/versions.yaml`.
+
+```yaml
+- name: <name>
+  # cron-enabled: true          # ← add ONLY after the dispatch check below passes
+  files: [<name>/melange.yaml]
+  source: { type: github-releases-latest, repo: <owner>/<repo>, strip-v: true, pin-major: <N> }
+  tarball: { url: "https://github.com/<owner>/<repo>/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/<owner>/<repo>/releases"
+    notes:    "https://github.com/<owner>/<repo>/releases/tag/v{version}"
+```
+
+### conventions & gotchas
+
+- **`pin-major`** locks the loop to minor/patch within that major. A new upstream
+  major does **not** auto-bump — with `major-issue: true` it opens an issue for a
+  human. (Majors can rename flags/config/entrypoints — always a human decision.)
+- **`github-releases-latest`** for a clean single "latest" release. **`github-tags`**
+  (with a `pattern:` and `strip-prefix:`) when releases are messy — e.g. `helm`
+  (Helm 4 shipped, so pin `^v3\.` via tags), `mimir` (real tags buried under chart
+  tags — use releases-latest + `strip-prefix: mimir-`).
+- **Use the canonical repo, not a redirect.** The resolver's raw curl does **not**
+  follow GitHub's 301 for renamed repos. `eclipse/mosquitto` → use
+  `eclipse-mosquitto/mosquitto`. Symptom of getting this wrong: `jq: Cannot index
+  string with string "name"`.
+- **Non-github tarball?** Point `tarball.url` at the real host (mosquitto builds
+  from `mosquitto.org/files/source/...`, not the GitHub archive).
+
+### Safe rollout (mandatory two-step)
+
+A new row ships **cron-disabled**. Then:
+
+```bash
+gh workflow run update-versions.yml -f only=<name>   # ignores the cron gate
+```
+Confirm it produces a correct PR (or a clean "no update"). **Only then** add
+`cron-enabled: true`. Why: update-versions PRs **auto-merge**, and a wrong row
+would auto-merge a bad bump to `main` and stall the whole fleet. Never enable an
+unvalidated row.
+
+---
+
+## 10. Transitive-dep CVE patching (source-built only)
+
+### Go images — `patch-go-deps.yml`
+
+Add the image to **three** bash assoc-arrays in the *Scan … and generate patches*
+step, or it silently accrues unpatched CVEs forever (this is how alertmanager
+shipped 24 crit/high CVEs):
+
+```bash
+MODROOTS=(     [<name>]="/home/build/<archive-dir>-${D}{{package.version}}" )   # space-sep multiple modules for monorepos
+MAIN_MODULES=( [<name>]="<the image's OWN module path>" )                        # so it doesn't try to go-get itself
+BUILD_MARKERS=([<name>]='<a literal string from your melange build step>' )     # patch block spliced before it
+```
+Then `gh workflow run patch-go-deps.yml` once to validate the splice.
+
+**When NOT to register — huge tangled graphs.** If the dependency graph is large
+and tightly coupled (trivy: buildkit/containerd/rclone/sigstore/aws-sdk…), grype
+flags ~20 transitive CVEs at once and pinning them to exact fix versions fights
+Go's MVS into cascading conflicts that no resolver reliably untangles. **Add the
+image to `SKIP_IMAGES` instead** and build from pure upstream source (no patch
+block). It stays current via its §9 version bump (upstream bumps their own deps
+each release) + the base rebuild; reachable gap CVEs get a **manual** targeted bump
+or a **VEX** `not_affected`. This mirrors Wolfi's own `HOW_TO_PATCH_CVES.md`
+("hand-resolve tangled graphs locally") and Chainguard's practice. See
+[`project` memory / this decision on PR #383]. Note: `patch-go-deps` opens **one
+shared PR** — one image's build failure blocks every image's patches, so a tangled
+graph left in the bot poisons the whole batch.
+
+### Ruby / Rust / Maven images — `.github/patch-deps.yaml`
+
+Add an entry under the matching language row (`bundler` / `rust` / `maven`) with
+`{ name, src-root, build-marker }`. Simpler declarative schema than the Go workflow.
+
+---
+
+## 11. License policy
+
+Record the SPDX id in `melange.yaml` `copyright:` and the apko
+`org.opencontainers.image.licenses`. Tiers:
+
+- 🟢 **Permissive** (MIT, BSD, Apache-2.0, MPL-2.0, EPL-2.0) — add freely.
+- 🟡 **Copyleft, OSI-approved** (GPL, LGPL, AGPL) — allowed; precedent: loki, tempo,
+  mimir, minio (AGPL).
+- 🔴 **Source-available, non-open** (SSPL, BUSL, Elastic, RSAL, vendor EULA) —
+  **avoid**, or use a permissive fork. Existing 🔴 exposures are tracked for
+  resolution (redis SSPL→AGPL redeclare, consul BUSL, cuda-python EULA).
+
+---
+
+## 12. Pre-push checklist & the CI gates that will catch you
+
+Before you push (source-built):
+
+```bash
+make <name>-melange && make <name> && make test-<name>   # §0 — must all pass
+python3 -c "import json; json.load(open('catalog.json'))" # valid JSON
+ruby -ryaml -e "YAML.load_file('.github/versions.yaml')"  # valid YAML
+```
+
+CI will independently enforce:
+
+| Check | Fails when |
+|---|---|
+| `validate-catalog` | `catalog.json` ≠ build matrix |
+| `melange-build` / `build-apko` (both arches) | the image doesn't build or its test fails |
+| gitleaks (pre-commit + CI) | a secret is committed |
+| VEX validation | malformed `vex/*.openvex.json` |
+
+## 13. Post-merge follow-ups (source-built)
+
+1. **Dispatch-test then enable** the versions.yaml row (§9 safe rollout).
+2. **Dispatch `patch-go-deps`** once to seed the transitive patch block (§10), if registered.
+3. First grype scan may surface transitive CVEs — let the next patch cycle handle
+   them, or VEX the false-positives.


### PR DESCRIPTION
Standardizes image onboarding into one complete, CI-accurate checklist so new images follow **all** requirements and can't silently skip a step — the exact failure mode behind the "frozen-8" (8 source-built images that never auto-updated) and the #355 catalog-drift PR failure.

## `docs/onboarding.md` (new — source of truth)
A single exhaustive reference, verified against the current codebase:
- **Complete registration checklist** with the CI-enforced items flagged (`catalog.json`, `vex/`, build matrix)
- apko-only vs source-built decision
- Go/C **build patterns** (CGO_ENABLED=0 static, version-ldflags, GOEXPERIMENT, C optional-feature disabling)
- **smoke-test structure** (version/help/offline-functional/no-shell) + the test gotchas
- **versions.yaml conventions** — pin-major, github-tags vs releases-latest, canonical-repo-not-redirect, non-github tarballs, and the **cron-disabled safe-rollout** two-step
- **transitive-dep patching** — the three `patch-go-deps` dicts, **and when to `SKIP_IMAGES` a tangled graph** (with the Chainguard/`HOW_TO_PATCH_CVES.md` rationale)
- **license tiers** (🟢/🟡/🔴)
- pre-push + the CI gates that will catch you
- every melange/test gotcha from recent debugging (strip-components, relative symlinks, C-app deps, chmod +x, nonroot 0600 perms, world-writable bind workdirs)

## `CONTRIBUTING.md` (updated)
Points to the new doc as the source of truth and fixes its table — `catalog.json` and `vex/` were **missing** (both CI-enforced), and "3–5 files" understated it.

Docs-only; internal links verified to resolve.