### PR TITLE
fix(patch-go-deps): opentofu → test-and-keep (unblock #435)

### DIFF
--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -285,6 +285,7 @@ jobs:
             [kaniko]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -o /dev/null ./cmd/executor'
             [skopeo]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -tags containers_image_openpgp -o /dev/null ./cmd/skopeo'
             [trivy]='GOTOOLCHAIN=local CGO_ENABLED=0 GOEXPERIMENT=jsonv2 go build -mod=mod -o /dev/null ./cmd/trivy'
+            [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -o /dev/null ./cmd/tofu'
           )
 
           HAS_PATCHES=false
@@ -313,7 +314,7 @@ jobs:
           # ones wait for the upstream release (logged per-dep, not silent).
           # SKIP_IMAGES stays for images we never auto-patch at all (none now).
           SKIP_IMAGES=" "
-          TESTKEEP_IMAGES=" trivy kaniko skopeo "
+          TESTKEEP_IMAGES=" trivy kaniko skopeo opentofu "
           for IMAGE in "${!MODROOTS[@]}"; do
             if [[ "$SKIP_IMAGES" == *" $IMAGE "* ]]; then
               echo "=== Skipping $IMAGE (excluded from auto transitive dep-patching; tracked via update-versions + base rebuild) ==="


### PR DESCRIPTION
## Root cause
The shared patch PR **#435** is red on **opentofu** (both arches):
```
go: github.com/rclone/rclone@v1.74.3 requires aws-sdk-go-v2/service/s3@v1.99.0,
    not aws-sdk-go-v2/service/s3@v1.97.3
```
grype's fix pins `s3@v1.97.3`, but opentofu's (un-bumped) `rclone` requires `v1.99.0`, so `go get` aborts — the trivy-class sibling conflict. The generation-time harmonizer misses it because rclone isn't in the bump set.

## Fix
opentofu vendors rclone (tangled graph), so add it to **TESTKEEP**. The probe drops the conflicting s3 bump (go-get fails → dropped + logged) and keeps every other fix that compiles — patch-what's-safe, build stays green. Added opentofu's exact probe command (`./cmd/tofu`) to `TESTKEEP_BUILD`. `actionlint` clean.

After merge: re-dispatch `patch-go-deps` to regenerate #435 with opentofu's test-and-keep block.

## Follow-up
Teach the harmonizer to raise a sibling to satisfy a *non-bumped* module's requirement (here `s3 → v1.99.0`, which is **higher** than grype's v1.97.3, so the CVE would still be fixed) — that would *patch* s3 rather than drop it.