### PR TITLE
fix(deferred): Makefile aggregates 88/88 + kafka/zookeeper major-detection

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -739,7 +739,7 @@
     urls:
       - "https://dlcdn.apache.org/kafka/"
       - "https://downloads.apache.org/kafka/"
-    pattern: 'href="4\.[0-9]+\.[0-9]+/"'
+    pattern: 'href="[0-9]+\.[0-9]+\.[0-9]+/"'
     pin-major: 4
   tarball:
     urls:
@@ -760,7 +760,7 @@
     urls:
       - "https://downloads.apache.org/zookeeper/"
       - "https://dlcdn.apache.org/zookeeper/"
-    pattern: 'href="zookeeper-(3\.[0-9]+\.[0-9]+)/"'
+    pattern: 'href="zookeeper-([0-9]+\.[0-9]+\.[0-9]+)/"'
     pin-major: 3
   tarball:
     urls:
@@ -774,6 +774,10 @@
     notes: "https://archive.apache.org/dist/zookeeper/zookeeper-{version}/"
 
 - name: tomcat
+  # Deliberately pinned to the Tomcat 11 line: the scrape URL points at the
+  # tomcat-11/ subdirectory. Detecting a new major (12) would need a two-level
+  # scrape of the parent dist listing (major dirs → version dirs) — a source
+  # redesign, tracked as a follow-up rather than done blindly.
   cron-enabled: true   # batch A JVM (validated 2026-07-13)
   files: [tomcat/melange.yaml]
   source:
@@ -831,6 +835,8 @@
 # ============================================================================
 
 - name: mariadb
+  # Deliberately pinned to the 11.4 LTS series (URL is series-scoped). New
+  # majors/LTS lines are a human decision (like mysql 8.4) — not auto-detected.
   cron-enabled: true   # wave 6
   files: [mariadb/melange.yaml]
   source:

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ endef
 all: build scan
 
 # Build all images
-build: python jenkins go node-slim nginx httpd redis-slim mysql memcached caddy haproxy postgres-slim bun sqlite dotnet java ruby php rails kafka valkey nats traefik envoy rabbitmq minio opensearch prometheus mariadb etcd victoria-metrics jaeger otelcol qdrant deno coredns openbao loki fluent-bit keycloak telegraf mimir gitea
+build: python node-slim bun go java ruby php dotnet deno mysql mariadb postgres-slim pgbouncer unbound external-dns velero kaniko step-ca skopeo sqlite opensearch redis-slim valkey memcached kafka zookeeper tomcat rabbitmq nats mosquitto nginx httpd caddy haproxy traefik envoy oauth2-proxy prometheus alertmanager victoria-metrics thanos mimir jaeger loki tempo otelcol fluent-bit telegraf node-exporter blackbox-exporter pushgateway coredns etcd openbao keycloak qdrant registry consul helm kubectl opentofu trivy cosign syft grype osv-scanner oras notation conftest kubeconform kube-bench trufflehog flux kustomize sops crane kubeseal helmfile regctl stern gitleaks step-cli opa jenkins gitea minio rails mailpit
 
 #------------------------------------------------------------------------------
 # SIGNING KEY (required for melange packages)
@@ -2439,7 +2439,16 @@ kubectl: kubectl-melange
 #------------------------------------------------------------------------------
 # CVE SCANNING
 #------------------------------------------------------------------------------
-scan: scan-python scan-jenkins scan-go scan-node-slim scan-nginx scan-httpd scan-redis-slim scan-mysql scan-memcached scan-caddy scan-haproxy scan-postgres-slim scan-bun scan-sqlite scan-dotnet scan-java scan-ruby scan-php scan-rails scan-kafka scan-valkey scan-nats scan-traefik scan-envoy scan-rabbitmq scan-minio scan-opensearch scan-prometheus scan-mariadb scan-coredns scan-openbao scan-loki scan-fluent-bit scan-keycloak
+# Generic scan rule — every image's scan recipe is identical (trivy
+# CRITICAL,HIGH on :latest); this pattern covers all of them. An explicit
+# scan-<img> target, if present, still wins.
+scan-%:
+	@echo "Scanning minimal-$*..."
+	trivy image --exit-code 1 --severity CRITICAL,HIGH \
+		$(REGISTRY)/$(OWNER)/minimal-$*:latest
+	@echo "✓ minimal-$*: scan passed"
+
+scan: scan-python scan-node-slim scan-bun scan-go scan-java scan-ruby scan-php scan-dotnet scan-deno scan-mysql scan-mariadb scan-postgres-slim scan-pgbouncer scan-unbound scan-external-dns scan-velero scan-kaniko scan-step-ca scan-skopeo scan-sqlite scan-opensearch scan-redis-slim scan-valkey scan-memcached scan-kafka scan-zookeeper scan-tomcat scan-rabbitmq scan-nats scan-mosquitto scan-nginx scan-httpd scan-caddy scan-haproxy scan-traefik scan-envoy scan-oauth2-proxy scan-prometheus scan-alertmanager scan-victoria-metrics scan-thanos scan-mimir scan-jaeger scan-loki scan-tempo scan-otelcol scan-fluent-bit scan-telegraf scan-node-exporter scan-blackbox-exporter scan-pushgateway scan-coredns scan-etcd scan-openbao scan-keycloak scan-qdrant scan-registry scan-consul scan-helm scan-kubectl scan-opentofu scan-trivy scan-cosign scan-syft scan-grype scan-osv-scanner scan-oras scan-notation scan-conftest scan-kubeconform scan-kube-bench scan-trufflehog scan-flux scan-kustomize scan-sops scan-crane scan-kubeseal scan-helmfile scan-regctl scan-stern scan-gitleaks scan-step-cli scan-opa scan-jenkins scan-gitea scan-minio scan-rails scan-mailpit
 
 scan-python:
 	@echo "Scanning minimal-python..."
@@ -2743,7 +2752,7 @@ size:
 #------------------------------------------------------------------------------
 # TESTING
 #------------------------------------------------------------------------------
-test: test-python test-jenkins test-go test-node-slim test-nginx test-httpd test-redis-slim test-mysql test-memcached test-caddy test-haproxy test-postgres-slim test-bun test-sqlite test-dotnet test-java test-ruby test-php test-rails test-kafka test-valkey test-nats test-traefik test-envoy test-rabbitmq test-minio test-opensearch test-prometheus test-mariadb test-coredns test-fluent-bit test-keycloak test-loki test-openbao test-gitea
+test: test-python test-node-slim test-bun test-go test-java test-ruby test-php test-dotnet test-deno test-mysql test-mariadb test-postgres-slim test-pgbouncer test-unbound test-external-dns test-velero test-kaniko test-step-ca test-skopeo test-sqlite test-opensearch test-redis-slim test-valkey test-memcached test-kafka test-zookeeper test-tomcat test-rabbitmq test-nats test-mosquitto test-nginx test-httpd test-caddy test-haproxy test-traefik test-envoy test-oauth2-proxy test-prometheus test-alertmanager test-victoria-metrics test-thanos test-mimir test-jaeger test-loki test-tempo test-otelcol test-fluent-bit test-telegraf test-node-exporter test-blackbox-exporter test-pushgateway test-coredns test-etcd test-openbao test-keycloak test-qdrant test-registry test-consul test-helm test-kubectl test-opentofu test-trivy test-cosign test-syft test-grype test-osv-scanner test-oras test-notation test-conftest test-kubeconform test-kube-bench test-trufflehog test-flux test-kustomize test-sops test-crane test-kubeseal test-helmfile test-regctl test-stern test-gitleaks test-step-cli test-opa test-jenkins test-gitea test-minio test-rails test-mailpit
 
 $(eval $(call DEV_TEST_RULE,python))
 $(eval $(call DEV_TEST_RULE,node-slim))


### PR DESCRIPTION
The two deferred audit items you asked for.

## #1 — Makefile aggregate completeness (build/test/scan → 88/88)
The aggregates only covered a subset (build 43/88, test 35/88, scan 34/88), so `make build|test|scan` silently skipped ~half the catalog (all of Batch F + the CLI/security tools).
- `build:` / `test:` regenerated from `catalog.json` — every image's build + `test-<img>` target already existed, just weren't aggregated.
- `scan:` — 47 images had **no** scan target. Since every scan recipe is identical (trivy CRITICAL,HIGH on `:latest`), added one **`scan-%` pattern rule** covering all of them (explicit targets still win) and completed the aggregate.
- Verified: `make -n build/test/scan` resolve; 88/88 coverage; `scan-<any-image>` works.

## #2 — Major-detection for scrape rows
- **kafka + zookeeper** scrape the *parent* Apache listing, so broadening the pattern's major to `[0-9]+` lets them raise a new-major issue (pin-major still gates the bump). Verified they resolve their current line (4.3.1 / 3.9.5).
- **tomcat / mariadb / php** left deliberately locked (documented in-file): tomcat's URL is the `tomcat-11/` subdir, mariadb's is series-scoped to 11.4 LTS, php is series-JSON — making these major-aware needs a per-source redesign / is a deliberate LTS choice.

`check-autoupdate` + `actionlint` clean; YAML valid.