### PR TITLE
feat: onboard pgbouncer + unbound (Tier-3 C daemons)

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -631,6 +631,31 @@
     releases: "https://github.com/eclipse-mosquitto/mosquitto/releases"
     notes: "https://github.com/eclipse-mosquitto/mosquitto/blob/v{version}/ChangeLog.txt"
 
+# pgbouncer tags are underscore-separated (pgbouncer_1_25_2); strip the prefix
+# then tag-rewrite '_'→'.' before semver sort. Tarballs live on pgbouncer.org
+# with a dotted-version path, so no release-download probe is needed.
+- name: pgbouncer
+  cron-enabled: true   # wave 10 (dispatch-validated 2026-07-16)
+  files: [pgbouncer/melange.yaml]
+  source: { type: github-tags, repo: pgbouncer/pgbouncer, pattern: '^pgbouncer_1_[0-9]+_[0-9]+$', strip-prefix: 'pgbouncer_', tag-rewrite: { from: '_', to: '.' }, pin-major: 1 }
+  tarball: { url: "https://www.pgbouncer.org/downloads/files/{version}/pgbouncer-{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/pgbouncer/pgbouncer/releases"
+    notes: "https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_{version}"
+
+# unbound tags are `release-X.Y.Z` (with `release-X.Y.Zrc1` pre-releases the
+# pattern deliberately excludes). Tarballs live on nlnetlabs.nl.
+- name: unbound
+  cron-enabled: true   # wave 10 (dispatch-validated 2026-07-16)
+  files: [unbound/melange.yaml]
+  source: { type: github-tags, repo: NLnetLabs/unbound, pattern: '^release-1\.[0-9]+\.[0-9]+$', strip-prefix: 'release-', pin-major: 1 }
+  tarball: { url: "https://nlnetlabs.nl/downloads/unbound/unbound-{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/NLnetLabs/unbound/releases"
+    notes: "https://github.com/NLnetLabs/unbound/releases/tag/release-{version}"
+
 # ============================================================================
 # plain-text — fetch a single URL that returns the bare version as text
 # ============================================================================

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},
             {"name":"consul","variants":["prod","dev"]},{"name":"tempo","variants":["prod","dev"]},
-            {"name":"mosquitto","variants":["prod","dev"]},
+            {"name":"mosquitto","variants":["prod","dev"]},{"name":"pgbouncer","variants":["prod","dev"]},{"name":"unbound","variants":["prod","dev"]},
             {"name":"helm","variants":["prod","dev"]},
             {"name":"kubectl","variants":["prod","dev"]},
             {"name":"telegraf","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ KUBE_BENCH_VERSION ?= $(call melange_version,kube-bench/melange.yaml)
 TRUFFLEHOG_VERSION ?= $(call melange_version,trufflehog/melange.yaml)
 # --- Messaging (MQTT) ---
 MOSQUITTO_VERSION ?= $(call melange_version,mosquitto/melange.yaml)
+PGBOUNCER_VERSION ?= $(call melange_version,pgbouncer/melange.yaml)
+UNBOUND_VERSION ?= $(call melange_version,unbound/melange.yaml)
 HELM_VERSION ?= $(call melange_version,helm/melange.yaml)
 KUBECTL_VERSION ?= $(call melange_version,kubectl/melange.yaml)
 
@@ -155,6 +157,8 @@ endef
 .PHONY: all build scan clean help lint-workflows check-autoupdate
 .PHONY: zookeeper zookeeper-melange test-zookeeper
 .PHONY: tomcat tomcat-melange test-tomcat
+.PHONY: pgbouncer pgbouncer-melange pgbouncer-dev test-pgbouncer test-pgbouncer-dev
+.PHONY: unbound unbound-melange unbound-dev test-unbound test-unbound-dev
 .PHONY: python python-dev jenkins jenkins-melange go go-dev node-slim node-slim-dev nginx httpd redis-slim redis-slim-melange redis-slim-dev mysql mysql-melange mysql-local memcached memcached-melange memcached-dev caddy caddy-melange haproxy haproxy-melange postgres-slim postgres-slim-dev bun bun-dev sqlite sqlite-dev dotnet dotnet-dev java java-dev ruby ruby-melange ruby-dev php php-melange php-dev rails rails-melange rails-dev deno deno-dev kafka kafka-melange keygen opensearch opensearch-melange opensearch-dev mariadb mariadb-melange mariadb-dev valkey valkey-melange valkey-dev
 .PHONY: valkey valkey-melange nats nats-melange traefik traefik-melange envoy envoy-melange rabbitmq rabbitmq-melange minio minio-melange
 .PHONY: prometheus prometheus-melange alertmanager alertmanager-melange mariadb mariadb-melange
@@ -278,6 +282,8 @@ $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,consul,consul-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,tempo,tempo-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mosquitto,mosquitto-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,pgbouncer,pgbouncer-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,unbound,unbound-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,telegraf,telegraf-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mimir,mimir-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 
@@ -2184,6 +2190,52 @@ mosquitto: mosquitto-melange
 	@rm -f mosquitto.tar sbom-*.spdx.json
 	@echo "✓ minimal-mosquitto built (source build)"
 
+pgbouncer-melange: keygen
+	@echo "Building PgBouncer $(PGBOUNCER_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build pgbouncer/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ PgBouncer package built from source"
+
+pgbouncer: pgbouncer-melange
+	@echo "Assembling minimal-pgbouncer image with apko..."
+	apko build pgbouncer/apko/pgbouncer.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-pgbouncer:$(VERSION) \
+		pgbouncer.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < pgbouncer.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-pgbouncer:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-pgbouncer:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-pgbouncer:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-pgbouncer:latest
+	@rm -f pgbouncer.tar sbom-*.spdx.json
+	@echo "✓ minimal-pgbouncer built (source build)"
+
+unbound-melange: keygen
+	@echo "Building Unbound $(UNBOUND_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build unbound/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Unbound package built from source"
+
+unbound: unbound-melange
+	@echo "Assembling minimal-unbound image with apko..."
+	apko build unbound/apko/unbound.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-unbound:$(VERSION) \
+		unbound.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < unbound.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-unbound:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-unbound:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-unbound:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-unbound:latest
+	@rm -f unbound.tar sbom-*.spdx.json
+	@echo "✓ minimal-unbound built (source build)"
+
 helm-melange: keygen
 	@echo "Building Helm $(HELM_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
 	melange build helm/melange.yaml \
@@ -2584,6 +2636,8 @@ $(eval $(call DEV_TEST_RULE,mailpit))
 $(eval $(call DEV_TEST_RULE,consul))
 $(eval $(call DEV_TEST_RULE,tempo))
 $(eval $(call DEV_TEST_RULE,mosquitto))
+$(eval $(call DEV_TEST_RULE,pgbouncer))
+$(eval $(call DEV_TEST_RULE,unbound))
 $(eval $(call DEV_TEST_RULE,telegraf))
 $(eval $(call DEV_TEST_RULE,mimir))
 
@@ -3065,6 +3119,18 @@ test-mosquitto:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-mosquitto:latest" && \
 		mosquitto/test.sh
 	@echo "✓ mosquitto tests passed"
+
+test-pgbouncer:
+	@echo "Testing pgbouncer image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-pgbouncer:latest" && \
+		pgbouncer/test.sh
+	@echo "✓ pgbouncer tests passed"
+
+test-unbound:
+	@echo "Testing unbound image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-unbound:latest" && \
+		unbound/test.sh
+	@echo "✓ unbound tests passed"
 
 test-helm:
 	@echo "Testing helm image..."

--- a/catalog.json
+++ b/catalog.json
@@ -26,6 +26,8 @@
     { "name": "mysql", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "mysql", "upstream_url": "https://www.mysql.com", "summary": "MySQL LTS built from source via melange." },
     { "name": "mariadb", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "mariadb", "upstream_url": "https://mariadb.org", "summary": "MariaDB LTS built from source via melange." },
     { "name": "postgres-slim", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "postgresql", "upstream_url": "https://www.postgresql.org", "summary": "PostgreSQL built on Wolfi." },
+    { "name": "pgbouncer", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "pgbouncer", "upstream_url": "https://www.pgbouncer.org", "summary": "Shell-less PgBouncer PostgreSQL connection pooler built from source via melange." },
+    { "name": "unbound", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "unbound", "upstream_url": "https://www.nlnetlabs.nl/projects/unbound/", "summary": "Shell-less Unbound validating recursive DNS resolver built from source via melange." },
     { "name": "sqlite", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "sqlite", "upstream_url": "https://www.sqlite.org", "summary": "Shell-less SQLite built on Wolfi." },
     { "name": "opensearch", "category": "Databases", "variants": ["prod", "dev"], "primary_package": "opensearch", "upstream_url": "https://opensearch.org", "summary": "OpenSearch 3.x on Wolfi with OpenJDK 21." },
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Image Roadmap — the road to 100 (demand-ranked)
 
-**Status: 70 / 100 images.** This is the source-of-truth plan for growing the catalog.
+**Status: 83 / 100 images.** This is the source-of-truth plan for growing the catalog.
 It supersedes the batch order from earlier sessions, which was ordered by *build ease* and
 *GitHub popularity*. This version is ordered by **actual container demand first**, then
 build effort.
@@ -64,9 +64,9 @@ by effort. Fills the catalog's thinnest categories (databases, proxies, apps).
 
 | ✓ | Image | Upstream | License | Build | 🐳 pulls | ⭐ | Notes |
 |---|---|---|---|---|---:|---:|---|
-| [ ] | pgbouncer | pgbouncer/pgbouncer | 🟢 ISC | C | 20M | 4k | Postgres pooler (thin DB cat) |
-| [ ] | unbound | NLnetLabs/unbound | 🟢 BSD | C | 12M | 5k | DNS resolver |
-| [ ] | varnish | varnishcache/varnish-cache | 🟢 BSD | C | 21M | 4k | HTTP cache |
+| [x] | pgbouncer | pgbouncer/pgbouncer | 🟢 ISC | C | 20M | 4k | Postgres pooler (thin DB cat) — shipped; underscore tags (tag-rewrite) |
+| [x] | unbound | NLnetLabs/unbound | 🟢 BSD | C | 12M | 5k | DNS resolver — shipped; `--sbindir=/usr/bin`, builtin evloop, local-data smoke test |
+| [ ] | ~~varnish~~ | varnishcache/varnish-cache | 🟢 BSD | C | 21M | 4k | **Deferred → see below.** varnishd compiles VCL with `cc` at runtime → needs gcc+binutils+headers in prod (breaks the shell-less/minimal thesis). |
 | [ ] | apisix | apache/apisix | 🟢 Apache-2.0 | C/Lua/OpenResty | 37M | 17k | API gateway (harder: OpenResty) |
 | [ ] | vaultwarden | dani-garcia/vaultwarden | 🟡 AGPL-3.0 | Rust | 304M | 64k | self-hosted Bitwarden |
 | [ ] | kvrocks | apache/kvrocks | 🟢 Apache-2.0 | C++ | 3.5M | 4k | Redis-on-RocksDB |
@@ -77,6 +77,7 @@ by effort. Fills the catalog's thinnest categories (databases, proxies, apps).
 
 | Image | Reason |
 |---|---|
+| varnish | varnishd compiles VCL → C → `.so` by invoking `cc` at runtime (`VCC_CC="exec cc … -fpic -shared -o %o %s"`), on every config load. A working prod image must therefore ship gcc + binutils + C headers + varnish's headers — a permanent compiler/attack-surface that breaks the "no compiler, minimum packages" thesis (Chainguard ships the toolchain for the same reason). Revisit only as a deliberate, documented exception, or pick a compiler-free HTTP-cache alternative. |
 | kubescape | Go, but a large build — needs ~40 G local disk freed (stale `/tmp/bubblewrap-guest-*`). Recipe already generated in batch-b; onboard once disk allows. |
 | pomerium | 1.6B pulls but `//go:embed`s an arch-specific Envoy binary (data plane). Needs an Envoy-fetch step + cross-arch handling — Envoy-image-class effort, not a clean crank. |
 | cmctl | cert-manager's `makefile-modules`/klone build; no clean `-X` version injection. Needs its own investigation of the version mechanism. |

--- a/pgbouncer/apko/pgbouncer-dev.yaml
+++ b/pgbouncer/apko/pgbouncer-dev.yaml
@@ -1,0 +1,87 @@
+# Development variant of minimal-pgbouncer.
+# Same source-built pgbouncer as prod, plus a shell and the tools you actually
+# reach for when debugging a pooler: psql (talk to the PgBouncer admin console
+# on :6432), curl/openssl, and bind-tools (DNS is the usual misconfig).
+#
+# In-house composition. Not for production.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base + pgbouncer (same as prod)
+    - wolfi-baselayout
+    - pgbouncer-minimal
+    - glibc
+    - ld-linux
+    - libgcc
+    - libevent
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- Postgres client: talk to the PgBouncer admin console
+    #     (`psql -p 6432 pgbouncer` → SHOW POOLS / SHOW STATS) ---
+    - postgresql-client
+
+    # --- HTTP / TLS debugging ---
+    - curl
+    - openssl
+
+    # --- DNS debugging (pooler resolves upstream DB hostnames) ---
+    - bind-tools
+
+    # --- VCS ---
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/pgbouncer
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-pgbouncer-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-pgbouncer: same pgbouncer + shell + psql (admin console) + curl/openssl/dig. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/pgbouncer"
+  org.opencontainers.image.licenses: "ISC"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/pgbouncer/apko/pgbouncer.yaml
+++ b/pgbouncer/apko/pgbouncer.yaml
@@ -1,0 +1,70 @@
+# Minimal PgBouncer image - built from source via melange
+# CVE patching via daily rebuilds from upstream source
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Our PgBouncer (built from source via melange)
+    - pgbouncer-minimal
+
+    # Core libraries
+    - glibc
+    - ld-linux
+    - libgcc
+
+    # libevent (event loop + evdns)
+    - libevent
+
+    # SSL/TLS libraries
+    - libssl3
+    - libcrypto3
+
+    # Certificates
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/pgbouncer /etc/pgbouncer/pgbouncer.ini
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/pgbouncer
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-pgbouncer"
+  org.opencontainers.image.description: "Hardened shell-less PgBouncer PostgreSQL connection pooler built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/pgbouncer"
+  org.opencontainers.image.licenses: "ISC"
+
+archs:
+  - x86_64
+  - aarch64

--- a/pgbouncer/melange.yaml
+++ b/pgbouncer/melange.yaml
@@ -1,0 +1,104 @@
+# Melange build configuration for minimal PgBouncer
+# Pure C from source, autotools build. Lightweight PostgreSQL connection pooler.
+# License: ISC.
+
+package:
+  name: pgbouncer-minimal
+  version: 1.25.2
+  epoch: 0
+  description: "Minimal PgBouncer PostgreSQL connection pooler built from source"
+  copyright:
+    - license: ISC
+
+vars:
+  # SHA256 of pgbouncer-{version}.tar.gz - updated by update-versions.yml
+  sha256: 924ad35113fd0a71c8e2dbe85b5d03445532e2b7b37a9f8a48983beea238b332
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - pkgconf
+      - libevent-dev
+      - openssl-dev
+
+pipeline:
+  # Download and verify the release dist tarball (ships a pre-generated
+  # configure — no autoreconf/autotools-dev needed).
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://www.pgbouncer.org/downloads/files/${{package.version}}/pgbouncer-${{package.version}}.tar.gz" \
+        -o /home/build/pgbouncer.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/pgbouncer.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf pgbouncer.tar.gz
+      rm pgbouncer.tar.gz
+
+  # Build: TLS via OpenSSL, DNS via libevent's evdns (no c-ares dep). Build the
+  # `pgbouncer` binary target only — the default `all` target also builds the
+  # man page via pandoc (doc/pgbouncer.1), which we don't ship in the sandbox.
+  - runs: |
+      cd /home/build/pgbouncer-${{package.version}}
+      ./configure \
+        --prefix=/usr \
+        --with-openssl \
+        --disable-debug
+      make -j"$(nproc)" pgbouncer
+
+  # Install into destdir (copy the binary directly to avoid `make install`,
+  # which depends on the docs target) + a sane minimal container config.
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/pgbouncer-${{package.version}}/pgbouncer "${{targets.destdir}}/usr/bin/"
+      strip --strip-unneeded "${{targets.destdir}}/usr/bin/pgbouncer"
+
+      # Default config: pool on :6432, log to stdout, no pidfile, sockets in
+      # /tmp (the only writable dir for nonroot). Users override by mounting
+      # their own /etc/pgbouncer/pgbouncer.ini. auth_type=trust + an empty
+      # userlist keeps a fresh container runnable; tighten for real use.
+      mkdir -p "${{targets.destdir}}/etc/pgbouncer"
+      cat > "${{targets.destdir}}/etc/pgbouncer/pgbouncer.ini" << 'CFG'
+      [databases]
+      ;; Add your target databases here, e.g.:
+      ;; mydb = host=postgres port=5432 dbname=mydb
+
+      [pgbouncer]
+      listen_addr = 0.0.0.0
+      listen_port = 6432
+      unix_socket_dir = /tmp
+      auth_type = trust
+      auth_file = /etc/pgbouncer/userlist.txt
+      admin_users = postgres
+      pool_mode = transaction
+      max_client_conn = 100
+      default_pool_size = 20
+      logfile =
+      pidfile =
+      CFG
+      cat > "${{targets.destdir}}/etc/pgbouncer/userlist.txt" << 'USERS'
+      ;; "username" "password"  — populate for md5/scram auth.
+      USERS
+
+  # Verify the build
+  - runs: |
+      echo "Verifying PgBouncer build..."
+      "${{targets.destdir}}/usr/bin/pgbouncer" --version
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/pgbouncer"
+
+update:
+  enabled: true
+  github:
+    identifier: pgbouncer/pgbouncer
+    use-tag: true
+    tag-filter: "pgbouncer_1_"

--- a/pgbouncer/test-dev.sh
+++ b/pgbouncer/test-dev.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Smoke test for minimal-pgbouncer-dev.
+# Same functional checks as prod, PLUS: a shell IS present, and the debugging
+# tools (psql for the admin console) are available.
+set -eu
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing PgBouncer version..."
+docker run --rm --entrypoint /usr/bin/pgbouncer "$IMAGE" --version 2>&1 | grep -qiE 'PgBouncer 1\.' \
+  || { echo "FAIL: version string not found"; exit 1; }
+
+echo "Testing PgBouncer starts and listens on :6432..."
+cid=$(docker run -d -p 16433:6432 "$IMAGE")
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+ok=0
+for _ in $(seq 1 15); do
+  if docker logs "$cid" 2>&1 | grep -qiE 'process up|listening on'; then ok=1; break; fi
+  if [ -z "$(docker ps -q --filter id="$cid")" ]; then break; fi
+  sleep 1
+done
+[ "$ok" = 1 ] || { echo "FAIL: pgbouncer did not come up"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+
+echo "Verifying shell IS present (dev)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'echo shell-ok' 2>/dev/null | grep -q shell-ok \
+  || { echo "FAIL: no shell in dev image"; exit 1; }
+
+echo "Verifying psql (admin console client) is present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'command -v psql' >/dev/null 2>&1 \
+  || { echo "FAIL: psql missing from dev image"; exit 1; }
+
+echo "All PgBouncer dev tests passed!"

--- a/pgbouncer/test.sh
+++ b/pgbouncer/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Smoke test for minimal-pgbouncer (prod).
+set -eu
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing PgBouncer version..."
+docker run --rm --entrypoint /usr/bin/pgbouncer "$IMAGE" --version 2>&1 | grep -qiE 'PgBouncer 1\.' \
+  || { echo "FAIL: version string not found"; exit 1; }
+
+echo "Testing PgBouncer starts and listens on :6432..."
+cid=$(docker run -d -p 16432:6432 "$IMAGE")
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+ok=0
+for _ in $(seq 1 15); do
+  if docker logs "$cid" 2>&1 | grep -qiE 'process up|listening on'; then ok=1; break; fi
+  if [ -z "$(docker ps -q --filter id="$cid")" ]; then break; fi
+  sleep 1
+done
+if [ "$ok" != 1 ]; then
+  echo "FAIL: pgbouncer did not come up"; docker logs "$cid" 2>&1 | tail -20; exit 1
+fi
+
+echo "Verifying the pooler accepts TCP connections on :6432..."
+(exec 3<>/dev/tcp/127.0.0.1/16432) 2>/dev/null \
+  && echo "port 6432 accepts connections" \
+  || { echo "FAIL: cannot connect to :6432"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo x" 2>/dev/null \
+  && { echo "FAIL: shell found!"; exit 1; } \
+  || echo "No shell (as expected)"
+
+echo "All PgBouncer tests passed!"

--- a/unbound/apko/unbound-dev.yaml
+++ b/unbound/apko/unbound-dev.yaml
@@ -1,0 +1,83 @@
+# Development variant of minimal-unbound.
+# Same source-built unbound as prod, plus a shell and the tools you reach for
+# when debugging a resolver: bind-tools (dig/drill), curl/openssl. Also carries
+# unbound-control/unbound-checkconf (already in the package) for live inspection.
+#
+# In-house composition. Not for production.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base + unbound (same as prod)
+    - wolfi-baselayout
+    - unbound-minimal
+    - glibc
+    - ld-linux
+    - libgcc
+    - libssl3
+    - libcrypto3
+    - expat
+    - ca-certificates-bundle
+
+    # --- Dev variant minimum (CONVENTIONS.md) ---
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+
+    # --- DNS debugging: dig / drill / nslookup ---
+    - bind-tools
+
+    # --- HTTP / TLS debugging ---
+    - curl
+    - openssl
+
+    # --- VCS ---
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/unbound -d -c /etc/unbound/unbound.conf
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+  LANG: C.UTF-8
+
+paths:
+  - path: /etc/unbound
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-unbound-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-unbound: same unbound + shell + bind-tools (dig) + curl/openssl. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/unbound"
+  org.opencontainers.image.licenses: "BSD-3-Clause"
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/unbound/apko/unbound.yaml
+++ b/unbound/apko/unbound.yaml
@@ -1,0 +1,72 @@
+# Minimal Unbound image - built from source via melange
+# CVE patching via daily rebuilds from upstream source
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    # Base filesystem
+    - wolfi-baselayout
+
+    # Our Unbound (built from source via melange)
+    - unbound-minimal
+
+    # Core libraries
+    - glibc
+    - ld-linux
+    - libgcc
+
+    # SSL/TLS (DNSSEC validation, DoT)
+    - libssl3
+    - libcrypto3
+
+    # XML parser (unbound-anchor reads the DNSSEC root anchor)
+    - expat
+
+    # Certificates
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Foreground (-d) recursive resolver. Binding :53 as nonroot requires the
+# NET_BIND_SERVICE capability or `--sysctl net.ipv4.ip_unprivileged_port_start=0`.
+entrypoint:
+  command: /usr/bin/unbound -d -c /etc/unbound/unbound.conf
+
+environment:
+  PATH: /usr/bin:/bin
+
+paths:
+  - path: /etc/unbound
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-unbound"
+  org.opencontainers.image.description: "Hardened shell-less Unbound validating recursive DNS resolver built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/unbound"
+  org.opencontainers.image.licenses: "BSD-3-Clause"
+
+archs:
+  - x86_64
+  - aarch64

--- a/unbound/melange.yaml
+++ b/unbound/melange.yaml
@@ -1,0 +1,119 @@
+# Melange build configuration for minimal Unbound
+# Pure C from source, autotools build. Validating, recursive, caching DNS resolver.
+# License: BSD-3-Clause.
+
+package:
+  name: unbound-minimal
+  version: 1.25.1
+  epoch: 0
+  description: "Minimal Unbound validating recursive DNS resolver built from source"
+  copyright:
+    - license: BSD-3-Clause
+
+vars:
+  # SHA256 of unbound-{version}.tar.gz - updated by update-versions.yml
+  sha256: 0fe8b6277b0959cfd17562debac0aa5f71e0b02dc4ffa9c60271c583edab586f
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - openssl-dev
+      - expat-dev
+
+pipeline:
+  # Download and verify the source tarball.
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://nlnetlabs.nl/downloads/unbound/unbound-${{package.version}}.tar.gz" \
+        -o /home/build/unbound.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/unbound.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf unbound.tar.gz
+      rm unbound.tar.gz
+
+  # Build: TLS via OpenSSL, config parsing via libexpat, builtin event loop
+  # (--with-libevent=no avoids a libevent runtime dep), no Python module.
+  # --sbindir=/usr/bin installs the daemon straight into /usr/bin (Wolfi is
+  # usrmerge — /usr/sbin doesn't exist), avoiding a post-install relocate.
+  - runs: |
+      cd /home/build/unbound-${{package.version}}
+      ./configure \
+        --prefix=/usr \
+        --sbindir=/usr/bin \
+        --sysconfdir=/etc \
+        --with-ssl \
+        --with-libexpat=/usr \
+        --with-libevent=no \
+        --without-pythonmodule \
+        --without-pyunbound \
+        --disable-static \
+        --disable-rpath
+      make -j"$(nproc)"
+
+  # Install into destdir + a nonroot-friendly recursive-resolver config.
+  - runs: |
+      cd /home/build/unbound-${{package.version}}
+      make install DESTDIR="${{targets.destdir}}"
+
+      # Drop control-setup helper cruft we don't ship; strip the binaries.
+      for b in unbound unbound-checkconf unbound-control unbound-anchor unbound-host; do
+        [ -f "${{targets.destdir}}/usr/bin/$b" ] && strip --strip-unneeded "${{targets.destdir}}/usr/bin/$b" || true
+      done
+
+      # Default config: foreground recursive resolver on :53, no chroot/setuid
+      # (the image already runs as nonroot 65532), logs to stderr. Answers a
+      # local health record from local-data with no recursion — used by the
+      # smoke test for an offline resolution round-trip. Users mount their own
+      # /etc/unbound/unbound.conf to override. Binding :53 as nonroot needs the
+      # NET_BIND_SERVICE cap or `--sysctl net.ipv4.ip_unprivileged_port_start=0`.
+      mkdir -p "${{targets.destdir}}/etc/unbound"
+      cat > "${{targets.destdir}}/etc/unbound/unbound.conf" << 'CFG'
+      server:
+          verbosity: 1
+          interface: 0.0.0.0
+          port: 53
+          do-daemonize: no
+          username: ""
+          chroot: ""
+          directory: "/etc/unbound"
+          pidfile: ""
+          use-syslog: no
+          logfile: ""
+          do-ip6: no
+          hide-identity: yes
+          hide-version: yes
+          access-control: 127.0.0.0/8 allow
+          access-control: 10.0.0.0/8 allow
+          access-control: 172.16.0.0/12 allow
+          access-control: 192.168.0.0/16 allow
+          local-zone: "health.local." static
+          local-data: "health.local. IN A 127.0.0.1"
+      CFG
+
+  # Verify the build. NB: don't run unbound-checkconf here — it chdir's to the
+  # config's runtime `directory: /etc/unbound`, which doesn't exist in the build
+  # sandbox (only destdir/etc/unbound does). The smoke test runs checkconf inside
+  # the assembled container, where /etc/unbound is present.
+  - runs: |
+      echo "Verifying Unbound build..."
+      "${{targets.destdir}}/usr/bin/unbound" -V | head -2
+      echo "Binary size:"
+      ls -lh "${{targets.destdir}}/usr/bin/unbound"
+
+update:
+  enabled: true
+  github:
+    identifier: NLnetLabs/unbound
+    use-tag: true
+    tag-filter: "release-1."

--- a/unbound/test-dev.sh
+++ b/unbound/test-dev.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Smoke test for minimal-unbound-dev.
+# Boots the resolver, then does a fully self-contained DNS round-trip using the
+# image's OWN dig (dev ships bind-tools) against the local-data health record.
+set -eu
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Unbound version..."
+docker run --rm --entrypoint /usr/bin/unbound "$IMAGE" -V 2>&1 | grep -qiE 'Version 1\.' \
+  || { echo "FAIL: version string not found"; exit 1; }
+
+echo "Starting Unbound (dev)..."
+cid=$(docker run -d --sysctl net.ipv4.ip_unprivileged_port_start=0 "$IMAGE")
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+ok=0
+for _ in $(seq 1 15); do
+  if docker logs "$cid" 2>&1 | grep -qiE 'start of service'; then ok=1; break; fi
+  if [ -z "$(docker ps -q --filter id="$cid")" ]; then break; fi
+  sleep 1
+done
+[ "$ok" = 1 ] || { echo "FAIL: unbound did not start"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+
+echo "Verifying shell IS present (dev)..."
+docker exec "$cid" /bin/sh -c 'echo shell-ok' 2>/dev/null | grep -q shell-ok \
+  || { echo "FAIL: no shell in dev image"; exit 1; }
+
+echo "DNS round-trip via the image's own dig (offline, local-data)..."
+ans=$(docker exec "$cid" dig @127.0.0.1 health.local A +short 2>/dev/null | tr -d '\r' | head -1)
+[ "$ans" = "127.0.0.1" ] \
+  && echo "health.local -> $ans" \
+  || { echo "FAIL: expected 127.0.0.1, got '${ans:-<none>}'"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+
+echo "All Unbound dev tests passed!"

--- a/unbound/test.sh
+++ b/unbound/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Smoke test for minimal-unbound (prod).
+set -eu
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing Unbound version..."
+docker run --rm --entrypoint /usr/bin/unbound "$IMAGE" -V 2>&1 | grep -qiE 'Version 1\.' \
+  || { echo "FAIL: version string not found"; exit 1; }
+
+echo "Validating shipped config (offline)..."
+docker run --rm --entrypoint /usr/bin/unbound-checkconf "$IMAGE" /etc/unbound/unbound.conf \
+  || { echo "FAIL: unbound-checkconf rejected the shipped config"; exit 1; }
+
+echo "Testing Unbound daemon starts and binds :53..."
+# nonroot needs the unprivileged-port sysctl to bind 53 in the smoke test.
+cid=$(docker run -d --sysctl net.ipv4.ip_unprivileged_port_start=0 \
+        -p 15353:53/udp -p 15353:53/tcp "$IMAGE")
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+ok=0
+for _ in $(seq 1 15); do
+  if docker logs "$cid" 2>&1 | grep -qiE 'start of service'; then ok=1; break; fi
+  if [ -z "$(docker ps -q --filter id="$cid")" ]; then break; fi
+  sleep 1
+done
+[ "$ok" = 1 ] || { echo "FAIL: unbound did not start"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+
+echo "Resolution round-trip against local-data (offline)..."
+if command -v dig >/dev/null 2>&1; then
+  ans=$(dig @127.0.0.1 -p 15353 health.local A +short 2>/dev/null || true)
+  [ "$ans" = "127.0.0.1" ] \
+    && echo "health.local -> $ans (resolver answered from local-data)" \
+    || { echo "FAIL: expected 127.0.0.1, got '${ans:-<none>}'"; docker logs "$cid" 2>&1 | tail -20; exit 1; }
+else
+  echo "(host has no dig; daemon-bind + checkconf already prove the resolver works)"
+fi
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo x" 2>/dev/null \
+  && { echo "FAIL: shell found!"; exit 1; } \
+  || echo "No shell (as expected)"
+
+echo "All Unbound tests passed!"

--- a/vex/pgbouncer.openvex.json
+++ b/vex/pgbouncer.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/pgbouncer",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-16T23:37:21Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/unbound.openvex.json
+++ b/vex/unbound.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/unbound",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-17T02:58:39Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Adds two demand-ranked Tier-3 images from `docs/roadmap.md`, both hardened, shell-less, source-built via melange, with prod + dev variants. **81 → 83 images.**

## pgbouncer 1.25.2 (ISC) — PostgreSQL connection pooler
Fills the thin **Databases** category (~20M pulls).
- autotools; builds the `pgbouncer` target only (the default `all` target also builds a pandoc man page we don't ship).
- versions.yaml uses `tag-rewrite: {from: '_', to: '.'}` for pgbouncer's underscore tags (`pgbouncer_1_25_2`); tarball from pgbouncer.org's dotted-version path.

## unbound 1.25.1 (BSD-3-Clause) — validating recursive DNS resolver
**Infrastructure** category (~12M pulls).
- autotools with `--sbindir=/usr/bin` (Wolfi usrmerge — no post-install relocate), builtin event loop (no libevent runtime dep), no chroot/setuid in the shipped config (already runs nonroot 65532).
- Smoke tests do a real, offline DNS resolution round-trip against a `local-data` health record (`health.local → 127.0.0.1`).

## Verification (local, x86_64)
- `make <img>` + `make <img>-dev` assemble; `make test-<img>` + `make test-<img>-dev` pass for both.
- `make check-autoupdate` → 83/83 configured; `make lint-workflows` clean.
- Both versions.yaml rows dispatch-validated: resolve `current == latest`, no spurious bump.
- aarch64 builds on CI's native ARM runners.

## varnish deferred
`varnishd` compiles VCL with `cc` at **runtime** (`VCC_CC="exec cc … -fpic -shared -o %o %s"`), so a working prod image would need gcc + binutils + headers permanently — a compiler/attack-surface that breaks the shell-less/minimal thesis. Documented in `docs/roadmap.md`; revisit as a deliberate exception or pick a compiler-free HTTP-cache alternative.