### PR TITLE
fix(hardening): site threshold + Node LTS + script lint (PR5/5)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -57,7 +57,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          MIN=50   # catalog has 57 images; allow a few flaky scans
+          # Require a nearly-complete scan: catalog size minus a small
+          # tolerance for flaky per-image scans (was hardcoded 50 while the
+          # catalog grew to 88, letting a ~57%% scan qualify).
+          MIN=$(( $(jq '.images|length' catalog.json) - 3 ))
           RID=""
           for id in $(gh api "repos/${{ github.repository }}/actions/workflows/build.yml/runs?status=success&branch=main&per_page=20" \
                         --jq '.workflow_runs[].id'); do

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,14 @@ on:
   pull_request:
     paths:
       - '.github/workflows/**'
-      - 'scripts/lint-workflows.sh'
+      - '.github/scripts/**'
+      - 'scripts/**.sh'
   push:
     branches: [main]
     paths:
       - '.github/workflows/**'
-      - 'scripts/lint-workflows.sh'
+      - '.github/scripts/**'
+      - 'scripts/**.sh'
 
 permissions:
   contents: read

--- a/.github/workflows/update-wolfi-packages.yml
+++ b/.github/workflows/update-wolfi-packages.yml
@@ -85,8 +85,10 @@ jobs:
           echo "Current Node.js package: $CURRENT_NODE"
 
           # Find all nodejs-XX packages (LTS versions are even numbers)
+          # Node LTS lines are EVEN majors (20/22/24…); odd majors are
+          # short-lived non-LTS. Filter to even before picking the highest.
           LATEST_NODE=$(grep -E "^nodejs-[0-9]+ " /tmp/packages.txt | \
-            awk '{print $1}' | sort -t- -k2 -n | tail -1)
+            awk '{n=$1; sub(/nodejs-/,"",n); if (n%2==0) print $1}' | sort -t- -k2 -n | tail -1)
           echo "Latest Node.js package: $LATEST_NODE"
 
           if [ -n "$LATEST_NODE" ] && [ "$LATEST_NODE" != "$CURRENT_NODE" ]; then

--- a/scripts/lint-workflows.sh
+++ b/scripts/lint-workflows.sh
@@ -58,3 +58,15 @@ echo "actionlint $("$actionlint_bin" --version | head -1) + shellcheck $("$shell
 cd "$repo_root"
 "$actionlint_bin" -color .github/workflows/*.yml
 echo "✓ workflow lint clean"
+
+# --- standalone shell scripts ---
+# The workflows shell out to these (check-upstream.sh, apply-update.sh, the
+# coverage gate, …); actionlint only sees run: blocks, so a syntax/quoting bug
+# here would break update-versions / the gate the same way an unlinted run:
+# block would. Lint them at the same error-severity bar (shebang picks dialect).
+echo "shellchecking standalone scripts…"
+mapfile -t script_files < <(ls .github/scripts/*.sh scripts/*.sh 2>/dev/null || true)
+if [ "${#script_files[@]}" -gt 0 ]; then
+  "$shellcheck_bin" --severity=error "${script_files[@]}"
+fi
+echo "✓ scripts lint clean"


### PR DESCRIPTION
Final audit-remediation PR — the misc-hardening items.

- **deploy-site scan threshold**: was hardcoded `MIN=50` while the catalog grew to **88**, so a ~57%-complete scan could qualify as the site's source run. Now computed from `catalog.json` (`size - 3` tolerance) so it tracks catalog growth automatically.
- **Node LTS selection**: `update-wolfi-packages` picked the highest `nodejs-N` **including odd (non-LTS) majors**, despite claiming LTS. Now filters to **even majors** (the LTS lines) before taking the highest.
- **Lint standalone scripts**: `.github/scripts/**` and `scripts/**.sh` (check-upstream.sh, apply-update.sh, the coverage gate, …) were outside the lint trigger and **never shellchecked** — yet the workflows shell out to them, so a bug there breaks update-versions / the gate the same way an unlinted `run:` block would. Added them to the lint trigger paths and shellcheck them (error-severity) in `lint-workflows.sh`.

**Verified:** extended `make lint-workflows` passes clean on all standalone scripts (no pre-existing error-level issues); `actionlint` clean.

This completes the sequenced audit remediation (PR1–PR5). Deliberately deferred (documented): full Makefile dev-target completeness (local-convenience) and per-source major-detection for the 5 scrape/series rows (policy call).