### PR TITLE
fix(patch-go-deps): restore dropped array parens + add workflow lint gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint workflows
+
+# Guardrail: validate GitHub Actions workflows (schema + embedded Bash) on every
+# change to them. Most workflows here run only on schedule/workflow_dispatch, so a
+# shell syntax error inside a `run:` block never executes on the PR that introduces
+# it — it detonates hours later on the scheduled run on main, blocking the shared
+# 6-hourly rebuild. This job runs actionlint + shellcheck (error severity) so such
+# breaks fail the PR instead. Same entrypoint as local `make lint-workflows`.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/lint-workflows.sh'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/lint-workflows.sh'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      # shellcheck is preinstalled on ubuntu-latest; the script fetches pinned
+      # actionlint. Reusing `make lint-workflows` keeps CI and local identical.
+      - name: Lint workflows (actionlint + shellcheck)
+        run: make lint-workflows

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -178,6 +178,7 @@ jobs:
             [kubeconform]="github.com/yannh/kubeconform"
             [kube-bench]="github.com/aquasecurity/kube-bench"
             [trufflehog]="github.com/trufflesecurity/trufflehog/v3"
+          )
 
           # Build step markers to insert before
           declare -A BUILD_MARKERS=(
@@ -223,6 +224,7 @@ jobs:
             [kubeconform]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [kube-bench]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [trufflehog]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+          )
 
           HAS_PATCHES=false
           PATCHED_LIST=""

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test-$(1)-dev:
 	@echo "✓ $(1) dev tests passed"
 endef
 
-.PHONY: all build scan clean help
+.PHONY: all build scan clean help lint-workflows
 .PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange redis-slim-dev mysql mysql-melange mysql-local memcached memcached-melange memcached-dev caddy caddy-melange haproxy haproxy-melange postgres-slim postgres-slim-dev bun bun-dev sqlite sqlite-dev dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange php-dev rails rails-melange rails-dev deno deno-dev kafka kafka-melange keygen opensearch opensearch-melange opensearch-dev mariadb mariadb-melange mariadb-dev valkey valkey-melange valkey-dev
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange alertmanager alertmanager-melange mariadb mariadb-melange
@@ -2959,6 +2959,16 @@ clean:
 	rm -f *.tar sbom-*.spdx.json
 	rm -rf packages/
 	@echo "✓ Cleanup complete"
+
+#------------------------------------------------------------------------------
+# LINT
+#------------------------------------------------------------------------------
+# Validate all GitHub Actions workflows (schema + embedded Bash in `run:` blocks)
+# via actionlint + shellcheck. Run this before pushing any .github/workflows/**
+# change — most workflows only run on schedule, so a shell syntax error there
+# never executes on the PR and would otherwise only surface on main.
+lint-workflows:
+	@./scripts/lint-workflows.sh
 
 #------------------------------------------------------------------------------
 # HELP

--- a/scripts/lint-workflows.sh
+++ b/scripts/lint-workflows.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Lint every GitHub Actions workflow: schema/expressions (actionlint) plus the
+# Bash embedded in each `run:` block (shellcheck, error-severity only).
+#
+# This is the guardrail for the class of bug that a workflow-only diff hides:
+# a dropped `)` in a Bash associative array inside `run:` passes YAML validation
+# and code review, then only detonates on the next *scheduled* run on main
+# (workflows that don't trigger on pull_request never execute on the PR).
+# actionlint feeds each run block to shellcheck, which flags the unparseable
+# array (SC1072/SC1073) before merge.
+#
+# Severity is pinned to `error` so we catch syntax breaks without drowning in
+# pre-existing style/info noise (SC2086 quoting, SC2129 redirect grouping).
+#
+# Same command runs locally (`make lint-workflows`) and in CI, so they can't drift.
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.7"
+SHELLCHECK_VERSION="0.10.0"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cache="${XDG_CACHE_HOME:-$HOME/.cache}/minimal-workflow-lint"
+mkdir -p "$cache"
+
+# --- actionlint (pinned) ---
+if command -v actionlint >/dev/null 2>&1 && [ "$(actionlint --version 2>/dev/null | head -1)" = "$ACTIONLINT_VERSION" ]; then
+  actionlint_bin="$(command -v actionlint)"
+elif [ -x "$cache/actionlint" ] && [ "$("$cache/actionlint" --version 2>/dev/null | head -1)" = "$ACTIONLINT_VERSION" ]; then
+  actionlint_bin="$cache/actionlint"
+else
+  echo "→ fetching actionlint ${ACTIONLINT_VERSION}"
+  curl -fsSL "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
+    | bash -s -- "$ACTIONLINT_VERSION" "$cache" >/dev/null
+  actionlint_bin="$cache/actionlint"
+fi
+
+# --- shellcheck (actionlint shells out to it for `run:` blocks) ---
+# Preinstalled on GitHub-hosted ubuntu runners; fetched locally if absent.
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck_bin="$(command -v shellcheck)"
+elif [ -x "$cache/shellcheck" ]; then
+  shellcheck_bin="$cache/shellcheck"
+else
+  echo "→ fetching shellcheck ${SHELLCHECK_VERSION}"
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"; [ "$arch" = "arm64" ] && arch="aarch64"
+  curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.${os}.${arch}.tar.xz" \
+    | tar -xJ -C "$cache" --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+  shellcheck_bin="$cache/shellcheck"
+fi
+
+# actionlint auto-discovers shellcheck on PATH and forwards SHELLCHECK_OPTS to it.
+export PATH="$(dirname "$shellcheck_bin"):$PATH"
+export SHELLCHECK_OPTS="--severity=error"
+
+echo "actionlint $("$actionlint_bin" --version | head -1) + shellcheck $("$shellcheck_bin" --version | awk -F': ' '/^version/{print $2}')"
+cd "$repo_root"
+"$actionlint_bin" -color .github/workflows/*.yml
+echo "✓ workflow lint clean"


### PR DESCRIPTION
## Problem

The `Patch Go Transitive Dependencies` scheduled workflow failed on **every run on main** since batch-b (#389): the job died with `syntax error near unexpected token '('` before scanning any image, so **no Go transitive-dep patch PRs were being generated at all**.

## Root cause

#389 appended 5 entries to two Bash associative arrays in the `Scan Go images` step (`MAIN_MODULES`, `BUILD_MARKERS`) by **replacing each array's closing `)` line** instead of inserting before it. Both arrays ran open into the next `declare -A ...=(`, and Bash choked on that `(`.

## Why it reached main (the real gap)

- `patch-go-deps.yml` runs only on `schedule` + `workflow_dispatch` — **never on `pull_request`**, so the broken shell never executed on the PR that introduced it. It only detonated 6h later on the scheduled run.
- **Nothing linted shell inside `run:` blocks.** A dropped `)` passes YAML validation and code review untouched.

## Fix

1. **Restore the two closing `)`** — the actual bug.
2. **Add a workflow lint gate** so this class of error can't reach main again:
   - `.github/workflows/lint.yml` — runs on any PR touching `.github/workflows/**`; actionlint + shellcheck at error severity.
   - `scripts/lint-workflows.sh` + `make lint-workflows` — identical check locally (pre-push), so CI and local can't drift.

## Verification

- shellcheck flags the exact bug on the pre-fix tree: `SC1072: Expected ) to close array assignment` — the gate **would have blocked #389**.
- `make lint-workflows` is **clean** on this branch.
- Severity pinned to `error`: catches syntax breaks, ignores pre-existing style/info noise (SC2086/SC2129).