### PR TITLE
feat(tags): rolling major/minor tags, plus a /docs site section and doc-drift fixes

### DIFF
--- a/.github/scripts/version-ladder.sh
+++ b/.github/scripts/version-ladder.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Rolling major/minor tag derivation, shared by build.yml's two publish steps.
+#
+# Consumers today pin either :latest (breaks on a major bump) or an exact patch
+# (frozen forever, including security fixes). The rolling ladder gives them a
+# middle option — :3 tracks the 3.x line, :3.21 tracks 3.21.x — so a major
+# upgrade stops being all-or-nothing. Same digest, no extra build: these are
+# additional tags on the image that was already published.
+#
+#   derive_version_ladder <version> -> space-separated extra tags (may be empty)
+#
+# Usage: source this file, then call derive_version_ladder "$VER".
+# Self-test: bash .github/scripts/version-ladder.sh --test
+
+derive_version_ladder() {
+  local raw="$1" base major minor
+
+  [ -n "$raw" ] || return 0
+
+  # Strip the Wolfi package epoch (-r0, -r12). apko-only images take their
+  # version from the SBOM, which carries it (python 3.14.7-r0); source-built
+  # images never do.
+  base="${raw%-r[0-9]*}"
+
+  # Only pure numeric dotted versions get a ladder. A pre-release or build
+  # suffix (1.2.3-rc1, 1.2.3+meta) is skipped — a rolling tag pointing at a
+  # pre-release would misrepresent the line.
+  case "$base" in
+    *[!0-9.]*) return 0 ;;
+  esac
+
+  major="${base%%.*}"
+  [ -n "$major" ] || return 0
+
+  # Calendar-versioned releases (minio: 2025.10.15) have no meaningful major
+  # line; a :2025 tag would imply a support line that does not exist.
+  if [ "$major" -ge 1000 ] 2>/dev/null; then
+    return 0
+  fi
+
+  # x.y.z -> x.y ; x.y -> x.y ; x -> none
+  case "$base" in
+    *.*.*) minor="${base%.*}" ;;
+    *.*)   minor="$base" ;;
+    *)     minor="" ;;
+  esac
+
+  # 0.x has no stable major line: semver permits breaking changes between 0.x
+  # minors, so a rolling :0 tag would promise compatibility we cannot keep.
+  # 16 images are on 0.x (thanos, trivy, otelcol, grype, …). There the minor is
+  # the compatibility boundary, so emit :0.42 but never :0.
+  if [ "$major" = "0" ]; then
+    printf '%s' "$minor"
+    return 0
+  fi
+
+  if [ -n "$minor" ] && [ "$minor" != "$major" ]; then
+    printf '%s %s' "$major" "$minor"
+  else
+    printf '%s' "$major"
+  fi
+}
+
+# --- self-test -------------------------------------------------------------
+if [ "${1:-}" = "--test" ]; then
+  fail=0
+  check() {
+    local in="$1" want="$2" got
+    got="$(derive_version_ladder "$in")"
+    if [ "$got" = "$want" ]; then
+      printf '  ok    %-14s -> [%s]\n' "$in" "$got"
+    else
+      printf '  FAIL  %-14s -> [%s], want [%s]\n' "$in" "$got" "$want"
+      fail=1
+    fi
+  }
+  check "3.4.0"       "3 3.4"      # source-built semver
+  check "8.10.0"      "8 8.10"     # redis
+  check "3.14.7-r0"   "3 3.14"     # apko-only, epoch stripped
+  check "1.26.5-r2"   "1 1.26"     # go
+  check "18.4-r7"     "18 18.4"    # postgres, two-part + epoch
+  check "3.53.4"      "3 3.53"     # sqlite, no epoch
+  check "2025.10.15"  ""           # minio, calendar-versioned
+  check "0.42.4"      "0.42"       # thanos, 0.x -> minor only
+  check "0.73.0"      "0.73"       # trivy
+  check "1.2.3-rc1"   ""           # pre-release
+  check "1.2.3+meta"  ""           # build metadata
+  check "7"           "7"          # single component
+  check ""            ""           # empty
+  [ "$fail" -eq 0 ] && echo "version-ladder: all cases passed"
+  exit "$fail"
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -789,11 +789,28 @@ jobs:
           # as version history — the plain :<version> tag moves on same-version
           # rebuilds. Daily granularity; retention is bounded by cleanup-packages.yml.
           DATE_TAG=$(date -u +%Y%m%d)
+          # Rolling major/minor tags (:3, :3.21) so consumers can track a line
+          # instead of choosing between :latest (breaks on a major bump) and an
+          # exact patch (frozen, including security fixes). Same digest.
+          # shellcheck source=.github/scripts/version-ladder.sh
+          . ./.github/scripts/version-ladder.sh
+          IMAGE_REF="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}"
+          VER="${{ steps.version.outputs.tag }}"
+          SUF="${{ matrix.tag_suffix }}"
+
+          TAGS=(
+            "${IMAGE_REF}:${VER}${SUF}"
+            "${IMAGE_REF}:${VER}-${DATE_TAG}${SUF}"
+            "${IMAGE_REF}:${{ matrix.latest_tag }}"
+          )
+          for L in $(derive_version_ladder "$VER"); do
+            TAGS+=("${IMAGE_REF}:${L}${SUF}")
+          done
+          echo "Publishing tags: ${TAGS[*]}"
+
           for attempt in 1 2 3; do
             if apko publish ${{ matrix.apko_config }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }}${{ matrix.tag_suffix }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }}-${DATE_TAG}${{ matrix.tag_suffix }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ matrix.latest_tag }} \
+                "${TAGS[@]}" \
                 --arch x86_64,aarch64 \
                 --sbom-path . \
                 > "$PUBLISH_OUT" 2>&1; then
@@ -1333,11 +1350,26 @@ jobs:
           # as version history — the plain :<version> tag moves on same-version
           # rebuilds. Daily granularity; retention is bounded by cleanup-packages.yml.
           DATE_TAG=$(date -u +%Y%m%d)
+          # Rolling major/minor tags — see the matching comment in build-apko.
+          # shellcheck source=.github/scripts/version-ladder.sh
+          . ./.github/scripts/version-ladder.sh
+          IMAGE_REF="${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}"
+          VER="${{ steps.version.outputs.tag }}"
+          SUF="${{ matrix.tag_suffix }}"
+
+          TAGS=(
+            "${IMAGE_REF}:${VER}${SUF}"
+            "${IMAGE_REF}:${VER}-${DATE_TAG}${SUF}"
+            "${IMAGE_REF}:${{ matrix.latest_tag }}"
+          )
+          for L in $(derive_version_ladder "$VER"); do
+            TAGS+=("${IMAGE_REF}:${L}${SUF}")
+          done
+          echo "Publishing tags: ${TAGS[*]}"
+
           for attempt in 1 2 3; do
             if apko publish ${{ matrix.apko_config }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }}${{ matrix.tag_suffix }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ steps.version.outputs.tag }}-${DATE_TAG}${{ matrix.tag_suffix }} \
-                ${{ env.REGISTRY }}/${{ github.repository_owner }}/minimal-${{ matrix.name }}:${{ matrix.latest_tag }} \
+                "${TAGS[@]}" \
                 --arch ${{ matrix.arches }} \
                 --repository-append ./packages \
                 --keyring-append ./melange.rsa.pub \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,48 @@ This guide covers how to add a new hardened container image to the project.
 
 ## Prerequisites
 
-Install the following tools locally:
+Install the same major tool versions CI uses — a version mismatch is a common
+source of "works locally, fails in CI":
+
+```bash
+go install chainguard.dev/apko@v1.1.6
+go install chainguard.dev/melange@v0.41.1
+brew install anchore/grype/grype
+```
 
 - [apko](https://github.com/chainguard-dev/apko) — image assembly
 - [melange](https://github.com/chainguard-dev/melange) — package building (only if compiling from source)
 - [Docker](https://docs.docker.com/get-docker/)
-- [Trivy](https://aquasecurity.github.io/trivy/) — vulnerability scanning (optional, for local scans)
+- [Grype](https://github.com/anchore/grype) — vulnerability scanning; this is what CI scans with
+
+Note: `melange build` cross-architecture builds need QEMU. Without it, an
+`--arch x86_64,aarch64` build fails on the aarch64 leg with
+`bwrap: execvp /bin/sh: Exec format error`. Build `--arch x86_64` locally; CI
+builds ARM on native runners.
+
+## Project structure
+
+```text
+minimal/
+├── <image>/
+│   ├── apko/<name>.yaml          # production image assembly
+│   ├── apko/<name>-dev.yaml      # development/debug variant
+│   ├── melange.yaml              # source build, when applicable
+│   ├── test.sh                   # production smoke test
+│   └── test-dev.sh               # development-variant smoke test
+├── vex/<name>.openvex.json       # per-image vulnerability statements
+├── .github/
+│   ├── versions.yaml             # source-version update registry
+│   ├── patch-deps.yaml           # non-Go dependency patch registry
+│   ├── autoupdate-coverage.yaml  # package-based update classification
+│   ├── scripts/                  # shared updater implementation
+│   └── workflows/                # build, update, security, site, and cleanup automation
+├── catalog.json                  # canonical public image inventory
+├── docs/                         # onboarding, update, and variant standards
+├── site/                         # minimalcontainers.com Astro site
+├── Makefile
+└── README.md
+```
 
 ## Adding a New Image
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ IMAGE=ghcr.io/$(git config user.name | tr '[:upper:]' '[:lower:]' | tr ' ' '-')/
   ./<image-name>/test.sh
 
 # Scan
-trivy image --severity CRITICAL,HIGH ghcr.io/.../minimal-<image-name>:latest
+grype ghcr.io/.../minimal-<image-name>:latest
 ```
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@
   <a href="https://minimalcontainers.com"><img src="https://img.shields.io/badge/Image_Catalog-Live-0d9488" alt="Image catalog"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
-  <img src="https://img.shields.io/badge/Images-91-0d9488" alt="Images: 91">
+  <img src="https://img.shields.io/badge/Images-96-0d9488" alt="Images: 96">
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures: amd64 and arm64">
 </p>
 
 <p align="center">
   <a href="#pull-and-verify-an-image">Verify an image</a> ·
-  <a href="#available-images--91-total">All 91 images</a> ·
+  <a href="https://minimalcontainers.com/images">All 96 images</a> ·
   <a href="#how-images-stay-current">Update model</a> ·
-  <a href="#build-locally">Build locally</a>
+  <a href="https://minimalcontainers.com/docs">Docs</a>
 </p>
 
 ---
@@ -84,131 +84,23 @@ More verification examples and the vulnerability-reporting policy are in [`.gith
 
 The project does not provide a vendor SLA, an on-call support contract, or FedRAMP/FIPS/STIG accreditation. The signatures, SBOMs, and provenance help with verification and audits, but do not replace those programs.
 
-## Available images — 91 total
+## Available images — 96 total
 
-The inventory below is derived from [`catalog.json`](catalog.json), which is validated against the build matrix in CI.
+Browse the full, always-current inventory with sizes and CVE counts at
+**[minimalcontainers.com/images](https://minimalcontainers.com/images)**.
+The canonical source is [`catalog.json`](catalog.json), validated against the
+build matrix in CI.
 
-| Category | Count | Images |
-|---|---:|---|
-| **Languages & Runtimes** | 9 | python, node-slim, bun, go, java, ruby, php, dotnet, deno |
-| **Databases** | 8 | mysql, mariadb, postgres-slim, pgbouncer, sqlite, opensearch, cassandra, solr |
-| **Caches, Queues & Messaging** | 9 | redis-slim, valkey, memcached, kafka, zookeeper, pulsar, rabbitmq, nats, mosquitto |
-| **Web Servers & Proxies** | 8 | tomcat, nginx, httpd, caddy, haproxy, traefik, envoy, oauth2-proxy |
-| **Observability** | 14 | prometheus, alertmanager, victoria-metrics, thanos, mimir, jaeger, loki, tempo, otelcol, fluent-bit, telegraf, node-exporter, blackbox-exporter, pushgateway |
-| **Infrastructure** | 9 | unbound, step-ca, coredns, etcd, openbao, keycloak, qdrant, registry, consul |
-| **Kubernetes, CI & IaC** | 29 | Kubernetes, supply-chain security, policy, registry, GitOps, backup, and IaC tools |
-| **Apps** | 5 | jenkins, gitea, minio, rails, mailpit |
-
-Live versions, image sizes, CVE results, packages, digests, and verification data are available at [minimalcontainers.com](https://minimalcontainers.com).
-
-<details>
-<summary><strong>Full image catalog with pull commands</strong></summary>
-
-<br>
-
-| Image | Pull command | Purpose |
-|---|---|---|
-| **Languages & Runtimes** |  |  |
-| `python` | `docker pull ghcr.io/rtvkiz/minimal-python:latest` | Shell-less Python 3 runtime built on Wolfi. |
-| `node-slim` | `docker pull ghcr.io/rtvkiz/minimal-node-slim:latest` | Shell-less Node.js runtime built on Wolfi. |
-| `bun` | `docker pull ghcr.io/rtvkiz/minimal-bun:latest` | Shell-less Bun JavaScript runtime built on Wolfi. |
-| `go` | `docker pull ghcr.io/rtvkiz/minimal-go:latest` | Go builder image built on Wolfi. |
-| `java` | `docker pull ghcr.io/rtvkiz/minimal-java:latest` | Shell-less OpenJDK JRE built on Wolfi. |
-| `ruby` | `docker pull ghcr.io/rtvkiz/minimal-ruby:latest` | Ruby runtime built from source with melange. |
-| `php` | `docker pull ghcr.io/rtvkiz/minimal-php:latest` | PHP runtime built from source with melange. |
-| `dotnet` | `docker pull ghcr.io/rtvkiz/minimal-dotnet:latest` | .NET runtime built on Wolfi. |
-| `deno` | `docker pull ghcr.io/rtvkiz/minimal-deno:latest` | Shell-less Deno TypeScript runtime built on Wolfi. |
-| **Databases** |  |  |
-| `mysql` | `docker pull ghcr.io/rtvkiz/minimal-mysql:latest` | MySQL LTS built from source with melange. |
-| `mariadb` | `docker pull ghcr.io/rtvkiz/minimal-mariadb:latest` | MariaDB LTS built from source with melange. |
-| `postgres-slim` | `docker pull ghcr.io/rtvkiz/minimal-postgres-slim:latest` | PostgreSQL built on Wolfi. |
-| `pgbouncer` | `docker pull ghcr.io/rtvkiz/minimal-pgbouncer:latest` | Shell-less PostgreSQL connection pooler. |
-| `sqlite` | `docker pull ghcr.io/rtvkiz/minimal-sqlite:latest` | Shell-less SQLite CLI and library. |
-| `opensearch` | `docker pull ghcr.io/rtvkiz/minimal-opensearch:latest` | OpenSearch with a curated Wolfi runtime. |
-| `cassandra` | `docker pull ghcr.io/rtvkiz/minimal-cassandra:latest` | Apache Cassandra with a custom jlink JRE. |
-| `solr` | `docker pull ghcr.io/rtvkiz/minimal-solr:latest` | Apache Solr with a custom jlink JRE. |
-| **Caches, Queues & Messaging** |  |  |
-| `redis-slim` | `docker pull ghcr.io/rtvkiz/minimal-redis-slim:latest` | Shell-less Redis built from source. |
-| `valkey` | `docker pull ghcr.io/rtvkiz/minimal-valkey:latest` | Shell-less Valkey built from source. |
-| `memcached` | `docker pull ghcr.io/rtvkiz/minimal-memcached:latest` | Shell-less Memcached built from source. |
-| `kafka` | `docker pull ghcr.io/rtvkiz/minimal-kafka:latest` | Apache Kafka with a custom jlink JRE and KRaft support. |
-| `zookeeper` | `docker pull ghcr.io/rtvkiz/minimal-zookeeper:latest` | Apache ZooKeeper with a custom jlink JRE. |
-| `pulsar` | `docker pull ghcr.io/rtvkiz/minimal-pulsar:latest` | Apache Pulsar with a custom jlink JRE. |
-| `rabbitmq` | `docker pull ghcr.io/rtvkiz/minimal-rabbitmq:latest` | RabbitMQ with Wolfi Erlang/OTP. |
-| `nats` | `docker pull ghcr.io/rtvkiz/minimal-nats:latest` | Shell-less NATS server. |
-| `mosquitto` | `docker pull ghcr.io/rtvkiz/minimal-mosquitto:latest` | Shell-less Eclipse Mosquitto MQTT broker. |
-| **Web Servers & Proxies** |  |  |
-| `tomcat` | `docker pull ghcr.io/rtvkiz/minimal-tomcat:latest` | Apache Tomcat with a custom jlink JRE and default webapps removed. |
-| `nginx` | `docker pull ghcr.io/rtvkiz/minimal-nginx:latest` | Shell-less Nginx built on Wolfi. |
-| `httpd` | `docker pull ghcr.io/rtvkiz/minimal-httpd:latest` | Apache HTTP Server built on Wolfi. |
-| `caddy` | `docker pull ghcr.io/rtvkiz/minimal-caddy:latest` | Shell-less Caddy web server. |
-| `haproxy` | `docker pull ghcr.io/rtvkiz/minimal-haproxy:latest` | Shell-less HAProxy load balancer. |
-| `traefik` | `docker pull ghcr.io/rtvkiz/minimal-traefik:latest` | Shell-less Traefik reverse proxy. |
-| `envoy` | `docker pull ghcr.io/rtvkiz/minimal-envoy:latest` | Shell-less Envoy proxy. |
-| `oauth2-proxy` | `docker pull ghcr.io/rtvkiz/minimal-oauth2-proxy:latest` | OAuth2/OIDC authenticating reverse proxy. |
-| **Observability** |  |  |
-| `prometheus` | `docker pull ghcr.io/rtvkiz/minimal-prometheus:latest` | Prometheus monitoring server. |
-| `alertmanager` | `docker pull ghcr.io/rtvkiz/minimal-alertmanager:latest` | Prometheus Alertmanager. |
-| `victoria-metrics` | `docker pull ghcr.io/rtvkiz/minimal-victoria-metrics:latest` | VictoriaMetrics time-series database. |
-| `thanos` | `docker pull ghcr.io/rtvkiz/minimal-thanos:latest` | Thanos HA Prometheus long-term storage. |
-| `mimir` | `docker pull ghcr.io/rtvkiz/minimal-mimir:latest` | Grafana Mimir long-term Prometheus storage. |
-| `jaeger` | `docker pull ghcr.io/rtvkiz/minimal-jaeger:latest` | Jaeger distributed tracing backend. |
-| `loki` | `docker pull ghcr.io/rtvkiz/minimal-loki:latest` | Grafana Loki log aggregation server. |
-| `tempo` | `docker pull ghcr.io/rtvkiz/minimal-tempo:latest` | Grafana Tempo distributed tracing backend. |
-| `otelcol` | `docker pull ghcr.io/rtvkiz/minimal-otelcol:latest` | OpenTelemetry Collector core. |
-| `fluent-bit` | `docker pull ghcr.io/rtvkiz/minimal-fluent-bit:latest` | Fluent Bit log processor and forwarder. |
-| `telegraf` | `docker pull ghcr.io/rtvkiz/minimal-telegraf:latest` | Telegraf metrics collection agent. |
-| `node-exporter` | `docker pull ghcr.io/rtvkiz/minimal-node-exporter:latest` | Prometheus hardware and OS metrics exporter. |
-| `blackbox-exporter` | `docker pull ghcr.io/rtvkiz/minimal-blackbox-exporter:latest` | Prometheus endpoint probing exporter. |
-| `pushgateway` | `docker pull ghcr.io/rtvkiz/minimal-pushgateway:latest` | Prometheus Pushgateway for batch and ephemeral jobs. |
-| **Infrastructure** |  |  |
-| `unbound` | `docker pull ghcr.io/rtvkiz/minimal-unbound:latest` | Validating recursive DNS resolver. |
-| `step-ca` | `docker pull ghcr.io/rtvkiz/minimal-step-ca:latest` | Smallstep online certificate authority. |
-| `coredns` | `docker pull ghcr.io/rtvkiz/minimal-coredns:latest` | CoreDNS DNS server. |
-| `etcd` | `docker pull ghcr.io/rtvkiz/minimal-etcd:latest` | Distributed key-value store. |
-| `openbao` | `docker pull ghcr.io/rtvkiz/minimal-openbao:latest` | OpenBao secret-management server. |
-| `keycloak` | `docker pull ghcr.io/rtvkiz/minimal-keycloak:latest` | Identity and access-management server. |
-| `qdrant` | `docker pull ghcr.io/rtvkiz/minimal-qdrant:latest` | Qdrant vector search engine. |
-| `registry` | `docker pull ghcr.io/rtvkiz/minimal-registry:latest` | OCI distribution registry. |
-| `consul` | `docker pull ghcr.io/rtvkiz/minimal-consul:latest` | HashiCorp Consul service discovery and KV. |
-| **Kubernetes, CI & IaC** |  |  |
-| `external-dns` | `docker pull ghcr.io/rtvkiz/minimal-external-dns:latest` | Kubernetes DNS controller. |
-| `velero` | `docker pull ghcr.io/rtvkiz/minimal-velero:latest` | Kubernetes backup and restore tool. |
-| `kaniko` | `docker pull ghcr.io/rtvkiz/minimal-kaniko:latest` | Kaniko container image builder. |
-| `skopeo` | `docker pull ghcr.io/rtvkiz/minimal-skopeo:latest` | Container image inspection and copy tool. |
-| `helm` | `docker pull ghcr.io/rtvkiz/minimal-helm:latest` | Helm package manager CLI. |
-| `kubectl` | `docker pull ghcr.io/rtvkiz/minimal-kubectl:latest` | Kubernetes command-line client. |
-| `opentofu` | `docker pull ghcr.io/rtvkiz/minimal-opentofu:latest` | Terraform-compatible OpenTofu IaC CLI. |
-| `trivy` | `docker pull ghcr.io/rtvkiz/minimal-trivy:latest` | Vulnerability, IaC, and secret scanner. |
-| `cosign` | `docker pull ghcr.io/rtvkiz/minimal-cosign:latest` | Sigstore signing and verification CLI. |
-| `syft` | `docker pull ghcr.io/rtvkiz/minimal-syft:latest` | SBOM generator. |
-| `grype` | `docker pull ghcr.io/rtvkiz/minimal-grype:latest` | Vulnerability scanner. |
-| `osv-scanner` | `docker pull ghcr.io/rtvkiz/minimal-osv-scanner:latest` | OSV dependency vulnerability scanner. |
-| `oras` | `docker pull ghcr.io/rtvkiz/minimal-oras:latest` | OCI registry client. |
-| `notation` | `docker pull ghcr.io/rtvkiz/minimal-notation:latest` | OCI artifact signing and verification CLI. |
-| `conftest` | `docker pull ghcr.io/rtvkiz/minimal-conftest:latest` | OPA-based configuration policy testing CLI. |
-| `kubeconform` | `docker pull ghcr.io/rtvkiz/minimal-kubeconform:latest` | Kubernetes manifest validator. |
-| `kube-bench` | `docker pull ghcr.io/rtvkiz/minimal-kube-bench:latest` | CIS Kubernetes benchmark checker. |
-| `trufflehog` | `docker pull ghcr.io/rtvkiz/minimal-trufflehog:latest` | Secret scanner. |
-| `flux` | `docker pull ghcr.io/rtvkiz/minimal-flux:latest` | Flux CD GitOps CLI. |
-| `kustomize` | `docker pull ghcr.io/rtvkiz/minimal-kustomize:latest` | Kubernetes configuration customization tool. |
-| `sops` | `docker pull ghcr.io/rtvkiz/minimal-sops:latest` | Secrets-file encryption tool. |
-| `crane` | `docker pull ghcr.io/rtvkiz/minimal-crane:latest` | OCI registry tool from go-containerregistry. |
-| `kubeseal` | `docker pull ghcr.io/rtvkiz/minimal-kubeseal:latest` | Sealed Secrets CLI. |
-| `helmfile` | `docker pull ghcr.io/rtvkiz/minimal-helmfile:latest` | Declarative Helm release manager. |
-| `regctl` | `docker pull ghcr.io/rtvkiz/minimal-regctl:latest` | OCI registry client from regclient. |
-| `stern` | `docker pull ghcr.io/rtvkiz/minimal-stern:latest` | Multi-pod Kubernetes log tailing tool. |
-| `gitleaks` | `docker pull ghcr.io/rtvkiz/minimal-gitleaks:latest` | Secret scanner. |
-| `step-cli` | `docker pull ghcr.io/rtvkiz/minimal-step-cli:latest` | Smallstep PKI and certificate CLI. |
-| `opa` | `docker pull ghcr.io/rtvkiz/minimal-opa:latest` | Open Policy Agent policy engine. |
-| **Apps** |  |  |
-| `jenkins` | `docker pull ghcr.io/rtvkiz/minimal-jenkins:latest` | Jenkins with a custom jlink JRE. |
-| `gitea` | `docker pull ghcr.io/rtvkiz/minimal-gitea:latest` | Self-hosted Git service. |
-| `minio` | `docker pull ghcr.io/rtvkiz/minimal-minio:latest` | S3-compatible object storage. |
-| `rails` | `docker pull ghcr.io/rtvkiz/minimal-rails:latest` | Ruby on Rails runtime. |
-| `mailpit` | `docker pull ghcr.io/rtvkiz/minimal-mailpit:latest` | SMTP and email testing tool. |
-
-</details>
+| Category | Count |
+|---|---:|
+| Kubernetes, CI & IaC | 29 |
+| Observability | 15 |
+| Infrastructure | 11 |
+| Databases | 9 |
+| Caches, Queues & Messaging | 9 |
+| Languages & Runtimes | 9 |
+| Web Servers & Proxies | 8 |
+| Apps | 5 |
 
 ## Quick start
 
@@ -236,184 +128,56 @@ docker run --rm --entrypoint /usr/bin/caddy \
 
 ## Using images in production
 
-Pin production deployments by digest when you need an immutable artifact:
+Pin by digest when you need an immutable artifact:
 
 ```dockerfile
 FROM ghcr.io/rtvkiz/minimal-python@sha256:<digest>
 ```
 
-Published tags serve different purposes:
+Or pin a **major line** (`:3`) to get ongoing patches without being carried across a
+breaking upstream release — `:latest` crosses major versions, an exact version tag
+never moves forward at all.
 
-| Reference | Example | Behavior |
-|---|---|---|
-| Digest | `minimal-python@sha256:…` | Immutable content identity; preferred for deployment pinning. |
-| Version | `minimal-caddy:2.11.4-r0` | Moves when that application version is rebuilt with newer packages. |
-| Dated version | `minimal-caddy:2.11.4-r0-20260725` | Build-history tag; may move if the image is rebuilt again on the same UTC date. |
-| Minor line | `minimal-caddy:2.11` | Tracks the newest patch within that minor line. |
-| Major line | `minimal-caddy:2` | Tracks the newest release within that major line; does not cross a major bump. |
-| Latest | `minimal-caddy:latest` | Tracks the newest published production build, **including across major versions**. |
-| Dev | `minimal-caddy:latest-dev` | Tracks the newest development/debug variant. |
+Every image also publishes a `:latest-dev` companion with a shell and toolchain,
+intended for multi-stage builds and debugging rather than production.
 
-Pin a major line (`:2`) if you want ongoing patches without being moved across a
-breaking upstream release — `:latest` will cross a major bump, an exact version
-tag never moves forward at all. Every tag above has a `-dev` companion
-(`:2-dev`, `:2.11-dev`).
-
-Two exceptions, by design: images on a `0.x` version publish only the minor line
-(`:0.42`, not `:0`) because semver permits breaking changes between `0.x` minors;
-and calendar-versioned images (minio, `2025.10.15`) publish no line tags at all.
-
-The Melange epoch resets to `r0` on an upstream application-version bump. It increments when the recipe itself changes while the upstream version stays the same.
-
-### Development variants
-
-All 91 images publish a `:latest-dev` companion. Prod and dev consume the same primary package from the same build; the dev image adds a shell, package manager, and image-appropriate build or debugging tools.
-
-Dev variants are intended for multi-stage builds and in-cluster debugging, not production workloads:
-
-```dockerfile
-FROM ghcr.io/rtvkiz/minimal-ruby:latest-dev AS build
-WORKDIR /work
-COPY Gemfile Gemfile.lock ./
-RUN bundle install
-
-FROM ghcr.io/rtvkiz/minimal-ruby:latest
-COPY --from=build /work /work
-```
-
-Dev images retain the production entrypoint. Override it for an interactive shell:
-
-```bash
-docker run -it --entrypoint /bin/sh \
-  ghcr.io/rtvkiz/minimal-caddy:latest-dev
-```
-
-Dev images use the same signing, SBOM, provenance, and publish pipeline as prod. They are not included in the public CVE dashboard because their intentionally larger toolchain surface is not representative of the production image. Composition rules are documented in [`docs/dev-variants/CONVENTIONS.md`](docs/dev-variants/CONVENTIONS.md).
+→ **[Tags & pinning](https://minimalcontainers.com/docs/tags)** ·
+**[Development variants](https://minimalcontainers.com/docs/dev-variants)**
 
 ## How images stay current
 
-Image maintenance uses separate loops because rebuilding an image and upgrading its application are different operations.
+Rebuilding an image and upgrading its application are different operations, so they
+run on separate loops — neither waits on the other, and neither needs a human.
 
-### 1. Six-hour rebuilds
+- **Every 6 hours** — the full catalog is rebuilt against current Wolfi packages, so
+  upstream fixes land without any code change.
+- **Daily** — upstream releases are detected, checksummed, and opened as auto-merging PRs.
+- **Every 6 hours** — transitive CVEs in Go, Ruby, Rust, and Maven dependencies are
+  patched into the build recipes.
+- **Every build** — guardrails assert that no image can be silently frozen and that the
+  catalog matches the build matrix.
 
-[`build.yml`](.github/workflows/build.yml) rebuilds the complete catalog every six hours. It keeps the currently pinned application version but consumes current Wolfi packages, toolchains, and any dependency-patch block already stored in the recipe.
-
-For a source-built image, the pipeline is:
-
-```text
-verified source archive
-  → native x86_64 and ARM64 Melange packages
-  → production and dev Apko images
-  → smoke test and production-image Grype scan
-  → multi-architecture publish
-  → Cosign signature, SPDX SBOM, and SLSA provenance
-  → verification and catalog artifacts
-```
-
-Pull requests build and test but do not publish. Only trusted non-PR runs publish to GHCR.
-
-### 2. Application-version updates
-
-[`update-versions.yml`](.github/workflows/update-versions.yml) checks 80 source-built applications daily using the declarative registry in [`.github/versions.yaml`](.github/versions.yaml). It updates the application version, verifies the upstream artifact checksum, resets the epoch, opens a PR, and enables auto-merge after required checks pass.
-
-Major-version pins stop unattended breaking upgrades. A new major can create an issue for explicit review instead.
-
-MinIO's date-based release tags are handled separately by [`update-minio.yml`](.github/workflows/update-minio.yml).
-
-For package-based images:
-
-- Rolling Wolfi package names (`nginx-mainline`, `apache2`, `sqlite`, `bun`) advance through the six-hour rebuild.
-- Versioned Wolfi package families (Python, Go, Node.js, .NET, Java, PostgreSQL) receive patch releases through rebuilds, while [`update-wolfi-packages.yml`](.github/workflows/update-wolfi-packages.yml) opens PRs when the package family itself must change.
-
-CI enforces complete update coverage using [`.github/autoupdate-coverage.yaml`](.github/autoupdate-coverage.yaml).
-
-### 3. Transitive dependency patches
-
-[`patch-go-deps.yml`](.github/workflows/patch-go-deps.yml) scans published Go binaries every six hours and proposes targeted module updates for fixable vulnerabilities. It preserves existing security pins, harmonizes related module families, and uses compile-before-keep checks for dependency-sensitive applications.
-
-[`patch-deps.yml`](.github/workflows/patch-deps.yml) performs the corresponding work for:
-
-- Rails gems.
-- Qdrant Rust crates.
-- Keycloak Maven dependencies.
-- Bundled Java archives in OpenSearch and Keycloak.
-
-Cassandra, Solr, and Pulsar bundled-JAR findings are report-only until their tightly coupled dependency families receive an explicit compatibility review.
-
-Generated changes are committed to automated PRs. The normal image build is the integration gate before auto-merge.
-
-### 4. Catalog and retention workflows
-
-| Workflow | Trigger | Responsibility |
-|---|---|---|
-| [`deploy-site.yml`](.github/workflows/deploy-site.yml) | Successful full build or site/catalog change | Builds `minimalcontainers.com` from recent complete scan and SBOM artifacts. |
-| [`auto-update-pr-branches.yml`](.github/workflows/auto-update-pr-branches.yml) | Push to `main` and every 30 minutes | Updates behind auto-merge PR branches so strict branch protection can continue. |
-| [`lint.yml`](.github/workflows/lint.yml) | Workflow or script changes | Runs Actionlint and ShellCheck before scheduled automation reaches `main`. |
-| [`cleanup-packages.yml`](.github/workflows/cleanup-packages.yml) | Weekly and manual | Reports untagged/expired dated versions; deletion is dry-run unless explicitly enabled. |
+→ **[How images stay current](https://minimalcontainers.com/docs/updates)** for the
+full model, workflows, and guardrails.
 
 ## Understanding vulnerability results
 
-A successful build does not mean an image has zero reported vulnerabilities.
+A successful build does not mean an image has zero reported vulnerabilities. Grype
+scans every production image; findings are informational and do not block publication.
+The catalog shows both raw and VEX-effective counts, and VEX suppressions are
+reconciled against every fresh scan so they cannot quietly go stale.
 
-- Grype scans production images and publishes raw JSON and SARIF results.
-- OpenVEX documents can mark a finding `not_affected` or `fixed` with justification.
-- The catalog shows both raw and VEX-effective counts.
-- VEX documents are schema-validated, and stale or newly fixable statements produce drift warnings.
-- Vulnerability findings are currently informational; the build has no global severity threshold that blocks publication.
-- Dev images are intentionally excluded from the public CVE dashboard.
-
-See [`tools/vex/README.md`](tools/vex/README.md) for the VEX workflow.
+→ **[Reading scan results](https://minimalcontainers.com/docs/vulnerabilities)**
 
 ## Build locally
 
-Install the same major tools used by CI:
-
 ```bash
-go install chainguard.dev/apko@v1.1.6
-go install chainguard.dev/melange@v0.41.1
-brew install anchore/grype/grype
+make python && make test-python        # apko-only image
+make caddy-melange && make caddy && make test-caddy   # source-built image
 ```
 
-Build and test an Apko-only image:
-
-```bash
-make python
-make test-python
-```
-
-Build and test a source-built image:
-
-```bash
-make caddy-melange
-make caddy
-make test-caddy
-```
-
-The authoritative onboarding and pre-push checklist is in [`docs/onboarding.md`](docs/onboarding.md). See the [Makefile](Makefile) for all local targets.
-
-## Project structure
-
-```text
-minimal/
-├── <image>/
-│   ├── apko/<name>.yaml          # production image assembly
-│   ├── apko/<name>-dev.yaml      # development/debug variant
-│   ├── melange.yaml              # source build, when applicable
-│   ├── test.sh                   # production smoke test
-│   └── test-dev.sh               # development-variant smoke test
-├── vex/<name>.openvex.json       # per-image vulnerability statements
-├── .github/
-│   ├── versions.yaml             # source-version update registry
-│   ├── patch-deps.yaml           # non-Go dependency patch registry
-│   ├── autoupdate-coverage.yaml  # package-based update classification
-│   ├── scripts/                  # shared updater implementation
-│   └── workflows/                # build, update, security, site, and cleanup automation
-├── catalog.json                  # canonical public image inventory
-├── docs/                         # onboarding, update, and variant standards
-├── site/                         # minimalcontainers.com Astro site
-├── Makefile
-└── README.md
-```
+Tooling, the project layout, and the full pre-push checklist are in
+[CONTRIBUTING.md](CONTRIBUTING.md) and [`docs/onboarding.md`](docs/onboarding.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -249,8 +249,19 @@ Published tags serve different purposes:
 | Digest | `minimal-python@sha256:…` | Immutable content identity; preferred for deployment pinning. |
 | Version | `minimal-caddy:2.11.4-r0` | Moves when that application version is rebuilt with newer packages. |
 | Dated version | `minimal-caddy:2.11.4-r0-20260725` | Build-history tag; may move if the image is rebuilt again on the same UTC date. |
-| Latest | `minimal-caddy:latest` | Tracks the newest published production build. |
+| Minor line | `minimal-caddy:2.11` | Tracks the newest patch within that minor line. |
+| Major line | `minimal-caddy:2` | Tracks the newest release within that major line; does not cross a major bump. |
+| Latest | `minimal-caddy:latest` | Tracks the newest published production build, **including across major versions**. |
 | Dev | `minimal-caddy:latest-dev` | Tracks the newest development/debug variant. |
+
+Pin a major line (`:2`) if you want ongoing patches without being moved across a
+breaking upstream release — `:latest` will cross a major bump, an exact version
+tag never moves forward at all. Every tag above has a `-dev` companion
+(`:2-dev`, `:2.11-dev`).
+
+Two exceptions, by design: images on a `0.x` version publish only the minor line
+(`:0.42`, not `:0`) because semver permits breaking changes between `0.x` minors;
+and calendar-versioned images (minio, `2025.10.15`) publish no line tags at all.
 
 The Melange epoch resets to `r0` on an upstream application-version bump. It increments when the recipe itself changes while the upstream version stays the same.
 

--- a/caddy/melange.yaml
+++ b/caddy/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-caddy.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: 2c3d02078286a6282cdb4d1d8744077788d556659dac0b64d8ed5886a7e5aeb9
 
 environment:

--- a/consul/melange.yaml
+++ b/consul/melange.yaml
@@ -15,7 +15,7 @@ package:
     - license: BUSL-1.1
 
 vars:
-  # SHA256 of consul source tarball - updated by update-consul.yml workflow
+  # SHA256 of consul source tarball - updated by update-versions.yml workflow
   sha256: d91f6f99338216f9fbbe3035f67debb990f5fa49f8c554281ee5c4c352e69019
 
 environment:

--- a/haproxy/melange.yaml
+++ b/haproxy/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: GPL-2.0-or-later
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-haproxy.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: 9298f565c2a9ba8a4e7f89c54be2c5d3fd960b5b304eb5515e15d29d2c15d4f7
 
 environment:

--- a/helm/melange.yaml
+++ b/helm/melange.yaml
@@ -12,7 +12,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 of helm source tarball - updated by update-helm.yml workflow
+  # SHA256 of helm source tarball - updated by update-versions.yml workflow
   sha256: 9265b7bcad329480fe1f14547befe5da1dbbede6bbd13e3dd6bfebb00d42cb68
 
 environment:

--- a/jenkins/melange.yaml
+++ b/jenkins/melange.yaml
@@ -12,7 +12,7 @@ package:
     - license: MIT
 
 vars:
-  # SHA256 checksum of jenkins.war - updated by update-jenkins.yml workflow
+  # SHA256 checksum of jenkins.war - updated by update-versions.yml workflow
   sha256: 9bbb2b329e52730ba7decd1a7a1095987f6250ec761fb21157dbb2cbcd1ef590
 
 environment:

--- a/kafka/melange.yaml
+++ b/kafka/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA512 of kafka_2.13-{version}.tgz - updated by update-kafka.yml workflow
+  # SHA512 of kafka_2.13-{version}.tgz - updated by update-versions.yml workflow
   sha512: c7d7b2318cb51aa0c61d3246a51c349210073c5c9b754947ef965a439f2f939e8600f204e134a75ac31faf3829c9370960ef7c6a9886c8a1dbf0339a21f4c54c
   scala_version: "2.13"
 

--- a/kube-state-metrics/melange.yaml
+++ b/kube-state-metrics/melange.yaml
@@ -1,0 +1,75 @@
+# Melange build configuration for minimal kube-state-metrics
+# Pure Go from source. Single static `kube-state-metrics` binary — exposes
+# Kubernetes object state (Deployments, Pods, Nodes, ...) as Prometheus metrics.
+# License: Apache-2.0.
+
+package:
+  name: kube-state-metrics-minimal
+  version: 2.19.1
+  epoch: 0
+  description: "Minimal kube-state-metrics Kubernetes object-state exporter built from source"
+  copyright:
+    - license: Apache-2.0
+
+vars:
+  # SHA256 of kube-state-metrics source tarball - updated by update-versions.yml
+  sha256: d62da96bd2c0497aa866f396762f1c11f3f6a066bb4e86c8168d96ddcddb9025
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify kube-state-metrics source
+  - runs: |
+      mkdir -p /home/build/kube-state-metrics-${{package.version}}
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/kubernetes/kube-state-metrics/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/kube-state-metrics.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/kube-state-metrics.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/kube-state-metrics.tar.gz -C /home/build/kube-state-metrics-${{package.version}} --strip-components=1
+      rm /home/build/kube-state-metrics.tar.gz
+
+  # Version is reported through the shared prometheus/common version package
+  # (upstream Makefile sets PKG = github.com/prometheus/common), NOT this
+  # project's own module path. `--version` prints an empty version if this is
+  # pointed at k8s.io/kube-state-metrics/v2 instead.
+  - runs: |
+      cd /home/build/kube-state-metrics-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= \
+          -X github.com/prometheus/common/version.Version=${{package.version}}" \
+        -o /home/build/kube-state-metrics-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/kube-state-metrics-bin "${{targets.destdir}}/usr/bin/kube-state-metrics"
+      chmod 0755 "${{targets.destdir}}/usr/bin/kube-state-metrics"
+
+  # Verify the build. Note: kube-state-metrics exposes a `version` SUBCOMMAND,
+  # not a --version flag (that errors with "unknown flag: --version").
+  - runs: |
+      echo "Verifying kube-state-metrics binary..."
+      "${{targets.destdir}}/usr/bin/kube-state-metrics" version
+
+update:
+  enabled: true
+  github:
+    identifier: kubernetes/kube-state-metrics
+    use-tag: true
+    tag-filter: "v2."

--- a/kubectl/melange.yaml
+++ b/kubectl/melange.yaml
@@ -14,7 +14,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 of kubernetes source tarball - updated by update-kubectl.yml workflow
+  # SHA256 of kubernetes source tarball - updated by update-versions.yml workflow
   sha256: 950f7dd65b64b18ca065a08ae73dd5f61ff72b48c8778c5bfceacc84eaaf10ed
 
 environment:

--- a/mailpit/melange.yaml
+++ b/mailpit/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: MIT
 
 vars:
-  # SHA256 of mailpit source tarball - updated by update-mailpit.yml workflow
+  # SHA256 of mailpit source tarball - updated by update-versions.yml workflow
   sha256: 19366f9b6fb3c8dd8f9c97b2e894133c6fbac2c2fee9657975874a0deab71777
 
 environment:

--- a/mariadb/melange.yaml
+++ b/mariadb/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: GPL-2.0-only
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-mariadb.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: 5ab7883db519bfcebfdd2aac09bc5544a12ce328f39edd46d0bf01690615ef6c
 
 environment:

--- a/memcached/melange.yaml
+++ b/memcached/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: BSD-3-Clause
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-memcached.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: d362c64e6d8d5287153501eabf7c85b4a761432fbf53f5d7b085d0bb1653c1dd
 
 environment:

--- a/mysql/melange.yaml
+++ b/mysql/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: GPL-2.0-only
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-mysql.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: eb3051164d625dd346a8203f76e0d5d5d9aec51dbe9d51788e39ec6b3f1394c2
 
 environment:

--- a/nats/melange.yaml
+++ b/nats/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-nats.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: fb873897f826686dc4407112613e80c61fba10a1b381375458784995cd9f295d
 
 environment:

--- a/prometheus/melange.yaml
+++ b/prometheus/melange.yaml
@@ -13,7 +13,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-prometheus.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: fb8eb45635c29b120cf54aa19a1b724348d49e385062ff519b8e0b4f457c26e1
 
 environment:

--- a/rabbitmq/melange.yaml
+++ b/rabbitmq/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: MPL-2.0
 
 vars:
-  # SHA256 of rabbitmq-server-generic-unix-{version}.tar.xz - updated by update-rabbitmq.yml
+  # SHA256 of rabbitmq-server-generic-unix-{version}.tar.xz - updated by update-versions.yml
   sha256: 992b73ad65856f5e0006cfb04366207c13da325462a3798d8e5ec22506219d67
 
 environment:

--- a/redis-exporter/melange.yaml
+++ b/redis-exporter/melange.yaml
@@ -1,0 +1,75 @@
+# Melange build configuration for minimal redis_exporter
+# Pure Go from source. Single static `redis_exporter` binary — scrapes Redis /
+# Valkey INFO and exposes it as Prometheus metrics.
+# License: MIT.
+
+package:
+  name: redis-exporter-minimal
+  version: 1.88.0
+  epoch: 0
+  description: "Minimal Redis exporter for Prometheus built from source"
+  copyright:
+    - license: MIT
+
+vars:
+  # SHA256 of redis_exporter source tarball - updated by update-versions.yml
+  sha256: 91288858a8c4465e545241d011cf2ecd0cf549004daef38e517f060d6389b9f6
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go
+      - git
+
+pipeline:
+  # Download and verify redis_exporter source. Note the upstream repo is
+  # `redis_exporter` (underscore) while our image is `redis-exporter` (hyphen,
+  # matching the catalog's naming convention).
+  - runs: |
+      mkdir -p /home/build/redis-exporter-${{package.version}}
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/oliver006/redis_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/redis-exporter.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/redis-exporter.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/redis-exporter.tar.gz -C /home/build/redis-exporter-${{package.version}} --strip-components=1
+      rm /home/build/redis-exporter.tar.gz
+
+  # Version lives in package main (upstream: -X main.BuildVersion). The binary
+  # prints "<<< filled in by build >>>" if this is not injected, which the smoke
+  # test greps against.
+  - runs: |
+      cd /home/build/redis-exporter-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= \
+          -X main.BuildVersion=${{package.version}}" \
+        -o /home/build/redis-exporter-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/redis-exporter-bin "${{targets.destdir}}/usr/bin/redis_exporter"
+      chmod 0755 "${{targets.destdir}}/usr/bin/redis_exporter"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying redis_exporter binary..."
+      "${{targets.destdir}}/usr/bin/redis_exporter" --version 2>&1 | head -2
+
+update:
+  enabled: true
+  github:
+    identifier: oliver006/redis_exporter
+    use-tag: true
+    tag-filter: "v1."

--- a/redis-slim/melange.yaml
+++ b/redis-slim/melange.yaml
@@ -32,7 +32,7 @@ package:
     provider-priority: 100
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-redis.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: b928cf47427b94bb0c6866c32df834bc8e5efc815b9ad2e2d24bf33f2c533e2a
 
 environment:

--- a/registry/melange.yaml
+++ b/registry/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: Apache-2.0
 
 vars:
-  # SHA256 of the distribution source tarball - updated by update-registry.yml workflow
+  # SHA256 of the distribution source tarball - updated by update-versions.yml workflow
   sha256: 419183e8c1426b5d625732cf6846a2d48ad8e898a1659d7bec7171b7d156673e
 
 environment:

--- a/site/src/components/Layout.astro
+++ b/site/src/components/Layout.astro
@@ -35,6 +35,7 @@ const year = new Date().getFullYear();
       </a>
       <nav class="nav">
         <a href="/images">Images</a>
+        <a href="/docs">Docs</a>
         <a href="/about">Verify</a>
         <a href="https://github.com/rtvkiz/minimal" rel="noopener" class="nav-cta">GitHub ↗</a>
       </nav>

--- a/site/src/pages/docs/dev-variants.astro
+++ b/site/src/pages/docs/dev-variants.astro
@@ -1,0 +1,46 @@
+---
+import Layout from '../../components/Layout.astro';
+import CopyButton from '../../components/CopyButton.astro';
+import { images } from '../../lib/catalog';
+const total = images.length;
+---
+<Layout title="Development variants — Minimal Containers" description="Every image ships a -dev companion with a shell and toolchain, for multi-stage builds and debugging.">
+  <section>
+    <div class="container-narrow">
+      <p class="eyebrow"><a href="/docs">Docs</a></p>
+      <h1 class="section-title">Development variants</h1>
+      <p class="section-sub">All {total} images publish a <code class="kv-mono">:latest-dev</code> companion. Production and dev consume the same primary package from the same build — dev adds a shell, a package manager, and image-appropriate build or debugging tools.</p>
+
+      <div class="notice" style="margin-top:24px">
+        Dev variants are intended for multi-stage builds and in-cluster debugging, not production workloads.
+      </div>
+
+      <h2 class="section-title" style="margin-top:44px">Multi-stage build</h2>
+      <p class="small muted">Build with the toolchain, ship without it.</p>
+      <CopyButton code={`FROM ghcr.io/rtvkiz/minimal-ruby:latest-dev AS build
+WORKDIR /work
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+FROM ghcr.io/rtvkiz/minimal-ruby:latest
+COPY --from=build /work /work`} />
+
+      <h2 class="section-title" style="margin-top:44px">Interactive shell</h2>
+      <p class="small muted">Dev images retain the production entrypoint. Override it to get a shell.</p>
+      <CopyButton code={`docker run -it --entrypoint /bin/sh \\
+  ghcr.io/rtvkiz/minimal-caddy:latest-dev`} />
+
+      <h2 class="section-title" style="margin-top:44px">Same pipeline, different scope</h2>
+      <p>
+        Dev images use the same signing, SBOM, provenance, and publish pipeline as production.
+        They are <b>excluded from the public CVE dashboard</b> — their intentionally larger toolchain
+        surface is not representative of the production image, so including them would misrepresent
+        both.
+      </p>
+      <p class="small muted">
+        Composition rules are documented in
+        <a href="https://github.com/rtvkiz/minimal/blob/main/docs/dev-variants/CONVENTIONS.md" rel="noopener">docs/dev-variants/CONVENTIONS.md</a>.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/docs/index.astro
+++ b/site/src/pages/docs/index.astro
@@ -1,0 +1,54 @@
+---
+import Layout from '../../components/Layout.astro';
+
+const sections = [
+  {
+    href: '/docs/tags',
+    cat: 'Using the images',
+    title: 'Tags & pinning',
+    desc: 'What each tag means, which one to pin, and how to track a major line without being moved across a breaking release.',
+  },
+  {
+    href: '/docs/dev-variants',
+    cat: 'Using the images',
+    title: 'Development variants',
+    desc: 'Every image ships a -dev companion with a shell and toolchain, for multi-stage builds and in-cluster debugging.',
+  },
+  {
+    href: '/docs/updates',
+    cat: 'How it works',
+    title: 'How images stay current',
+    desc: 'Two independent update loops plus transitive dependency patching — and the guardrails that stop an image going stale unnoticed.',
+  },
+  {
+    href: '/docs/vulnerabilities',
+    cat: 'How it works',
+    title: 'Reading scan results',
+    desc: 'Why a green build does not mean zero CVEs, what VEX changes, and how the raw and effective counts differ.',
+  },
+];
+---
+<Layout title="Docs — Minimal Containers" description="How to use Minimal Containers images, and how they are kept current.">
+  <section>
+    <div class="container-narrow">
+      <h1 class="section-title">Docs</h1>
+      <p class="section-sub">How to use the images, and how they are kept current. For the full inventory see <a href="/images">Images</a>; to check the claims yourself see <a href="/about">Verify</a>.</p>
+
+      <div class="grid" style="margin-top:28px">
+        {sections.map((s) => (
+          <article class="card">
+            <span class="cat">{s.cat}</span>
+            <a class="card-title" href={s.href}>{s.title}</a>
+            <p class="desc">{s.desc}</p>
+          </article>
+        ))}
+      </div>
+
+      <h2 class="section-title" style="margin-top:44px">Contributing</h2>
+      <p class="small muted">
+        Build recipes, the onboarding checklist, and local build instructions live in the
+        repository: <a href="https://github.com/rtvkiz/minimal" rel="noopener">github.com/rtvkiz/minimal</a>.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/docs/tags.astro
+++ b/site/src/pages/docs/tags.astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../../components/Layout.astro';
+import CopyButton from '../../components/CopyButton.astro';
+---
+<Layout title="Tags & pinning — Minimal Containers" description="What each published tag means and which one to pin for production.">
+  <section>
+    <div class="container-narrow">
+      <p class="eyebrow"><a href="/docs">Docs</a></p>
+      <h1 class="section-title">Tags &amp; pinning</h1>
+      <p class="section-sub">Every image publishes several tags pointing at the same build. Which one you pin decides what happens when the software changes underneath you.</p>
+
+      <h2 style="font-size:1.1rem;margin-top:32px">Pin by digest for immutability</h2>
+      <p class="small muted">A digest is content-addressed — it can never move. Preferred for production deployments.</p>
+      <CopyButton code={`FROM ghcr.io/rtvkiz/minimal-python@sha256:<digest>`} />
+
+      <h2 class="section-title" style="margin-top:44px">What each tag does</h2>
+      <table class="data">
+        <thead><tr><th>Reference</th><th>Example</th><th>Behavior</th></tr></thead>
+        <tbody>
+          <tr><td><b>Digest</b></td><td><code class="kv-mono">minimal-python@sha256:…</code></td><td>Immutable content identity. Never moves.</td></tr>
+          <tr><td><b>Version</b></td><td><code class="kv-mono">minimal-caddy:2.11.4-r0</code></td><td>Moves when that application version is rebuilt with newer packages.</td></tr>
+          <tr><td><b>Dated version</b></td><td><code class="kv-mono">minimal-caddy:2.11.4-r0-20260725</code></td><td>Build-history tag; may move if rebuilt again on the same UTC date.</td></tr>
+          <tr><td><b>Minor line</b></td><td><code class="kv-mono">minimal-caddy:2.11</code></td><td>Newest patch within that minor line.</td></tr>
+          <tr><td><b>Major line</b></td><td><code class="kv-mono">minimal-caddy:2</code></td><td>Newest release within that major line. Does not cross a major bump.</td></tr>
+          <tr><td><b>Latest</b></td><td><code class="kv-mono">minimal-caddy:latest</code></td><td>Newest production build, <b>including across major versions</b>.</td></tr>
+          <tr><td><b>Dev</b></td><td><code class="kv-mono">minimal-caddy:latest-dev</code></td><td>Newest development/debug variant.</td></tr>
+        </tbody>
+      </table>
+
+      <h2 class="section-title" style="margin-top:44px">Which should you pin?</h2>
+      <p>
+        <b>Pin a major line</b> (<code class="kv-mono">:2</code>) if you want ongoing patches without being
+        moved across a breaking upstream release. <code class="kv-mono">:latest</code> will cross a major
+        bump; an exact version tag never moves forward at all, so it stops receiving security fixes.
+        Pin a <b>digest</b> when you need a byte-identical artifact and will update it deliberately.
+      </p>
+      <p class="small muted">Every tag above has a <code class="kv-mono">-dev</code> companion — <code class="kv-mono">:2-dev</code>, <code class="kv-mono">:2.11-dev</code>.</p>
+
+      <h2 class="section-title" style="margin-top:44px">Two deliberate exceptions</h2>
+      <ul>
+        <li><b>Images on a <code class="kv-mono">0.x</code> version</b> publish only the minor line (<code class="kv-mono">:0.42</code>, never <code class="kv-mono">:0</code>). Semantic versioning permits breaking changes between <code class="kv-mono">0.x</code> minors, so a rolling <code class="kv-mono">:0</code> would promise a compatibility guarantee that does not exist.</li>
+        <li><b>Calendar-versioned images</b> (minio, <code class="kv-mono">2025.10.15</code>) publish no line tags — a <code class="kv-mono">:2025</code> tag would imply a support line that is not a real thing.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">About the epoch</h2>
+      <p class="small muted">
+        The Melange epoch (<code class="kv-mono">-r0</code>) resets on an upstream application-version bump,
+        and increments when the build recipe changes while the upstream version stays the same.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/docs/updates.astro
+++ b/site/src/pages/docs/updates.astro
@@ -1,0 +1,82 @@
+---
+import Layout from '../../components/Layout.astro';
+import { images } from '../../lib/catalog';
+const total = images.length;
+const repo = 'https://github.com/rtvkiz/minimal/blob/main';
+---
+<Layout title="How images stay current — Minimal Containers" description="Two independent update loops, transitive dependency patching, and the guardrails that stop an image going stale unnoticed.">
+  <section>
+    <div class="container-narrow">
+      <p class="eyebrow"><a href="/docs">Docs</a></p>
+      <h1 class="section-title">How images stay current</h1>
+      <p class="section-sub">Rebuilding an image and upgrading its application are different operations, so they run on separate loops. Neither waits on the other, and neither needs a human.</p>
+
+      <h2 class="section-title" style="margin-top:40px">1 · Six-hour rebuilds</h2>
+      <p>
+        <a href={`${repo}/.github/workflows/build.yml`} rel="noopener">build.yml</a> rebuilds the complete
+        catalog every six hours. It keeps the currently pinned application version but consumes current
+        Wolfi packages and toolchains — so an upstream glibc or OpenSSL fix reaches every image without
+        anyone changing a line of code.
+      </p>
+      <p class="small muted">For a source-built image the pipeline is:</p>
+      <pre class="codeblock"><code>verified source archive
+  → native x86_64 and ARM64 Melange packages
+  → production and dev Apko images
+  → smoke test and production-image Grype scan
+  → multi-architecture publish
+  → Cosign signature, SPDX SBOM, and SLSA provenance
+  → verification and catalog artifacts</code></pre>
+      <p class="small muted">Pull requests build and test but never publish. Only trusted non-PR runs push to GHCR.</p>
+
+      <h2 class="section-title" style="margin-top:44px">2 · Application-version updates</h2>
+      <p>
+        <a href={`${repo}/.github/workflows/update-versions.yml`} rel="noopener">update-versions.yml</a>
+        checks source-built applications daily against a declarative registry
+        (<a href={`${repo}/.github/versions.yaml`} rel="noopener">versions.yaml</a>). It updates the version,
+        verifies the upstream artifact checksum, resets the epoch, opens a pull request, and enables
+        auto-merge once required checks pass.
+      </p>
+      <p>
+        <b>Major-version pins stop unattended breaking upgrades.</b> When a new major appears the workflow
+        can open an issue for explicit review rather than bumping across it.
+      </p>
+      <p class="small muted">For package-based images:</p>
+      <ul class="small muted">
+        <li>Rolling Wolfi packages (<code class="kv-mono">nginx-mainline</code>, <code class="kv-mono">apache2</code>, <code class="kv-mono">sqlite</code>, <code class="kv-mono">bun</code>) advance through the six-hour rebuild.</li>
+        <li>Versioned families (Python, Go, Node.js, .NET, Java, PostgreSQL) get patch releases through rebuilds, while <a href={`${repo}/.github/workflows/update-wolfi-packages.yml`} rel="noopener">update-wolfi-packages.yml</a> opens PRs when the package family itself must change.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">3 · Transitive dependency patches</h2>
+      <p>
+        <a href={`${repo}/.github/workflows/patch-go-deps.yml`} rel="noopener">patch-go-deps.yml</a> scans
+        published Go binaries every six hours and proposes targeted module updates for fixable
+        vulnerabilities. It preserves existing security pins, harmonizes related module families, and for
+        dependency-sensitive applications <b>probes each candidate fix against a real compile</b>, keeping
+        only those that still build.
+      </p>
+      <p>
+        <a href={`${repo}/.github/workflows/patch-deps.yml`} rel="noopener">patch-deps.yml</a> does the
+        same for Rails gems, Qdrant Rust crates, Keycloak Maven dependencies, and bundled Java archives in
+        OpenSearch and Keycloak.
+      </p>
+      <p class="small muted">
+        Generated changes land as automated pull requests — the normal image build is the integration gate
+        before auto-merge. Cassandra, Solr, and Pulsar bundled-JAR findings are report-only until their
+        tightly coupled dependency families get an explicit compatibility review.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">4 · Guardrails</h2>
+      <p class="small muted">Automation that fails silently is worse than none, so each of these turns an invisible problem into a failed build.</p>
+      <table class="data">
+        <thead><tr><th>Check</th><th>Runs</th><th>Enforces</th></tr></thead>
+        <tbody>
+          <tr><td><b>Auto-update coverage</b></td><td>Every build</td><td>All {total} images have exactly one live update mechanism — an image cannot be silently frozen.</td></tr>
+          <tr><td><b>Catalog validation</b></td><td>Every build</td><td>The published catalog and the build matrix can never drift apart.</td></tr>
+          <tr><td><b>Workflow lint</b></td><td>Workflow changes</td><td>Actionlint and ShellCheck, so a shell error cannot reach a scheduled run on main.</td></tr>
+          <tr><td><b>Branch auto-update</b></td><td>Push to main, every 30 min</td><td>Keeps auto-merge pull requests from stalling under strict branch protection.</td></tr>
+          <tr><td><b>Retention</b></td><td>Weekly</td><td>Prunes untagged and expired dated versions. Deletion is dry-run unless explicitly enabled.</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/docs/vulnerabilities.astro
+++ b/site/src/pages/docs/vulnerabilities.astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../../components/Layout.astro';
+const repo = 'https://github.com/rtvkiz/minimal/blob/main';
+---
+<Layout title="Reading scan results — Minimal Containers" description="Why a green build does not mean zero CVEs, and how raw and VEX-effective counts differ.">
+  <section>
+    <div class="container-narrow">
+      <p class="eyebrow"><a href="/docs">Docs</a></p>
+      <h1 class="section-title">Reading scan results</h1>
+      <p class="section-sub">A successful build does not mean an image has zero reported vulnerabilities. Here is exactly what the numbers mean.</p>
+
+      <h2 class="section-title" style="margin-top:40px">What gets published</h2>
+      <ul>
+        <li><b>Grype scans every production image</b> and publishes raw JSON and SARIF results. SARIF is uploaded to the repository's Security tab.</li>
+        <li><b>Findings are informational.</b> There is no global severity threshold that blocks publication — a CVE with no available fix should not stop a security update to everything else in the image.</li>
+        <li><b>Dev images are excluded</b> from the dashboard. Their larger toolchain surface is not representative of the production image.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">Raw vs effective counts</h2>
+      <p>
+        The catalog shows two numbers. <b>Raw</b> is what the scanner reported. <b>Effective</b> is what
+        remains after applying <a href="https://openvex.dev/" rel="noopener">OpenVEX</a> statements, which
+        can mark a finding <code class="kv-mono">not_affected</code> or <code class="kv-mono">fixed</code>
+        with a stated justification.
+      </p>
+      <p class="small muted">
+        Both are shown deliberately. A single "0 CVEs" headline hides whether it was achieved by patching
+        or by suppression.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Suppressions cannot quietly rot</h2>
+      <p>
+        Anything can be suppressed once. The check that matters is whether a suppression is
+        <em>still true</em>, so every scan reconciles VEX statements against fresh results and flags two
+        kinds of drift:
+      </p>
+      <ul>
+        <li><b>Stale</b> — the suppressed CVE is no longer present at all, so the statement is dead weight.</li>
+        <li><b>Now fixable</b> — a real upstream fix exists, so the finding should be <em>patched, not hidden</em>.</li>
+      </ul>
+      <p class="small muted">
+        VEX documents are also schema-validated in CI. The workflow is documented in
+        <a href={`${repo}/tools/vex/README.md`} rel="noopener">tools/vex/README.md</a>.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Check it yourself</h2>
+      <p class="small muted">
+        Every claim here is verifiable from your terminal without an account — see <a href="/about">Verify</a>.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/tempo/melange.yaml
+++ b/tempo/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: AGPL-3.0-only
 
 vars:
-  # SHA256 of tempo source tarball - updated by update-tempo.yml workflow
+  # SHA256 of tempo source tarball - updated by update-versions.yml workflow
   sha256: 9da6e1c411694d1010bb7641ab55e365095bc85fd76d02e142ede0fa2162cf71
 
 environment:

--- a/traefik/melange.yaml
+++ b/traefik/melange.yaml
@@ -11,7 +11,7 @@ package:
     - license: MIT
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-traefik.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: 385efa2402785fc98634f23c300d91b9aa92e8153b617080613a081a646ae103
 
 environment:

--- a/valkey/melange.yaml
+++ b/valkey/melange.yaml
@@ -12,7 +12,7 @@ package:
     - license: BSD-3-Clause
 
 vars:
-  # SHA256 checksum of source tarball - updated by update-valkey.yml workflow
+  # SHA256 checksum of source tarball - updated by update-versions.yml workflow
   sha256: 7d7232acd1b8a49b4e05d07a00b3ca8c801ae06ab633ca6a3423bc5f385ab7ee
 
 environment:


### PR DESCRIPTION
Three related changes. The first enables the others: the tag ladder is what makes a major upgrade safe, and the docs describe it.

---

## 1. Rolling major/minor tags

```
minimal-helm:3.21.3            exact build          unchanged
minimal-helm:3.21.3-20260810   immutable history    unchanged
minimal-helm:3.21              newest 3.21.x        NEW
minimal-helm:3                 newest 3.x           NEW
minimal-helm:latest            newest anything      unchanged
```

Same digest — additional tags on the image already published. **No extra build, scan, signature, or storage.** Purely additive.

**Why:** today consumers pick between `:latest` (crosses a major bump with its breaking changes) and an exact patch (frozen forever, including no security fixes). Nothing in between. That is why #440 (helm 3.x -> 4.x) is a decision we have to get right on everyone's behalf. Once `:3` exists and people pin it, we can move `:latest` and `:4` without breaking anyone.

Derivation lives in `.github/scripts/version-ladder.sh` with a `--test` self-check, because the inputs vary:

| case | example | result |
|---|---|---|
| source-built semver | `3.4.0` | `:3`, `:3.4` |
| apko-only, Wolfi epoch | `3.14.7-r0` | `:3`, `:3.14` |
| two-part + epoch | `18.4-r7` | `:18`, `:18.4` |
| calendar-versioned | `2025.10.15` (minio) | none |
| `0.x` | `0.42.4` (thanos) | `:0.42` only |
| pre-release | `1.2.3-rc1` | none |

`0.x` gets no major tag on purpose — semver permits breaking changes between `0.x` minors, so a rolling `:0` would promise compatibility we cannot keep. 16 images are affected.

Verified: 13/13 self-test; dry-run across all 96 images; tag array simulated for prod and dev before wiring in. `cleanup-packages.yml` is unaffected — its retention only selects versions whose tags **all** match `-YYYYMMDD`.

---

## 2. A `/docs` section on the site, README 426 -> 190 lines

The README had grown to 426 lines, and a third of it was a hand-maintained image table that had already drifted — it claimed **91** images while `catalog.json` has **96**. The site already renders that inventory live.

New pages: `/docs`, `/docs/tags`, `/docs/dev-variants`, `/docs/updates`, `/docs/vulnerabilities`, plus a Docs nav entry. They read counts from the catalog at build time, so they cannot go stale the way the README did.

Each removed README section leaves a summary and a link. Contributor material (CI-pinned tool versions, project layout) moved into `CONTRIBUTING.md` rather than being dropped.

---

## 3. Doc-drift fixes

**19 melange.yaml files** credited per-image `update-<name>.yml` workflows that were consolidated into `update-versions.yml` and deleted.

Not cosmetic — `versions.yaml` records that this exact class caused an incident:

> mosquitto: the melange comment referenced an update-mosquitto.yml that never existed -> silently frozen at 2.0.20 (audit 2026-07-08)

Verified all 19 are genuinely covered before rewriting (cron-enabled `versions.yaml` rows; `make check-autoupdate` passes for all 96). `update-minio.yml` left alone — it still exists.

**CONTRIBUTING.md** told contributors to scan with `trivy`, while CI scans with **grype** — following the guide gave results that would not match what the PR is judged by.

All melange edits are comment-only (verified no non-comment line differs), so the CLAUDE.md documentation exception applies and no rebuild is required.

---

Refs #440
