### PR TITLE
fix(ci): make cosign retries idempotent, retry apko build, thanos test-and-keep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -495,15 +495,22 @@ jobs:
           max_attempts: 3
           command: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
+      # See the matching comment in build-melange: packages.wolfi.dev returns
+      # intermittent 403s on APKINDEX.tar.gz and apko does not retry them.
       - name: Build image with apko
-        run: |
-          apko build ${{ matrix.apko_config }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }} \
-            ${{ matrix.name }}${{ matrix.tag_suffix }}.tar \
-            --arch x86_64
-          docker load < ${{ matrix.name }}${{ matrix.tag_suffix }}.tar
-          LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" | head -1)
-          docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            apko build ${{ matrix.apko_config }} \
+              ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }} \
+              ${{ matrix.name }}${{ matrix.tag_suffix }}.tar \
+              --arch x86_64
+            docker load < ${{ matrix.name }}${{ matrix.tag_suffix }}.tar
+            LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" | head -1)
+            docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}
 
       - name: Report image size
         run: |
@@ -761,7 +768,9 @@ jobs:
           fi
           echo "tag=$VERSION" >> $GITHUB_OUTPUT
           echo "Primary package: $PRIMARY_PKG, version: $VERSION"
-          rm -f sbom-*.spdx.json
+          # Also clear any attestation markers so the attest step's
+          # idempotence guard starts from a clean slate for this publish.
+          rm -f sbom-*.spdx.json .attested-sbom-*.spdx.json
 
       - name: Test image
         run: |
@@ -818,7 +827,20 @@ jobs:
           # Same Sigstore flakiness as the SBOM attest step below.
           retry_wait_seconds: 60
           command: |
-            cosign sign --yes "${{ steps.publish.outputs.image }}"
+            # Rekor answers a re-POST of an identical entry with HTTP 409
+            # createLogEntryConflict, and cosign surfaces that as exit 1. But 409
+            # means the signature IS in the transparency log — the desired end
+            # state. Left untreated it makes this step non-idempotent: any blip
+            # that lands the entry then drops the connection guarantees every
+            # remaining attempt "fails" on the conflict (jenkins, main
+            # 2026-08-06). Treat it as success so the retry can converge.
+            OUT=$(cosign sign --yes "${{ steps.publish.outputs.image }}" 2>&1); RC=$?
+            echo "$OUT"
+            if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'createLogEntryConflict'; then
+              echo "note: rekor already holds an equivalent entry — signature is recorded, treating as success"
+              RC=0
+            fi
+            exit "$RC"
 
       - name: Attach SBOM attestation
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
@@ -832,19 +854,44 @@ jobs:
           retry_wait_seconds: 60
           command: |
             # apko --sbom-path . writes per-arch + index SBOMs to the working directory during publish
+            #
+            # This loop must be idempotent across attempts. It attests three
+            # SBOMs; if the third hits a transient rekor error, a naive retry
+            # re-attests all three and the first two now come back 409
+            # createLogEntryConflict — so the step could never go green again
+            # (deno, main 2026-08-06: 3 attempts, all lost to conflicts on
+            # SBOMs that had already succeeded). Two guards: skip SBOMs already
+            # attested in an earlier attempt, and treat 409 as success.
             FOUND=0
+            FAILED=0
             for SBOM in sbom-x86_64.spdx.json sbom-aarch64.spdx.json sbom-index.spdx.json; do
               [ -f "$SBOM" ] || continue
               FOUND=$((FOUND + 1))
-              cosign attest --yes --type spdxjson \
+              if [ -f ".attested-${SBOM}" ]; then
+                echo "skipping ${SBOM}: already attested in an earlier attempt"
+                continue
+              fi
+              OUT=$(cosign attest --yes --type spdxjson \
                 --predicate "$SBOM" \
-                "${{ steps.publish.outputs.image }}"
+                "${{ steps.publish.outputs.image }}" 2>&1); RC=$?
+              echo "$OUT"
+              if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'createLogEntryConflict'; then
+                echo "note: rekor already holds an equivalent entry for ${SBOM} — treating as success"
+                RC=0
+              fi
+              if [ "$RC" -eq 0 ]; then
+                touch ".attested-${SBOM}"
+              else
+                echo "::warning::attestation for ${SBOM} failed (will retry)"
+                FAILED=1
+              fi
             done
             if [ "$FOUND" -eq 0 ]; then
               echo "::error::No SBOM files found to attest"
               ls -la sbom-*.spdx.json 2>&1 || true
               exit 1
             fi
+            exit "$FAILED"
 
       - name: Generate SLSA build provenance
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
@@ -999,17 +1046,27 @@ jobs:
         run: |
           echo "${{ secrets.MELANGE_SIGNING_KEY_PUB }}" > melange.rsa.pub
 
+      # packages.wolfi.dev intermittently answers APKINDEX.tar.gz with 403 under
+      # load, and apko has no internal retry for index fetches — a single 403
+      # failed opa-dev outright on the scheduled main build (2026-08-06). Every
+      # other network-touching step here is already wrapped; this one was the
+      # gap.
       - name: Build image with apko
-        run: |
-          apko build ${{ matrix.apko_config }} \
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }} \
-            ${{ matrix.name }}${{ matrix.tag_suffix }}.tar \
-            --arch x86_64 \
-            --repository-append ./packages \
-            --keyring-append ./melange.rsa.pub
-          docker load < ${{ matrix.name }}${{ matrix.tag_suffix }}.tar
-          LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" | head -1)
-          docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            apko build ${{ matrix.apko_config }} \
+              ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }} \
+              ${{ matrix.name }}${{ matrix.tag_suffix }}.tar \
+              --arch x86_64 \
+              --repository-append ./packages \
+              --keyring-append ./melange.rsa.pub
+            docker load < ${{ matrix.name }}${{ matrix.tag_suffix }}.tar
+            LOADED_IMAGE=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "minimal-${{ matrix.name }}" | grep "${{ github.sha }}${{ matrix.tag_suffix }}" | head -1)
+            docker tag "$LOADED_IMAGE" ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ github.sha }}${{ matrix.tag_suffix }}
 
       - name: Report image size
         run: |
@@ -1315,7 +1372,15 @@ jobs:
           # Same Sigstore flakiness as the SBOM attest step below.
           retry_wait_seconds: 60
           command: |
-            cosign sign --yes "${{ steps.publish.outputs.image }}"
+            # Rekor 409 createLogEntryConflict == already recorded; see the
+            # matching comment in the build-apko job's sign step.
+            OUT=$(cosign sign --yes "${{ steps.publish.outputs.image }}" 2>&1); RC=$?
+            echo "$OUT"
+            if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'createLogEntryConflict'; then
+              echo "note: rekor already holds an equivalent entry — signature is recorded, treating as success"
+              RC=0
+            fi
+            exit "$RC"
 
       - name: Attach SBOM attestation
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''
@@ -1328,12 +1393,31 @@ jobs:
           # whole scheduled build (conftest-dev, 2026-07-29). Back off properly.
           retry_wait_seconds: 60
           command: |
+            # Idempotent across attempts — see the matching comment in the
+            # build-apko job's attest step (deno, main 2026-08-06).
+            FAILED=0
             for SBOM in sbom-x86_64.spdx.json sbom-aarch64.spdx.json sbom-index.spdx.json; do
               [ -f "$SBOM" ] || continue
-              cosign attest --yes --type spdxjson \
+              if [ -f ".attested-${SBOM}" ]; then
+                echo "skipping ${SBOM}: already attested in an earlier attempt"
+                continue
+              fi
+              OUT=$(cosign attest --yes --type spdxjson \
                 --predicate "$SBOM" \
-                "${{ steps.publish.outputs.image }}"
+                "${{ steps.publish.outputs.image }}" 2>&1); RC=$?
+              echo "$OUT"
+              if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'createLogEntryConflict'; then
+                echo "note: rekor already holds an equivalent entry for ${SBOM} — treating as success"
+                RC=0
+              fi
+              if [ "$RC" -eq 0 ]; then
+                touch ".attested-${SBOM}"
+              else
+                echo "::warning::attestation for ${SBOM} failed (will retry)"
+                FAILED=1
+              fi
             done
+            exit "$FAILED"
 
       - name: Generate SLSA build provenance
         if: github.event_name != 'pull_request' && steps.publish.outputs.digest != ''

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -290,6 +290,7 @@ jobs:
             [skopeo]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -tags containers_image_openpgp -o /dev/null ./cmd/skopeo'
             [trivy]='GOTOOLCHAIN=local CGO_ENABLED=0 GOEXPERIMENT=jsonv2 go build -mod=mod -o /dev/null ./cmd/trivy'
             [opentofu]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -o /dev/null ./cmd/tofu'
+            [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build -mod=mod -tags netgo,slicelabels -o /dev/null ./cmd/thanos'
           )
           # Minimum dependency floor needed by a source compatibility backport
           # before independently probing the generated candidates. This is a
@@ -323,8 +324,19 @@ jobs:
           # every safely-patchable CVE lands now and only genuinely-incompatible
           # ones wait for the upstream release (logged per-dep, not silent).
           # SKIP_IMAGES stays for images we never auto-patch at all (none now).
+          # thanos joined this class in 2026-08: grype reports a mongo-driver CVE
+          # fixed in v1.17.7, but thanos's full module graph pulls rclone v1.74.3,
+          # which requires mongo-driver v1.17.9. Because the whole candidate set
+          # goes in as one batched `go get`, that single below-graph pin aborts
+          # the batch ("rclone@v1.74.3 requires mongo-driver@v1.17.9, not
+          # v1.17.7") and drags docker/cli down with it, failing every thanos
+          # build on the patch-go-deps PR. Harmonization (above) can't catch it:
+          # it only reads the go.mod of modules that are themselves in the fix
+          # set, and rclone isn't one of them. Test-and-keep probes each
+          # candidate independently, so the unsatisfiable pin is dropped and the
+          # other ~14 CVE fixes still land.
           SKIP_IMAGES=" "
-          TESTKEEP_IMAGES=" caddy trivy kaniko skopeo opentofu "
+          TESTKEEP_IMAGES=" caddy trivy kaniko skopeo opentofu thanos "
           for IMAGE in "${!MODROOTS[@]}"; do
             if [[ "$SKIP_IMAGES" == *" $IMAGE "* ]]; then
               echo "=== Skipping $IMAGE (excluded from auto transitive dep-patching; tracked via update-versions + base rebuild) ==="


### PR DESCRIPTION
Fixes the three real causes behind the recent red builds on `main` and the `patch-go-deps` PR. (The other recent failures — `Auto-update PR branches`, `Patch transitive dependencies` — were a GitHub incident: `Failed to resolve action download info: Service Unavailable` / `job was not acquired by Runner`. Nothing to fix there.)

## 1. cosign retries were non-idempotent

jenkins (main) and deno (scheduled main) both died on:

```
[POST /api/v1/log/entries][409] createLogEntryConflict
  {"message":"an equivalent entry already exists in the transparency log..."}
```

Rekor answers a re-POST of an identical entry with 409 and cosign exits 1 — but 409 means the signature **is** in the log, i.e. the desired end state.

The attest step loops over three SBOMs with no per-SBOM state, which made the failure a ratchet. deno, attempt 1: x86_64 ✅, aarch64 ✅, index ❌ (transient). Attempt 2 re-attested all three — and the two that had **already succeeded** now returned 409. Attempt 3, same. The retry could never converge; a transient blip was permanently converted into a red build.

Fix: treat 409 as success, and record a per-SBOM marker so a retry only re-attests what has not landed. Markers are cleared alongside the SBOMs before publish.

## 2. `apko build` was the one unretried network step

opa-dev failed the scheduled main build on:

```
reading index https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz: unexpected status code 403
```

Every other network-touching step (melange, `apko publish`, registry login, grype download) is already wrapped in `nick-fields/retry`. This one was a bare `run:`, and apko has no internal retry for index fetches. Wrapped both copies (3 attempts, 30s backoff).

## 3. thanos — the only deterministic failure

`Build Hardened Images` failed on the `patch-go-deps` PR **five runs in a row**, always thanos, always:

```
go: github.com/rclone/rclone@v1.74.3 requires go.mongodb.org/mongo-driver@v1.17.9,
    not go.mongodb.org/mongo-driver@v1.17.7
```

grype reports the mongo-driver CVE as fixed in v1.17.7. thanos ships v1.17.6, so it looks like an upgrade — but thanos's **full** module graph pulls rclone v1.74.3, which floors mongo-driver at v1.17.9. The pin is therefore a downgrade, `go get` refuses, and the downgrade cascade drags `docker/cli` down too (that second warning is a symptom, not a separate bug).

The harmonization pass can't catch this — it only reads the `go.mod` of modules that are themselves in the fix set, and rclone isn't one. And because every pin goes in as a single batched `go get`, that one bad pin destroyed the whole patch and every thanos build.

Fix: move thanos to **test-and-keep**, which probes each candidate against a real compile and keeps only what works. Same class of graph the file already documents for skopeo ("docker/cli conflicts with buildkit/fulcio → `go get` aborts"). thanos now keeps the other ~14 CVE fixes instead of losing all of them.

## Validation

`make lint-workflows` clean (actionlint + shellcheck). Workflow-only change; no image build inputs touched, so per CLAUDE.md the per-image build/test gate does not apply.

## Note before merge

Test-and-keep runs a probe compile per candidate (~15 for thanos). Go's build cache makes probes 2..N much cheaper than cold builds, but thanos is a large binary and that melange job will get noticeably longer. caddy/trivy/opentofu already pay this cost.

PR #501 still carries the broken generated thanos block; it regenerates on the next scheduled `patch-go-deps` run after this lands.