### PR TITLE
fix(kustomize): raise go.work directive so patch-go-deps x/* bumps build

### DIFF
--- a/kustomize/melange.yaml
+++ b/kustomize/melange.yaml
@@ -37,6 +37,20 @@ pipeline:
       tar xzf /home/build/kustomize.tar.gz -C /home/build/kustomize-${{package.version}} --strip-components=1
       rm /home/build/kustomize.tar.gz
 
+  - runs: |
+      # kustomize ships a go.work (a ~45-module workspace) whose `go` directive
+      # trails the toolchain. patch-go-deps bumps the golang.org/x/* family to
+      # @latest, which now requires go >= 1.25; go1.26 then HARD-FAILS the whole
+      # workspace ("go.work lists go 1.24.0, but a member requires >= 1.25.0")
+      # during `go mod tidy` — even under GOWORK=off — before the build is
+      # reached. Raise the workspace directive to the build toolchain so it can
+      # never sit below a bumped member's requirement (self-heals on the next
+      # bump too). Harmless when there are no bumps. See patch-go-deps x/* pin.
+      if [ -f /home/build/kustomize-${{package.version}}/go.work ]; then
+        ( cd /home/build/kustomize-${{package.version}} \
+          && go work edit -go="$(go env GOVERSION | sed 's/^go//')" )
+      fi
+
   # patch-go-deps: auto-generated — do not edit manually
   - runs: |
       export GOWORK=off


### PR DESCRIPTION
## The failure

patch-go-deps **PR #455** failed on **kustomize** (both arches, prod + dev):

```
go: module . listed in go.work file requires go >= 1.25.0, but go.work lists go 1.24.0
ERRO failed to build package ... task exited with code 1
```

## Root cause

- The generator pins the whole `golang.org/x/*` family to proxy `@latest` when any x/* CVE is flagged. Every sibling's latest (`crypto v0.54`, `net v0.57`, `sys v0.47`, `tools v0.48`, …) **now declares `go 1.25`**.
- `go get` bumps `kustomize/go.mod`'s go directive to 1.25 accordingly.
- kustomize ships a **`go.work`** (a ~45-module workspace) whose `go` directive is **1.24.0**.
- **go 1.26** (the build toolchain — CI swaps in Wolfi's latest `go-1.XX`) hard-fails a workspace whose directive is below a member's requirement, **during `go mod tidy`, even under `GOWORK=off`** — before the build is ever reached. (go 1.24 doesn't do this, which is why it only bites in CI.)

Other Go images in the same PR pass because they have no `go.work`; their go.mod directive bumps freely.

## Fix

A pre-patch melange step raises the workspace directive to the build toolchain:

```sh
go work edit -go="$(go env GOVERSION | sed 's/^go//')"
```

So `go.work` can never sit below a bumped member's requirement, and it self-heals on future bumps. Harmless when there are no bumps.

## Verification (local)

1. `make kustomize-melange` + `make kustomize` + `make test-kustomize` — all green with the step added (no regression to the normal build).
2. **Injected the exact #455 `x/*@latest` `go get` into the patch block** and ran `make kustomize-melange` → **now succeeds** (this is precisely what fails in CI today).
3. Manual patch + build of the raised-`go.work` source produces a working `kustomize version` binary.

Once merged, the next patch-go-deps run regenerates #455's branch on top of this and kustomize will build.