### PR TITLE
fix: real correctness bugs from the follow-up audit

### DIFF
--- a/vex/cuda-python.openvex.json
+++ b/vex/cuda-python.openvex.json
@@ -1,9 +1,0 @@
-{
-  "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://github.com/rtvkiz/minimal/vex/cuda-python",
-  "author": "rtvkiz",
-  "timestamp": "2026-06-02T00:00:00Z",
-  "version": 1,
-  "tooling": "tools/vex/validate.sh",
-  "statements": []
-}


### PR DESCRIPTION
The follow-up audit correctly caught that my earlier fixes were incomplete. This fixes the ones with **actual failure modes** (verified each against main).

1. **Wolfi dev-parity (.NET/Java)** — the sed only rewrote *prod-side* package names, so on a major bump the dev image kept `dotnet-N-sdk`/`-targeting-pack` and `openjdk-N-default-jdk` on the **old** major (a mismatched runtime/SDK image). Now rewrites the whole `dotnet-<major>` / `openjdk-<major>` family via a word-boundary sed (`\b` stops at `dotnet-100`). Simulated 10→11 and 26→27: **all** dev packages move.
2. **memcached + rails** had `pin-major` but no `major-issue: true` — a new major would silently stop updates with no issue (rails tracks rubygems `latest`, so it *will* see rails 9). Added the flag.
3. **Go-registration gate too loose** — matched an image key in *any* of the 3 patch-go-deps dicts. Now requires **≥3** (all of MODROOTS/MAIN_MODULES/BUILD_MARKERS). Regression-tested: dropping velero from one dict is now caught (`2/3`).
4. **cuda-python orphan** — removed its stale VEX file and the `docker push` lines (disabled/not shipped → `make push` would fail on it). Kept the dir (intentional non-prod example).
5. Added the missing **`PHP_VERSION`** Makefile variable.

Verified: `check-autoupdate` + `lint-workflows` (incl. standalone scripts) clean; `make -n push` OK; dev-parity sims pass.

Remaining audit items (completeness/docs — lower severity): 32/33 dev Make rules, `push:` 26→88, more resolver assertions (tarball availability, all-resolver PR run, apply-update mutation assert, 100-tag window), and stale 57-image README/site docs. Tracked as follow-ups.