### PR TITLE
feat(ci): enforce auto-update coverage for every prod image

### DIFF
--- a/.github/autoupdate-coverage.yaml
+++ b/.github/autoupdate-coverage.yaml
@@ -1,0 +1,48 @@
+# Auto-update coverage classification for PACKAGE-BASED prod images.
+#
+# Source-built images (those with a <name>/melange.yaml) are NOT listed here —
+# their auto-update is inferred directly from .github/versions.yaml (a row whose
+# files: points at the melange, with cron-enabled: true). scripts/check-autoupdate-coverage.sh
+# enforces that every catalog.json image resolves to exactly one mechanism.
+#
+# Package-based images pull Wolfi packages at apko assemble time, so they have
+# two valid mechanisms:
+
+# wolfi-versioned: apko pins a *versioned* Wolfi package (e.g. python-3.14, go-1.26).
+# Patch/minor releases flow in on the 6-hourly rebuild; a MAJOR-line bump requires
+# editing the apko package name, which update-wolfi-packages.yml detects and PRs.
+wolfi-versioned:
+  - python          # python-3.14
+  - go              # go-1.26
+  - node-slim       # nodejs-*
+  - dotnet          # dotnet-*
+  - java            # openjdk-*
+  - postgres-slim   # postgresql-*
+
+# wolfi-rolling: apko references an *unversioned / rolling* Wolfi package
+# (e.g. apache2, nginx-mainline, sqlite, bun). Wolfi keeps that single package at
+# the latest release, so the image is always current via the 6-hourly rebuild.
+# No dedicated updater is needed by design.
+wolfi-rolling:
+  - nginx           # nginx-mainline (rolling)
+  - httpd           # apache2 (unversioned)
+  - sqlite          # sqlite (unversioned)
+  - bun             # bun (unversioned)
+
+# bespoke: SOURCE-BUILT images auto-updated by a dedicated workflow instead of
+# the shared .github/versions.yaml pipeline. Each MUST name the workflow and a
+# reason. These are migration targets — fold them into versions.yaml once the
+# shared pipeline supports their versioning model.
+bespoke:
+  - name: minio
+    workflow: .github/workflows/update-minio.yml
+    reason: >-
+      MinIO ships date-based RELEASE.YYYY-MM-DDTHH-MM-SSZ tags mapped to a
+      YYYY.MM.DD version, plus a separate full-tag var (minio_release) used in
+      the tarball URL. That needs a tag->version transform and a raw-{tag}
+      template var the shared versions.yaml pipeline does not yet support.
+      Tracked for migration into versions.yaml.
+
+# exempt: images with a deliberate, documented reason for having NO auto-update.
+# Each entry MUST carry a reason. Empty for now — kept as an explicit escape hatch.
+exempt: []

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -222,8 +222,9 @@
     releases: "https://github.com/open-policy-agent/opa/releases"
     notes: "https://github.com/open-policy-agent/opa/releases/tag/v{version}"
 
-# cron-enabled after a dispatch check (gh workflow run update-versions.yml -f only=osv-scanner).
+# Batch-B security CLIs — wave 9, dispatch-validated 2026-07-12.
 - name: osv-scanner
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [osv-scanner/melange.yaml]
   source: { type: github-releases-latest, repo: google/osv-scanner, strip-v: true, pin-major: 2 }
   tarball: { url: "https://github.com/google/osv-scanner/archive/refs/tags/v{version}.tar.gz", field: sha256 }
@@ -233,6 +234,7 @@
     notes: "https://github.com/google/osv-scanner/releases/tag/v{version}"
 
 - name: notation
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [notation/melange.yaml]
   source: { type: github-releases-latest, repo: notaryproject/notation, strip-v: true, pin-major: 1 }
   tarball: { url: "https://github.com/notaryproject/notation/archive/refs/tags/v{version}.tar.gz", field: sha256 }
@@ -242,6 +244,7 @@
     notes: "https://github.com/notaryproject/notation/releases/tag/v{version}"
 
 - name: conftest
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [conftest/melange.yaml]
   source: { type: github-releases-latest, repo: open-policy-agent/conftest, strip-v: true, pin-major: 0 }
   tarball: { url: "https://github.com/open-policy-agent/conftest/archive/refs/tags/v{version}.tar.gz", field: sha256 }
@@ -251,6 +254,7 @@
     notes: "https://github.com/open-policy-agent/conftest/releases/tag/v{version}"
 
 - name: kubeconform
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [kubeconform/melange.yaml]
   source: { type: github-releases-latest, repo: yannh/kubeconform, strip-v: true, pin-major: 0 }
   tarball: { url: "https://github.com/yannh/kubeconform/archive/refs/tags/v{version}.tar.gz", field: sha256 }
@@ -260,6 +264,7 @@
     notes: "https://github.com/yannh/kubeconform/releases/tag/v{version}"
 
 - name: kube-bench
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [kube-bench/melange.yaml]
   source: { type: github-releases-latest, repo: aquasecurity/kube-bench, strip-v: true, pin-major: 0 }
   tarball: { url: "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v{version}.tar.gz", field: sha256 }
@@ -269,6 +274,7 @@
     notes: "https://github.com/aquasecurity/kube-bench/releases/tag/v{version}"
 
 - name: trufflehog
+  cron-enabled: true   # wave 9 (validated 2026-07-12)
   files: [trufflehog/melange.yaml]
   source: { type: github-releases-latest, repo: trufflesecurity/trufflehog, strip-v: true, pin-major: 3 }
   tarball: { url: "https://github.com/trufflesecurity/trufflehog/archive/refs/tags/v{version}.tar.gz", field: sha256 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,12 @@ jobs:
           fi
           echo "OK — catalog.json matches the build matrix ($(wc -l < /tmp/catalog.txt) images)."
 
+      - name: Assert every prod image has auto-update configured
+        # Invariant: no image ships without a live auto-update mechanism (a
+        # cron-enabled versions.yaml row, a declared Wolfi-package class, or a
+        # bespoke updater). Same check as local `make check-autoupdate`.
+        run: make check-autoupdate
+
   #----------------------------------------------------------------------------
   # GENERATE EPHEMERAL SIGNING KEY (PRs only - secrets not available for forks)
   #----------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test-$(1)-dev:
 	@echo "✓ $(1) dev tests passed"
 endef
 
-.PHONY: all build scan clean help lint-workflows
+.PHONY: all build scan clean help lint-workflows check-autoupdate
 .PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange redis-slim-dev mysql mysql-melange mysql-local memcached memcached-melange memcached-dev caddy caddy-melange haproxy haproxy-melange postgres-slim postgres-slim-dev bun bun-dev sqlite sqlite-dev dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange php-dev rails rails-melange rails-dev deno deno-dev kafka kafka-melange keygen opensearch opensearch-melange opensearch-dev mariadb mariadb-melange mariadb-dev valkey valkey-melange valkey-dev
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange alertmanager alertmanager-melange mariadb mariadb-melange
@@ -2969,6 +2969,12 @@ clean:
 # never executes on the PR and would otherwise only surface on main.
 lint-workflows:
 	@./scripts/lint-workflows.sh
+
+# Assert every prod image (catalog.json) has exactly one live auto-update
+# mechanism (a cron-enabled versions.yaml row, or a declared Wolfi-package
+# class). Run before pushing any new image or versions.yaml/catalog.json change.
+check-autoupdate:
+	@./scripts/check-autoupdate-coverage.sh
 
 #------------------------------------------------------------------------------
 # HELP

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -66,7 +66,9 @@ Tick every box. The ones marked **⛔ CI-enforced** will fail your PR if missing
 - [ ] **`Makefile`** — version var + `.PHONY` + build/test targets (§6)
 - [ ] **`.github/workflows/build.yml`** — add to `MELANGE_IMAGES` or `APKO_IMAGES` (§7) **⛔**
 - [ ] **`catalog.json`** — one entry (§7) **⛔ validate-catalog fails the PR without it**
-- [ ] **`.github/versions.yaml`** — auto-bump row — **source-built only** (§9)
+- [ ] **auto-update configured (§9)** **⛔ check-autoupdate fails the PR without it** —
+      source-built → `cron-enabled` `.github/versions.yaml` row; apko-only →
+      classify in `.github/autoupdate-coverage.yaml`
 - [ ] **transitive-dep patching** — source-built only (§10):
       Go → three dicts in `patch-go-deps.yml` **or** add to `SKIP_IMAGES`;
       Ruby/Rust/Maven → `.github/patch-deps.yaml`
@@ -299,7 +301,21 @@ and unreachable CVEs. Tooling: `tools/vex/{validate,reconcile}.sh`.
 
 ---
 
-## 9. versions.yaml auto-bump (source-built only)
+## 9. Auto-update — mandatory for every image
+
+**Every prod image must have exactly one live auto-update mechanism.** This is
+enforced by `make check-autoupdate` (§12) against `catalog.json`, so an image
+cannot be onboarded without it. Which mechanism depends on the image type:
+
+- **apko-only (package-based)** — declare it in **`.github/autoupdate-coverage.yaml`**:
+  `wolfi-versioned` if apko pins a versioned package (`python-3.14`, `go-1.26`) whose
+  major-line bumps come from `update-wolfi-packages.yml`; `wolfi-rolling` if apko
+  references an unversioned/rolling package (`apache2`, `nginx-mainline`, `sqlite`)
+  that is always current via the 6-hourly rebuild. (`exempt`/`bespoke` exist as
+  documented escape hatches — each requires a reason.)
+- **source-built** — add a `cron-enabled` `versions.yaml` row (below).
+
+### versions.yaml auto-bump (source-built only)
 
 The `update-versions.yml` cron advances the **app version** (see
 [version-management.md](version-management.md) for the full two-loop model). Add a
@@ -333,17 +349,21 @@ row. Full schema + examples are at the top of `.github/versions.yaml`.
 - **Non-github tarball?** Point `tarball.url` at the real host (mosquitto builds
   from `mosquitto.org/files/source/...`, not the GitHub archive).
 
-### Safe rollout (mandatory two-step)
+### Safe rollout (validate once, then ship enabled)
 
-A new row ships **cron-disabled**. Then:
+**Validate before you enable — but the onboarding PR must land the row already
+`cron-enabled: true`.** The `check-autoupdate` gate (§12) fails any PR that ships a
+source-built image with a missing or frozen (not-yet-enabled) row, so you cannot
+merge an image without live auto-update. Validate first, then enable in the same PR:
 
 ```bash
 gh workflow run update-versions.yml -f only=<name>   # ignores the cron gate
 ```
-Confirm it produces a correct PR (or a clean "no update"). **Only then** add
-`cron-enabled: true`. Why: update-versions PRs **auto-merge**, and a wrong row
-would auto-merge a bad bump to `main` and stall the whole fleet. Never enable an
-unvalidated row.
+Confirm it produces a correct PR (or a clean "no update"), **then** set
+`cron-enabled: true` on the row before pushing. Why validate first: update-versions
+PRs **auto-merge**, and a wrong row would auto-merge a bad bump to `main` and stall
+the whole fleet. Never enable an unvalidated row — but never leave a validated one
+frozen either (that is exactly how the batch-b CLIs silently stopped auto-updating).
 
 ---
 
@@ -404,6 +424,8 @@ Before you push (source-built):
 make <name>-melange && make <name> && make test-<name>   # §0 — must all pass
 python3 -c "import json; json.load(open('catalog.json'))" # valid JSON
 ruby -ryaml -e "YAML.load_file('.github/versions.yaml')"  # valid YAML
+make check-autoupdate                                     # §9 — auto-update configured
+make lint-workflows                                       # if you touched .github/workflows/**
 ```
 
 CI will independently enforce:
@@ -411,13 +433,17 @@ CI will independently enforce:
 | Check | Fails when |
 |---|---|
 | `validate-catalog` | `catalog.json` ≠ build matrix |
+| `check-autoupdate` | a prod image has no live auto-update (missing/frozen row, or unclassified apko-only image) |
 | `melange-build` / `build-apko` (both arches) | the image doesn't build or its test fails |
+| `lint-workflows` (actionlint + shellcheck) | a workflow schema error or shell syntax error in a `run:` block |
 | gitleaks (pre-commit + CI) | a secret is committed |
 | VEX validation | malformed `vex/*.openvex.json` |
 
 ## 13. Post-merge follow-ups (source-built)
 
-1. **Dispatch-test then enable** the versions.yaml row (§9 safe rollout).
+1. The versions.yaml row already lands **validated + `cron-enabled`** in the onboarding
+   PR (§9 safe rollout) — `check-autoupdate` blocks a frozen row, so there is no
+   post-merge "enable" step to forget.
 2. **Dispatch `patch-go-deps`** once to seed the transitive patch block (§10), if registered.
 3. First grype scan may surface transitive CVEs — let the next patch cycle handle
    them, or VEX the false-positives.

--- a/scripts/check-autoupdate-coverage.sh
+++ b/scripts/check-autoupdate-coverage.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# Assert that EVERY prod image (catalog.json) has exactly one auto-update
+# mechanism configured. This is the invariant that stops an image from being
+# onboarded — or silently drifting — without auto-update wired up.
+#
+# Mechanisms:
+#   source-built (<name>/melange.yaml exists)
+#       -> a .github/versions.yaml row whose files: points at that melange,
+#          with cron-enabled: true. A row that exists but is not cron-enabled
+#          (a "frozen" row) FAILS — auto-update must be live, not pending.
+#   package-based (no melange.yaml)
+#       -> declared in .github/autoupdate-coverage.yaml as either
+#          wolfi-versioned (major-bump PR via update-wolfi-packages.yml) or
+#          wolfi-rolling (auto-current via the 6-hourly rebuild), or exempt.
+#
+# Same entrypoint locally (`make check-autoupdate`) and in CI (build.yml
+# validate-catalog job), so they cannot drift. jq is assumed present (it is on
+# GitHub ubuntu runners); yq (mikefarah v4) is fetched if absent.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+CATALOG="catalog.json"
+VERSIONS=".github/versions.yaml"
+COVERAGE=".github/autoupdate-coverage.yaml"
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+
+if command -v yq >/dev/null 2>&1; then
+  yq_bin="yq"
+else
+  cache="${XDG_CACHE_HOME:-$HOME/.cache}/minimal-workflow-lint"
+  mkdir -p "$cache"
+  yq_bin="$cache/yq"
+  if [ ! -x "$yq_bin" ]; then
+    echo "→ fetching yq"
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_${os}_amd64" -o "$yq_bin"
+    chmod +x "$yq_bin"
+  fi
+fi
+
+fail=0
+err() { printf '  \033[31m✗\033[0m %s\n' "$*"; fail=1; }
+
+# --- inputs -----------------------------------------------------------------
+mapfile -t prod < <(jq -r '.images[].name' "$CATALOG" | sort -u)
+
+versions_json="$("$yq_bin" -o=json '.' "$VERSIONS")"
+coverage_json="$("$yq_bin" -o=json '.' "$COVERAGE")"
+
+# versions.yaml: image-dir -> cron-enabled (true|false).
+# A `files:` entry may be a plain string ("caddy/melange.yaml") or an object
+# ({path,pattern,template}); a row may touch several melange files (e.g. the
+# ruby row rewrites both ruby/ and rails/). Map every melange path in every row,
+# and let an enabled row win if the same image is touched by more than one.
+declare -A vcron
+while IFS=$'\t' read -r dir cron; do
+  [ -z "$dir" ] && continue
+  if [ "${vcron[$dir]:-}" != "true" ]; then vcron["$dir"]="$cron"; fi
+done < <(jq -r '
+  .[] | select(.files) |
+  ((.["cron-enabled"]) == true) as $cron |
+  .files[] |
+  (if type == "string" then . else .path end) as $p |
+  select($p | test("/melange\\.yaml$")) |
+  [($p | sub("/melange\\.yaml$"; "")), $cron] | @tsv
+' <<<"$versions_json")
+
+# coverage lists
+mapfile -t wolfi_versioned < <(jq -r '.["wolfi-versioned"] // [] | .[]' <<<"$coverage_json")
+mapfile -t wolfi_rolling   < <(jq -r '.["wolfi-rolling"]   // [] | .[]' <<<"$coverage_json")
+mapfile -t exempt          < <(jq -r '.exempt             // [] | .[]?.name // empty' <<<"$coverage_json")
+mapfile -t bespoke         < <(jq -r '.bespoke            // [] | .[]?.name // empty' <<<"$coverage_json")
+
+# bespoke image -> its declared workflow file (for existence check)
+declare -A bespoke_wf
+while IFS=$'\t' read -r name wf; do
+  [ -n "$name" ] && bespoke_wf["$name"]="$wf"
+done < <(jq -r '.bespoke // [] | .[] | [.name, (.workflow // "")] | @tsv' <<<"$coverage_json")
+
+has() { local x="$1"; shift; local e; for e in "$@"; do [ "$e" = "$x" ] && return 0; done; return 1; }
+
+# --- forward check: every prod image is covered ------------------------------
+echo "Checking auto-update coverage for ${#prod[@]} prod images…"
+for img in "${prod[@]}"; do
+  if [ -f "$img/melange.yaml" ]; then
+    # source-built -> a cron-enabled versions.yaml row, OR a declared bespoke updater
+    if has "$img" "${bespoke[@]:-}"; then
+      wf="${bespoke_wf[$img]:-}"
+      if [ -z "$wf" ]; then
+        err "$img: declared bespoke but no workflow named in $COVERAGE"
+      elif [ ! -f "$wf" ]; then
+        err "$img: bespoke workflow '$wf' does not exist"
+      fi
+    elif [ -z "${vcron[$img]+x}" ]; then
+      err "$img: source-built but has NO .github/versions.yaml row (auto-update missing)"
+    elif [ "${vcron[$img]}" != "true" ]; then
+      err "$img: versions.yaml row exists but cron-enabled is not true (frozen — validate then enable)"
+    fi
+  else
+    # package-based -> must be classified
+    if has "$img" "${wolfi_versioned[@]:-}"; then :
+    elif has "$img" "${wolfi_rolling[@]:-}"; then :
+    elif has "$img" "${exempt[@]:-}"; then :
+    else
+      err "$img: package-based but not classified in $COVERAGE (add to wolfi-versioned/wolfi-rolling/exempt)"
+    fi
+  fi
+done
+
+# --- reverse checks: no stale/orphan config ---------------------------------
+in_prod() { has "$1" "${prod[@]}"; }
+
+for dir in "${!vcron[@]}"; do
+  in_prod "$dir" || err "versions.yaml has a row for '$dir' which is not a prod image in $CATALOG (orphan/rename?)"
+done
+for name in "${wolfi_versioned[@]:-}" "${wolfi_rolling[@]:-}"; do
+  [ -n "$name" ] || continue
+  in_prod "$name" || err "$COVERAGE lists '$name' which is not a prod image in $CATALOG"
+  [ -f "$name/melange.yaml" ] && err "$COVERAGE lists '$name' as package-based, but it has a melange.yaml (should be a versions.yaml row)"
+done
+for name in "${bespoke[@]:-}" "${exempt[@]:-}"; do
+  [ -n "$name" ] || continue
+  in_prod "$name" || err "$COVERAGE lists '$name' which is not a prod image in $CATALOG"
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "✗ auto-update coverage FAILED — every prod image must have exactly one live auto-update mechanism."
+  exit 1
+fi
+echo "✓ auto-update coverage: all ${#prod[@]} prod images configured"


### PR DESCRIPTION
## Goal

Before onboarding any new images, get **every existing prod image onto auto-update**, and make "auto-update configured" a **hard, CI-enforced invariant** — mirroring the existing `catalog.json ↔ build matrix` parity gate.

An audit found several prod images not actually auto-updating, with nothing to stop a new image being onboarded without it. This closes those gaps and prevents recurrence.

## What was broken

| Image(s) | Problem |
|---|---|
| osv-scanner, notation, conftest, kubeconform, kube-bench, trufflehog | versions.yaml row existed but `cron-enabled` was never set — **frozen**, silently not auto-updating (landed cron-disabled during batch-b and never flipped) |
| minio | auto-updated by a bespoke `update-minio.yml`, off the standard pipeline |

*(cuda-python is out of scope — not in `catalog.json`, non-prod.)*

## Remediation

- **Unfroze the 6 CLIs** (wave 9): each dispatch-validated locally via `check-upstream.sh` (current == latest, source config resolves correctly), then flipped `cron-enabled: true`.
- **minio**: recognized its bespoke updater as a declared mechanism. Full migration into `versions.yaml` is deferred to a focused follow-up — it needs a tag→version transform + raw-`{tag}` var in the shared `check-upstream.sh`/`apply-update.sh` (which drive all 59 rows), too risky to bundle here. Tracked in `.github/autoupdate-coverage.yaml`.

## The gate (prevents recurrence)

- `scripts/check-autoupdate-coverage.sh` + `.github/autoupdate-coverage.yaml`: every image in `catalog.json` must map to **exactly one live mechanism** — a `cron-enabled` versions.yaml row (source-built), a Wolfi-package class `wolfi-versioned`/`wolfi-rolling` (apko-only), or a declared `bespoke`/`exempt` entry. **Both missing and frozen rows fail.**
- Runs as `make check-autoupdate` locally and as a step in build.yml's `validate-catalog` job (same source of truth, can't drift).

## Verification

- Gate **fails** on the pre-remediation tree, listing exactly the 6 frozen CLIs + minio.
- Gate **green** after remediation: all 70 prod images configured.
- **Negative test**: injecting an unconfigured image into `catalog.json` fails the gate (proves the onboarding invariant); reverts green.
- `make lint-workflows` green (build.yml edit parses); `check-autoupdate-coverage.sh` shellcheck-clean.

## Docs

`docs/onboarding.md`: auto-update is now a mandatory, CI-enforced registration step. Source-built rows land **validated + cron-enabled in the same PR** (no more freeze); apko-only images must be classified in the coverage config. Added `check-autoupdate` + `lint-workflows` to the pre-push checklist and CI-gates table.

## Follow-up

- [ ] Migrate minio into the versions.yaml pipeline (separate PR; extend shared scripts with opt-in guards + full regression testing).