### PR TITLE
feat(oauth2-proxy): add OAuth2 Proxy image (Tier-1)

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -283,6 +283,17 @@
     releases: "https://github.com/trufflesecurity/trufflehog/releases"
     notes: "https://github.com/trufflesecurity/trufflehog/releases/tag/v{version}"
 
+# Tier 1 — Kubernetes / GitOps + proxies (docs/roadmap.md)
+- name: oauth2-proxy
+  cron-enabled: true   # tier 1 (validated 2026-07-12)
+  files: [oauth2-proxy/melange.yaml]
+  source: { type: github-releases-latest, repo: oauth2-proxy/oauth2-proxy, strip-v: true, pin-major: 7 }
+  tarball: { url: "https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/oauth2-proxy/oauth2-proxy/releases"
+    notes: "https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v{version}"
+
 - name: thanos
   cron-enabled: true   # wave 8 (dispatch-validated 2026-07-08)
   files: [thanos/melange.yaml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,7 @@ jobs:
             {"name":"kubeconform","variants":["prod","dev"]},
             {"name":"kube-bench","variants":["prod","dev"]},
             {"name":"trufflehog","variants":["prod","dev"]},
+            {"name":"oauth2-proxy","variants":["prod","dev"]},
             {"name":"thanos","variants":["prod","dev"]},
             {"name":"node-exporter","variants":["prod","dev"]},
             {"name":"blackbox-exporter","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -131,6 +131,7 @@ jobs:
             [kubeconform]="/home/build/kubeconform-${D}{{package.version}}"
             [kube-bench]="/home/build/kube-bench-${D}{{package.version}}"
             [trufflehog]="/home/build/trufflehog-${D}{{package.version}}"
+            [oauth2-proxy]="/home/build/oauth2-proxy-${D}{{package.version}}"
           )
 
           # Main module path per image. Grype's buildinfo scan reports the
@@ -178,6 +179,7 @@ jobs:
             [kubeconform]="github.com/yannh/kubeconform"
             [kube-bench]="github.com/aquasecurity/kube-bench"
             [trufflehog]="github.com/trufflesecurity/trufflehog/v3"
+            [oauth2-proxy]="github.com/oauth2-proxy/oauth2-proxy/v7"
           )
 
           # Build step markers to insert before
@@ -224,6 +226,7 @@ jobs:
             [kubeconform]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [kube-bench]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [trufflehog]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [oauth2-proxy]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
           )
 
           HAS_PATCHES=false

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ GITLEAKS_VERSION ?= $(call melange_version,gitleaks/melange.yaml)
 STEP_VERSION ?= $(call melange_version,step-cli/melange.yaml)
 OPA_VERSION ?= $(call melange_version,opa/melange.yaml)
 OSV_SCANNER_VERSION ?= $(call melange_version,osv-scanner/melange.yaml)
+OAUTH2_PROXY_VERSION ?= $(call melange_version,oauth2-proxy/melange.yaml)
 NOTATION_VERSION ?= $(call melange_version,notation/melange.yaml)
 CONFTEST_VERSION ?= $(call melange_version,conftest/melange.yaml)
 KUBECONFORM_VERSION ?= $(call melange_version,kubeconform/melange.yaml)
@@ -165,6 +166,7 @@ endef
 .PHONY: step-cli step-cli-melange test-step-cli
 .PHONY: opa opa-melange test-opa
 .PHONY: osv-scanner osv-scanner-melange test-osv-scanner
+.PHONY: oauth2-proxy oauth2-proxy-melange test-oauth2-proxy
 .PHONY: notation notation-melange test-notation
 .PHONY: conftest conftest-melange test-conftest
 .PHONY: kubeconform kubeconform-melange test-kubeconform
@@ -1689,6 +1691,29 @@ osv-scanner: osv-scanner-melange
 	@rm -f osv-scanner.tar sbom-*.spdx.json
 	@echo "✓ minimal-osv-scanner built (source build)"
 
+oauth2-proxy-melange: keygen
+	@echo "Building OAuth2 Proxy $(OAUTH2_PROXY_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build oauth2-proxy/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ OAuth2 Proxy package built from source"
+
+oauth2-proxy: oauth2-proxy-melange
+	@echo "Assembling minimal-oauth2-proxy image with apko..."
+	apko build oauth2-proxy/apko/oauth2-proxy.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:$(VERSION) \
+		oauth2-proxy.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < oauth2-proxy.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:latest
+	@rm -f oauth2-proxy.tar sbom-*.spdx.json
+	@echo "✓ minimal-oauth2-proxy built (source build)"
+
 
 #------------------------------------------------------------------------------
 # NOTATION IMAGE (melange Go source build + apko)
@@ -2664,6 +2689,12 @@ test-osv-scanner:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-osv-scanner:latest" && \
 		osv-scanner/test.sh
 	@echo "✓ osv-scanner tests passed"
+
+test-oauth2-proxy:
+	@echo "Testing oauth2-proxy image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-oauth2-proxy:latest" && \
+		oauth2-proxy/test.sh
+	@echo "✓ oauth2-proxy tests passed"
 
 test-notation:
 	@echo "Testing notation image..."

--- a/catalog.json
+++ b/catalog.json
@@ -43,6 +43,7 @@
     { "name": "haproxy", "category": "Web Servers & Proxies", "variants": ["prod", "dev"], "primary_package": "haproxy", "upstream_url": "https://www.haproxy.org", "summary": "Shell-less HAProxy built from source via melange." },
     { "name": "traefik", "category": "Web Servers & Proxies", "variants": ["prod", "dev"], "primary_package": "traefik", "upstream_url": "https://traefik.io", "summary": "Shell-less Traefik reverse proxy built from source via melange." },
     { "name": "envoy", "category": "Web Servers & Proxies", "variants": ["prod", "dev"], "primary_package": "envoy", "upstream_url": "https://www.envoyproxy.io", "summary": "Shell-less Envoy proxy." },
+    { "name": "oauth2-proxy", "category": "Web Servers & Proxies", "variants": ["prod", "dev"], "primary_package": "oauth2-proxy", "upstream_url": "https://oauth2-proxy.github.io/oauth2-proxy/", "summary": "Shell-less OAuth2 Proxy (OIDC/OAuth2 authenticating reverse proxy), built from source via melange." },
 
     { "name": "prometheus", "category": "Observability", "variants": ["prod", "dev"], "primary_package": "prometheus", "upstream_url": "https://prometheus.io", "summary": "Prometheus monitoring server built from source via melange." },
     { "name": "alertmanager", "category": "Observability", "variants": ["prod", "dev"], "primary_package": "alertmanager", "upstream_url": "https://prometheus.io/docs/alerting/latest/alertmanager/", "summary": "Prometheus Alertmanager built from source via melange." },

--- a/oauth2-proxy/apko/oauth2-proxy-dev.yaml
+++ b/oauth2-proxy/apko/oauth2-proxy-dev.yaml
@@ -1,0 +1,49 @@
+# Development variant of minimal-oauth2-proxy.
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - oauth2-proxy-minimal
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/oauth2-proxy
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-oauth2-proxy-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-oauth2-proxy: same oauth2-proxy + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/oauth2-proxy"
+  org.opencontainers.image.licenses: "MIT"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/oauth2-proxy/apko/oauth2-proxy.yaml
+++ b/oauth2-proxy/apko/oauth2-proxy.yaml
@@ -1,0 +1,41 @@
+# Minimal OAuth2 Proxy image - OIDC/OAuth2 authenticating reverse proxy, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - oauth2-proxy-minimal
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/oauth2-proxy
+
+environment:
+  PATH: /usr/bin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-oauth2-proxy"
+  org.opencontainers.image.description: "Hardened shell-less OAuth2 Proxy (OIDC/OAuth2 authenticating reverse proxy) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/oauth2-proxy"
+  org.opencontainers.image.licenses: "MIT"
+
+archs:
+  - x86_64
+  - aarch64

--- a/oauth2-proxy/melange.yaml
+++ b/oauth2-proxy/melange.yaml
@@ -1,0 +1,76 @@
+# Melange build configuration for minimal OAuth2 Proxy
+# Pure Go from source. Single static `oauth2-proxy` binary (reverse proxy /
+# auth sidecar providing OIDC/OAuth2 authentication in front of upstreams).
+# License: MIT (oauth2-proxy authors).
+
+package:
+  name: oauth2-proxy-minimal
+  version: 7.15.3
+  epoch: 0
+  description: "Minimal OAuth2 Proxy (OIDC/OAuth2 authenticating reverse proxy) built from source"
+  copyright:
+    - license: MIT
+
+vars:
+  # SHA256 of oauth2-proxy source tarball - updated by update-versions.yml workflow
+  sha256: a13491bfd083e570d451275458728fb3f722b4d46657644df1ea90c676c552da
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify oauth2-proxy source
+  - runs: |
+      mkdir -p /home/build/oauth2-proxy-${{package.version}}
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/oauth2-proxy.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/oauth2-proxy.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/oauth2-proxy.tar.gz -C /home/build/oauth2-proxy-${{package.version}} --strip-components=1
+      rm /home/build/oauth2-proxy.tar.gz
+
+  # Version is reported via pkg/version.VERSION (see upstream Makefile).
+  # CGO_ENABLED=0 gives a static binary.
+  # patch-go-deps: auto-generated — do not edit manually
+  - runs: |
+      export GOWORK=off
+      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
+      for root in /home/build/oauth2-proxy-${{package.version}}; do
+        [ -f "$root/go.mod" ] || continue
+        ( cd "$root" \
+          && go mod tidy -e \
+          && { [ ! -d vendor ] || go mod vendor; } )
+      done
+  # end-patch-go-deps
+  - runs: |
+      cd /home/build/oauth2-proxy-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= \
+          -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=${{package.version}}" \
+        -o /home/build/oauth2-proxy-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/oauth2-proxy-bin "${{targets.destdir}}/usr/bin/oauth2-proxy"
+      chmod 0755 "${{targets.destdir}}/usr/bin/oauth2-proxy"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying oauth2-proxy binary..."
+      "${{targets.destdir}}/usr/bin/oauth2-proxy" --version

--- a/oauth2-proxy/test-dev.sh
+++ b/oauth2-proxy/test-dev.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Smoke test for minimal-oauth2-proxy-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing oauth2-proxy version (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/oauth2-proxy "$IMAGE" --version 2>&1 | grep -qiE '7\.[0-9]+'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing bind-tools (dig)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "dig -v" 2>&1 | grep -qE "^DiG"
+
+echo "Testing git..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "git --version" | grep -q "git version"
+
+echo "✓ All oauth2-proxy-dev smoke tests passed"

--- a/oauth2-proxy/test.sh
+++ b/oauth2-proxy/test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing oauth2-proxy version..."
+docker run --rm "$IMAGE" --version 2>&1 | grep -qiE '7\.[0-9]+'
+
+echo "Testing oauth2-proxy help (flags load)..."
+# oauth2-proxy uses Go's flag package: --help prints usage and exits non-zero;
+# piped to grep (no pipefail) that non-zero exit is masked, we assert on content.
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'provider|upstream|http-address|cookie-secret'
+
+echo "Testing oauth2-proxy rejects a bad config (validation wired)..."
+# With no provider/client-id/cookie-secret it must refuse to start, proving the
+# config validation path is intact offline (no network, no real provider needed).
+docker run --rm "$IMAGE" --http-address=127.0.0.1:0 2>&1 | grep -qiE 'missing|required|invalid|cookie|client' \
+  && echo "oauth2-proxy config validation OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All oauth2-proxy tests passed!"

--- a/vex/oauth2-proxy.openvex.json
+++ b/vex/oauth2-proxy.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/oauth2-proxy",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-12T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
First **Tier-1** image from [`docs/roadmap.md`](../blob/main/docs/roadmap.md) — the demand-ranked road to 100. oauth2-proxy is a top pick: **97M Docker pulls**, the ubiquitous OIDC/OAuth2 auth sidecar in Kubernetes.

| | |
|---|---|
| Version | 7.15.3 |
| License | MIT 🟢 |
| Build | pure-Go static from source (go-1.26.5) |
| Category | Web Servers & Proxies |
| Catalog | 70 → **71** |

## Onboarding (10/10 points, per docs/onboarding.md)
melange · apko prod+dev · test{,-dev}.sh (+x) · Makefile targets · build.yml matrix · catalog.json · patch-go-deps 3 dicts · **versions.yaml row (dispatch-validated → cron-enabled)** · vex.

## Local validation (mandatory pre-push)
- `make oauth2-proxy` — melange + apko build green.
- `make test-oauth2-proxy` — prod smoke test green (--version, --help flag listing, offline config-validation rejection, no-shell).
- **dev variant** assembled + `test-dev.sh` green (the hardening lesson: test `-dev` locally, not just prod).
- `make check-autoupdate` ✓ (71 images) · `make lint-workflows` ✓.

## Notes
- It's a **server** (listens :4180), not a CLI — entrypoint runs oauth2-proxy; the smoke test proves the binary + config validation wiring without needing a live OIDC provider.
- Version injected via `-X .../v7/pkg/version.VERSION`; main package at module root.