### PR TITLE
fix(update-versions): stop php resolver hanging the cron on php.net stalls

### DIFF
--- a/.github/scripts/check-upstream.sh
+++ b/.github/scripts/check-upstream.sh
@@ -50,7 +50,10 @@ fi
 
 # --- fetch LATEST per source type ---
 gh_curl() {
-  curl -sS --retry 3 --retry-all-errors \
+  # --max-time bounds each attempt so a stalled endpoint (server accepts the
+  # connection then never sends a body — --connect-timeout alone won't catch it)
+  # fails fast instead of hanging the whole update-versions job.
+  curl -sS --connect-timeout 20 --max-time 20 --retry 3 --retry-all-errors \
     ${GH_TOKEN:+-H "Authorization: Bearer $GH_TOKEN"} \
     "$1"
 }
@@ -117,7 +120,7 @@ fetch_github_tags() {
 # Single URL returning the bare version as text (e.g. jenkins latestCore.txt).
 fetch_plain_text() {
   local url; url=$(j '.source.url')
-  curl -fsSL --retry 3 --retry-all-errors "$url" | tr -d '[:space:]'
+  curl -fsSL --connect-timeout 20 --max-time 20 --retry 3 --retry-all-errors "$url" | tr -d '[:space:]'
 }
 
 # Substitute {series} = "MAJOR.MINOR" of current version into a URL template.
@@ -134,7 +137,8 @@ fetch_first_url() {
   # Reads URLs from $@; returns first non-empty body.
   local u body
   for u in "$@"; do
-    body=$(curl -fsSL --connect-timeout 20 --retry 3 --retry-all-errors "$u" 2>/dev/null) || continue
+    # --max-time so a stalled URL fails fast and we fall through to the next one.
+    body=$(curl -fsSL --connect-timeout 20 --max-time 20 --retry 3 --retry-all-errors "$u" 2>/dev/null) || continue
     [ -n "$body" ] && { printf '%s' "$body"; return 0; }
   done
   return 1

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -851,7 +851,14 @@
   source:
     type: json
     # {series} is templated from current MAJOR.MINOR (e.g. 8.5) at check time.
-    url: "https://www.php.net/releases/index.php?json&version={series}"
+    # php.net's per-series JSON endpoint intermittently stalls for the current
+    # series (it hung on 8.5 in the 2026-07-20 run and 4-min-timed-out the job),
+    # so fall back to the major-only query — same {"version": ...} shape,
+    # currently reliable. fetch_first_url tries these in order; --max-time now
+    # bounds a stalled primary so the fallback is actually reached.
+    urls:
+      - "https://www.php.net/releases/index.php?json&version={series}"
+      - "https://www.php.net/releases/index.php?json&version=8"
     jq: '.version // empty'
     pin-major: 8
   tarball:


### PR DESCRIPTION
## Root cause
The **Update upstream versions** cron failed on 2026-07-20 (run 29732862367), on the **php** job. php.net's per-series JSON endpoint `releases/index.php?json&version=8.5` *accepted the connection then stalled sending a body*. The resolver's curl had `--connect-timeout` but **no `--max-time`**, so it hung ~4 min through retries and failed the job. Series 8.4 and the major-only query both respond in <1s — it's a php.net-side issue with the current (8.5) series.

## Fix (two parts — the alternative endpoint is a *fallback*, not a replacement)
1. **`check-upstream.sh`** — add `--max-time 20` to the metadata-fetch curls (`gh_curl`, `fetch_plain_text`, `fetch_first_url`). Healthy version endpoints answer in <1s, so a stalled URL now fails fast instead of hanging the whole job. This is general resilience for *any* flaky upstream — the real bug was the missing timeout.
2. **php `versions.yaml` row** — becomes a `urls:` list: the series endpoint stays **primary**, with the major-only `?json&version=8` (same `{"version":...}` shape, currently reliable) as **fallback**. `fetch_first_url` falls through when the primary stalls.

## Verification
- php now resolves `8.5.8` via the fallback in **~87s** (was a ~4-min hang → fail).
- `bash -n` + `shellcheck -S error` clean.

Note: the other recent red runs (patch-go-deps on kaniko/skopeo) are fixed separately in #427.