### PR TITLE
fix(audit): correctness fixes + preventive guards (PR1/5)

### DIFF
--- a/.github/scripts/check-upstream.sh
+++ b/.github/scripts/check-upstream.sh
@@ -48,6 +48,20 @@ else
 fi
 [ -n "$current" ] || { echo "::error::could not read current version for $name"; exit 1; }
 
+# --- pin-alignment guard ---
+# The configured pin-major MUST match the current recipe's major. If it doesn't,
+# the row is misconfigured: the pin-major guard below treats every same-major
+# release as an un-adopted "new major" and silently freezes the image (helmfile
+# 1.7.0 pinned to `7` did exactly this — zero updates since onboarding). Fail
+# loudly here so the mistake is visible instead of a quiet freeze.
+if [ -n "$pin_major" ]; then
+  current_major="${current%%.*}"
+  if [ "$current_major" != "$pin_major" ]; then
+    echo "::error::$name: pin-major=$pin_major does not match current version $current (major $current_major) — fix the row's pin-major"
+    exit 1
+  fi
+fi
+
 # --- fetch LATEST per source type ---
 gh_curl() {
   # --max-time bounds each attempt so a stalled endpoint (server accepts the
@@ -208,7 +222,15 @@ if [ -n "$pin_major" ]; then
   fi
 fi
 
-if [ "$latest" = "$current" ]; then
+# --- no-downgrade guard ---
+# Only advance forward. `latest != current` alone would let a stale endpoint,
+# an incomplete tag window, or a misconfigured source emit a DOWNGRADE PR.
+# Require latest > current (semver) before proposing an update.
+highest=$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -1)
+if [ "$latest" = "$current" ] || [ "$highest" != "$latest" ]; then
+  if [ "$latest" != "$current" ]; then
+    echo "::warning::$name: upstream latest ($latest) is not newer than current ($current) — not downgrading"
+  fi
   echo "update=false" >> "$out"
   echo "current_version=$current" >> "$out"
   exit 0

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -351,7 +351,7 @@
 - name: helmfile
   cron-enabled: true   # tier 2 (validated 2026-07-12)
   files: [helmfile/melange.yaml]
-  source: { type: github-releases-latest, repo: helmfile/helmfile, strip-v: true, pin-major: 7 }
+  source: { type: github-releases-latest, repo: helmfile/helmfile, strip-v: true, pin-major: 1 }
   tarball: { url: "https://github.com/helmfile/helmfile/archive/refs/tags/v{version}.tar.gz", field: sha256 }
   major-issue: true
   links:

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -121,6 +121,9 @@ jobs:
             [cosign]="/home/build/cosign-${D}{{package.version}}"
             [syft]="/home/build/syft-${D}{{package.version}}"
             [grype]="/home/build/grype-${D}{{package.version}}"
+            [node-exporter]="/home/build/node_exporter-${D}{{package.version}}"
+            [blackbox-exporter]="/home/build/blackbox_exporter-${D}{{package.version}}"
+            [pushgateway]="/home/build/pushgateway-${D}{{package.version}}"
             [oras]="/home/build/oras-${D}{{package.version}}"
             [gitleaks]="/home/build/gitleaks-${D}{{package.version}}"
             [step-cli]="/home/build/step-cli-${D}{{package.version}}"
@@ -182,6 +185,9 @@ jobs:
             [cosign]="github.com/sigstore/cosign/v3"
             [syft]="github.com/anchore/syft"
             [grype]="github.com/anchore/grype"
+            [node-exporter]="github.com/prometheus/node_exporter"
+            [blackbox-exporter]="github.com/prometheus/blackbox_exporter"
+            [pushgateway]="github.com/prometheus/pushgateway"
             [oras]="oras.land/oras"
             [gitleaks]="github.com/zricethezav/gitleaks/v8"
             [step-cli]="github.com/smallstep/cli"
@@ -242,6 +248,9 @@ jobs:
             [cosign]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [syft]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [grype]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [node-exporter]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [blackbox-exporter]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [pushgateway]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [oras]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [gitleaks]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [step-cli]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'

--- a/scripts/check-autoupdate-coverage.sh
+++ b/scripts/check-autoupdate-coverage.sh
@@ -127,9 +127,60 @@ for name in "${bespoke[@]:-}" "${exempt[@]:-}"; do
   in_prod "$name" || err "$COVERAGE lists '$name' which is not a prod image in $CATALOG"
 done
 
+# --- VEX existence: every prod image ships a vex/<name>.openvex.json ----------
+for img in "${prod[@]}"; do
+  [ -f "vex/$img.openvex.json" ] || err "$img: missing vex/$img.openvex.json (every catalog image needs a VEX file)"
+done
+
+# --- pin-alignment: a row's pin-major must equal its melange's current major --
+# A wrong pin silently freezes the image — the resolver treats every same-major
+# release as an un-adopted "new major" (helmfile 1.7.0 pinned to 7 → zero
+# updates since onboarding, yet coverage passed). Assert it here at PR time.
+# Read current the way the resolver does: a row may track a non-default field
+# (rails tracks `rails_version`, not `version`) or use a custom grep — skip those
+# we can't read simply rather than misfire.
+# NB: emit "-" for an absent current-field — never an empty field. IFS=$'\t'
+# treats tab as whitespace, so `read` collapses an empty field between two tabs
+# and misaligns the rest (this silently defeated the check at first).
+while IFS=$'\t' read -r rname melpath pinmaj curfield hasgrep; do
+  [ -n "$pinmaj" ] || continue
+  [ -f "$melpath" ] || continue
+  [ "$curfield" = "-" ] && curfield=""
+  if [ "$hasgrep" = "true" ] && [ -z "$curfield" ]; then
+    continue   # custom current-grep — resolver handles it; don't guess here
+  fi
+  field="${curfield:-version}"
+  # single awk (no grep|head pipe — that SIGPIPEs under set -o pipefail)
+  cur=$(awk -v f="$field" 'index($0,"  " f ":")==1 {v=$2; gsub(/"/,"",v); print v; exit}' "$melpath")
+  [ -n "$cur" ] || continue
+  curmaj="${cur%%.*}"
+  [ "$curmaj" = "$pinmaj" ] || err "$rname: versions.yaml pin-major=$pinmaj != current major $curmaj (version $cur) — this freezes the image"
+done < <(jq -r '
+  .[] | select(.source["pin-major"] != null) |
+  [ .name,
+    (.files[0] | if type=="string" then . else .path end),
+    (.source["pin-major"]|tostring),
+    (.source["current-field"] // "-"),
+    ((.source["current-grep"] != null)|tostring) ] | @tsv
+' <<<"$versions_json")
+
+# --- Go transitive-dep patching: every source-built Go image must be registered
+# in patch-go-deps.yml (as a MODROOTS key — SKIP/TESTKEEP images keep their key
+# too). Catches silently-unpatched Go images (blackbox/node-exporter/pushgateway
+# shipped this way). ------------------------------------------------------------
+PGD=".github/workflows/patch-go-deps.yml"
+for img in "${prod[@]}"; do
+  [ -f "$img/melange.yaml" ] || continue
+  # Go image heuristic: a whitespace-anchored "go build" (so Rust's
+  # "cargo build" — which contains the substring "go build" — doesn't match).
+  grep -qE '(^|[[:space:]])go build' "$img/melange.yaml" || continue
+  grep -qE "^[[:space:]]*\[$img\]=" "$PGD" \
+    || err "$img: source-built Go image not registered in patch-go-deps.yml (add to the 3 dicts, or SKIP/TESTKEEP it)"
+done
+
 if [ "$fail" -ne 0 ]; then
   echo
   echo "✗ auto-update coverage FAILED — every prod image must have exactly one live auto-update mechanism."
   exit 1
 fi
-echo "✓ auto-update coverage: all ${#prod[@]} prod images configured"
+echo "✓ auto-update coverage: all ${#prod[@]} prod images configured + VEX + pin-alignment + Go-patch registration"

--- a/vex/alertmanager.openvex.json
+++ b/vex/alertmanager.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/alertmanager",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-21T03:01:18Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/blackbox-exporter.openvex.json
+++ b/vex/blackbox-exporter.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/blackbox-exporter",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-21T03:01:18Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/node-exporter.openvex.json
+++ b/vex/node-exporter.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/node-exporter",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-21T03:01:18Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/pushgateway.openvex.json
+++ b/vex/pushgateway.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/pushgateway",
+  "author": "rtvkiz",
+  "timestamp": "2026-07-21T03:01:18Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
First of the sequenced audit remediation. Each live bug is fixed **and** paired with a CI-enforced invariant so the class can't recur (the anti-drift model).

## Live bugs fixed
- **helmfile pin 7 → 1** — it was pinned to a major that never existed, so the resolver treated every 1.x release as an un-adopted "new major" and **froze it at 1.7.0 with zero updates since onboarding**. Now advances (→ 1.7.1) and issue #403 stops recurring.
- **blackbox-exporter / node-exporter / pushgateway** — registered in `patch-go-deps` (all 3 dicts). They got app-version bumps but their transitive Go CVEs were never patched.
- **VEX** — added the 4 missing files (alertmanager + the 3 exporters).

## Guards added (prevent recurrence)
- **Resolver — pin-alignment**: fail loudly if a row's `pin-major` ≠ the current recipe major. The exact helmfile misconfig now errors instead of silently freezing.
- **Resolver — no-downgrade**: only propose an update when `latest > current` (semver) — a stale endpoint / short tag window / misconfig can't emit a downgrade PR.
- **Coverage gate — three new invariants**: every catalog image has a VEX file; every pinned row's `pin-major` matches its current major (respects `current-field`, e.g. rails tracks `rails_version`); every source-built Go image is registered in `patch-go-deps` (or SKIP/TESTKEEP).

## Verification
- Gate **catches** a reverted-bad helmfile pin and a downgrade; **passes clean** on all 88 (rails read via `current-field`; qdrant's `cargo build` no longer misread as Go — a false positive I caught and fixed while building the gate).
- `shellcheck` + `actionlint` clean.

Addresses audit findings #1, #2, #5, #6, and the VEX-enforcement gap. Next PRs: wolfi dev-parity (#3), major-detection review (#4), Makefile drift, misc hardening.