### PR TITLE
fix(patch-go-deps): exclude kaniko + skopeo (tangled vendored graphs)

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -284,7 +284,14 @@ jobs:
           # upstream app-version bump (update-versions.yml — the vendor bumps
           # their own go.mod) plus the 6-hourly base rebuild; a genuinely
           # reachable gap gets a manual targeted bump or a VEX not_affected.
-          SKIP_IMAGES=" trivy "
+          # kaniko and skopeo joined trivy here (2026-07-19, PR #426 fallout):
+          # both vendor the docker/moby/buildkit/containers stack, so grype's
+          # bumps break them the same way — kaniko: docker/docker bump →
+          # "undefined: archive.Compression" in vendored archive_deprecated.go;
+          # skopeo: buildkit needs docker/cli v29.2.1 + fulcio needs v29.4.0 vs
+          # grype's v29.2.0 → `go get` aborts on the version conflict. Pure
+          # upstream + version-bump + VEX, same as trivy.
+          SKIP_IMAGES=" trivy kaniko skopeo "
           for IMAGE in "${!MODROOTS[@]}"; do
             if [[ "$SKIP_IMAGES" == *" $IMAGE "* ]]; then
               echo "=== Skipping $IMAGE (excluded from auto transitive dep-patching; tracked via update-versions + base rebuild) ==="

--- a/kaniko/melange.yaml
+++ b/kaniko/melange.yaml
@@ -42,18 +42,11 @@ pipeline:
       tar xzf /home/build/kaniko.tar.gz -C /home/build/kaniko-${{package.version}} --strip-components=1
       rm /home/build/kaniko.tar.gz
 
+  # NOTE: excluded from patch-go-deps (SKIP_IMAGES) — kaniko vendors the
+  # docker/moby stack, whose graph is too tangled to force-bump (a docker/docker
+  # bump breaks vendored archive_deprecated.go). Builds pure upstream from
+  # vendor/; transitive CVEs ride the version bump + base rebuild + VEX.
   # Version is reported via pkg/version.version (see upstream Makefile).
-  # patch-go-deps: auto-generated — do not edit manually
-  - runs: |
-      export GOWORK=off
-      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
-      for root in /home/build/kaniko-${{package.version}}; do
-        [ -f "$root/go.mod" ] || continue
-        ( cd "$root" \
-          && go mod tidy -e \
-          && { [ ! -d vendor ] || go mod vendor; } )
-      done
-  # end-patch-go-deps
   - runs: |
       cd /home/build/kaniko-${{package.version}}
       GOTOOLCHAIN=local CGO_ENABLED=0 go build \

--- a/skopeo/melange.yaml
+++ b/skopeo/melange.yaml
@@ -44,19 +44,13 @@ pipeline:
       tar xzf /home/build/skopeo.tar.gz -C /home/build/skopeo-${{package.version}} --strip-components=1
       rm /home/build/skopeo.tar.gz
 
+  # NOTE: excluded from patch-go-deps (SKIP_IMAGES) — skopeo vendors the
+  # containers/buildkit/docker stack, whose graph is too tangled to force-bump
+  # (buildkit needs docker/cli v29.2.1, fulcio v29.4.0 → `go get` conflicts).
+  # Builds pure upstream from vendor/; transitive CVEs ride the version bump +
+  # base rebuild + VEX.
   # CGO_ENABLED=0 + -tags containers_image_openpgp → static binary with no
   # libgpgme/btrfs/devmapper C deps (Go-native OpenPGP, graphdrivers excluded).
-  # patch-go-deps: auto-generated — do not edit manually
-  - runs: |
-      export GOWORK=off
-      _retry() { local i; for i in 5 15 30; do "$@" && return 0; echo "retry: $* failed, sleeping ${i}s"; sleep $i; done; "$@"; }
-      for root in /home/build/skopeo-${{package.version}}; do
-        [ -f "$root/go.mod" ] || continue
-        ( cd "$root" \
-          && go mod tidy -e \
-          && { [ ! -d vendor ] || go mod vendor; } )
-      done
-  # end-patch-go-deps
   - runs: |
       cd /home/build/skopeo-${{package.version}}
       GOTOOLCHAIN=local CGO_ENABLED=0 go build \


### PR DESCRIPTION
## Root cause (PR #426)
The first `patch-go-deps` run after Batch F merged broke on the two new container-tooling images:

- **kaniko** — grype bumped `docker/docker` for a CVE; the newer docker's vendored `archive_deprecated.go` references `archive.Compression` / `archive.Uncompressed` that kaniko's code doesn't match → `undefined: archive.Compression`.
- **skopeo** — sibling conflict: `buildkit` requires `docker/cli@v29.2.1`, `fulcio` requires `v29.4.0`, but grype pinned `v29.2.0` → `go get` aborts.

Both vendor the **docker/moby/buildkit/containers** stack — the same **trivy-class tangled graph** where blind transitive force-bumping can't converge (documented in `docs/onboarding.md` §10).

## Fix
- Add `kaniko` and `skopeo` to `SKIP_IMAGES` (join trivy).
- Strip their seed patch-go-deps blocks → build **pure upstream from `vendor/`**.
- Transitive CVEs now ride the `update-versions` app bump + 6-hourly base rebuild + VEX, exactly like trivy.

This was an onboarding mis-classification on my part in Batch F — they should have been SKIP-listed from the start (container tooling with docker/moby vendoring is always trivy-class).

## Verification
- Both build clean locally (x86_64) with no patch block — melange verify runs `executor version` / `skopeo --version`.
- `make lint-workflows` clean.

After merge, the next `patch-go-deps` cron regenerates the shared PR **excluding** kaniko/skopeo (keeping other images' valid patches).