### PR TITLE
docs: stop onboarding new images into the scanner blind spot

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -95,7 +95,7 @@ contents:
     - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
   packages:
     - wolfi-baselayout
-    - <name>-minimal          # source-built: your melange package. apko-only: the Wolfi apk.
+    - <name>                  # source-built: your melange package. apko-only: the Wolfi apk.
     - ca-certificates-bundle  # always, for TLS
 
 accounts:
@@ -154,10 +154,22 @@ Model on `cosign/melange.yaml` (Go) or `mosquitto/melange.yaml` (C). Skeleton:
 
 ```yaml
 package:
-  name: <name>-minimal
+  # Name it exactly what the upstream project is called — the same string NVD and
+  # the Wolfi secdb index it under. NOT `<name>-minimal`: syft derives the CPE from
+  # the apk name, so a suffix produces cpe:2.3:a:foo-minimal:foo-minimal:* which
+  # matches nothing in NVD and nothing in the Wolfi secdb, and grype silently
+  # reports zero CVEs. Measured: `haproxy-minimal` 0 findings vs `haproxy` 14 at an
+  # identical version. See §"Package naming and scanner visibility" below.
+  name: <name>
   version: X.Y.Z
   epoch: 0
   copyright: [{ license: <SPDX id> }]
+  dependencies:
+    # Required whenever Wolfi also ships a package of this name: apko resolves a
+    # top-level name across ALL repositories and picks the highest version — it does
+    # not prefer our local repo. provider-priority is evaluated before version in
+    # apko's comparator, so this pins resolution to our build permanently.
+    provider-priority: 100
 
 vars:
   sha256: <tarball sha256>     # updated by update-versions.yml
@@ -204,6 +216,39 @@ GOTOOLCHAIN=local CGO_ENABLED=0 go build \
   across a minor bump often adds build deps. mosquitto 2.1 turned on `WITH_EDITLINE`
   (→ editline), `WITH_HTTP_API` (→ libmicrohttpd), `WITH_SQLITE` (→ sqlite3); all
   disabled with `=no` for a minimal broker. Read the new version's `config.mk`.
+
+### Package naming and scanner visibility
+
+The melange `package.name` is not cosmetic — it is the only identity a scanner has
+for a C/C++ image, and it decides whether that image is scanned at all.
+
+Grype matches through two paths, and a `-minimal` suffix breaks both:
+
+| Path | Keyed on | With `foo-minimal` |
+|---|---|---|
+| `wolfi:distro:wolfi:rolling` (secdb, fix-aware) | apk package name | no secdb entry → no matches |
+| `nvd:cpe` | CPE syft derives from the apk name | `cpe:2.3:a:foo-minimal:foo-minimal:*` → matches nothing in NVD |
+
+Syft's `apk-db-cataloger` reads `/usr/lib/apk/db/installed`, which carries no CPE
+field, and it ignores the embedded SBOM at `/var/lib/db/sbom/`. A melange `cpe:`
+block therefore does **not** reach `grype <image>` — renaming the package is the
+only fix. A controlled test at an identical version: `haproxy-minimal` reported
+**0** findings, `haproxy` reported **14**.
+
+Go images are partially covered by accident — syft's `go-module` cataloger reads
+the binary's build info and gives them a second identity. Non-Go images have no
+fallback and are fully blind.
+
+**Rules**
+- Name the package exactly what upstream calls it (`redis`, `haproxy`, `nginx`).
+- Add `dependencies.provider-priority: 100` whenever Wolfi ships a package of the
+  same name, so apk cannot substitute Wolfi's build for ours on a version bump.
+- The image name stays `minimal-<name>` — this is the *apk package* name only, and
+  it must match in `melange.yaml`, `apko/<name>.yaml`, and `apko/<name>-dev.yaml`.
+
+**Migration in progress.** 84 existing `melange.yaml` files still carry the suffix.
+`redis-slim` is the completed reference; the rollout plan is in
+`docs/package-rename-plan.md`. New images must not add to the backlog.
 
 ---
 

--- a/docs/package-rename-plan.md
+++ b/docs/package-rename-plan.md
@@ -1,0 +1,159 @@
+# Plan: rename `<app>-minimal` apk packages to upstream names
+
+Status: **planned**. Pilot landed (`redis`, commit `df7c509`). 84 images remain on main (86 melange.yaml files; `redis` renamed, `cuda-python` never suffixed).
+
+## Problem
+
+Syft derives a package's CPE from its apk name. A `-minimal` suffix produces
+`cpe:2.3:a:haproxy-minimal:haproxy-minimal:*`, which matches nothing in NVD
+(indexed as `cpe:2.3:a:haproxy:haproxy:*`) and nothing in the Wolfi secdb. **Both
+of grype's matchers miss**, so the scan reports clean while the image is unscanned.
+
+Controlled test, identical SBOM and version `2.2.0-r0`, only the name differing:
+
+| package name | CVEs found |
+|---|---|
+| `haproxy-minimal` | 0 |
+| `haproxy` | 14 |
+
+Verified end to end on real images (not edited SBOMs) — see "Evidence" below.
+
+## Severity split
+
+Go images carry a second identity from syft's binary cataloger
+(`minimal-helm` also reports `go-module helm.sh/helm/v3`), so their application
+CVEs still surface. Non-Go images have **only** the apk entry and are fully blind.
+
+| group | count | status |
+|---|---|---|
+| non-Go (blind) | 26 | highest priority |
+| Go (partially mitigated) | 58 | lower urgency |
+
+Measured masked CVEs at time of analysis: 8, including 2 Criticals on HAProxy 3.4.0.
+Treat as a rough signal — undercounts (naive `vendor=product=name`) and overcounts
+(CPE false positives).
+
+## The change, per image
+
+Exactly 3 files. Example, haproxy:
+
+```diff
+ # haproxy/melange.yaml
+ package:
+-  name: haproxy-minimal
++  name: haproxy
+   version: 3.4.0
+   epoch: 0
++  dependencies:
++    provider-priority: 100
+```
+
+```diff
+ # haproxy/apko/haproxy.yaml  AND  haproxy/apko/haproxy-dev.yaml
+   packages:
+-    - haproxy-minimal
++    - haproxy
+```
+
+`site/src/data/images.json` also contains the old name but is **generated** by
+`build-data.mjs`; it regenerates on the next deploy. Do not hand-edit.
+
+### Why `provider-priority`
+
+apko resolves a top-level package name across **all** repositories and picks the
+highest version — it does **not** prefer the local repo. In
+`apko@v1.1.6/pkg/apk/apk/repo.go`, `comparePackages()` sorts by: matching repo/origin
+(only when `compare != nil`) → installed → installed origin → **pin** →
+**ProviderPriority** → **version** → name. At line 657 a top-level request passes
+`compare = nil`, so the repository tiebreak never runs.
+
+Without a priority, any Wolfi package of the same name at a higher version silently
+replaces the source-built binary, with a green build.
+
+### Which name to use
+
+Use the **bare upstream name**, never Wolfi's versioned variant.
+
+Wolfi ships both (`helm` + `helm-3`/`helm-4`; `mariadb` + `mariadb-10.6`…`12.2`).
+Their versioned packages are themselves CPE-poisoned — Wolfi's own `helm-4` yields
+`cpe:2.3:a:helm-4:helm-4:*`, the same bug. The bare name matched **both** namespaces
+in testing.
+
+## Waves
+
+**Wave 1 — 20 images.** Non-Go, no Wolfi name collision. Start with `haproxy`
+(carries the 2 Criticals, proven 0 → 14).
+
+```
+cassandra envoy fluent-bit haproxy jenkins kafka keepalived memcached
+mosquitto mysql opensearch php pulsar rabbitmq rails ruby tomcat
+unbound zookeeper
+```
+
+**Wave 2 — 6 images.** Non-Go, Wolfi ships the same name; `provider-priority`
+becomes load-bearing.
+
+```
+deno keycloak mariadb pgbouncer qdrant solr valkey
+```
+
+**Wave 3 — 58 Go images.** Real but partially mitigated. Mechanical by this point.
+
+**Wave 4 — the guard.** CI check failing if any melange package name collides with
+a Wolfi `APKINDEX` entry without `provider-priority` set. Prevents silent regression
+as Wolfi's catalog grows.
+
+Also rename `kube-state-metrics` and `redis-exporter` as part of their onboarding
+(both untracked WIP at time of writing; both are Go apps).
+
+## Per-image recipe
+
+1. `melange.yaml`: rename `package.name`, add `dependencies.provider-priority: 100`
+2. Update **both** apko variants' `contents.packages` — atomically with step 1
+3. `melange build --arch x86_64` (aarch64 cannot build locally — no QEMU; CI covers it)
+4. `apko build` both variants → log must read `installing <app> (<version>)`, not a Wolfi package
+5. `test.sh` and `test-dev.sh` → exit 0
+6. **grype before/after** → record the delta
+
+Batch ~5 images per PR. `strict: true` branch protection means a large PR is
+repeatedly invalidated by bump merges, and one bad image shouldn't block four good ones.
+
+## Risks and notes
+
+- **No CVE gate exists.** `grype "$IMAGE" -o json -o sarif` — no `--fail-on`, no
+  severity cutoff. Newly-surfaced CVEs cannot fail a build. They will appear on the
+  catalog site, so the public "0 CVEs" number will rise — frame it before it lands.
+- **NVD vendor mismatch is unresolved.** Envoy is indexed under vendor `envoyproxy`,
+  not `envoy`. Syft has a CPE dictionary that may bridge some cases; unverified.
+  **If the after-scan is still 0, the rename alone did not fix that image.** This is
+  why step 6 is non-negotiable.
+- **melange's `cpe:` field does not help.** It reaches only melange's generated SBOM.
+  The apk database has no CPE field, and syft catalogued 0 packages from the image's
+  `/var/lib/db/sbom/` — `grype <image>` reads `/usr/lib/apk/db/installed`.
+- **Directory name ≠ package name** in some images (`redis-slim` → `redis`). Verify
+  per image; do not derive mechanically.
+- **Sweep for stray references** — a renamed package with a stale apko reference fails
+  to resolve. haproxy had 3 real references; redis had 3 plus comments.
+
+## Evidence
+
+Real `apko build` runs, local package named `helm` 3.21.3 vs Wolfi's `helm-4` 4.2.3-r1:
+
+| local package | apko installed |
+|---|---|
+| `helm` 3.21.3, no priority | Wolfi's `helm-4` 4.2.3-r1 |
+| `helm` 3.21.3, `provider-priority: 100` | our `helm` 3.21.3-r0 |
+
+Real image scans:
+
+```
+renamed image:  helm 3.21.3-r0  cpe:2.3:a:helm:helm:*     matches=5  ns=nvd:cpe, wolfi:distro
+wolfi's build:  helm-4 4.2.3-r1 cpe:2.3:a:helm-4:helm-4:* (poisoned)
+```
+
+Pilot (`redis`, same version 8.10.0):
+
+```
+published redis-minimal  → 0 redis CVEs
+locally built redis      → 1 redis CVE (CVE-2025-49112)
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Image Roadmap — the road to 100 (demand-ranked)
 
-**Status: 93 / 100 images.** This is the source-of-truth plan for growing the catalog.
+**Status: 96 / 100 images.** This is the source-of-truth plan for growing the catalog.
 It supersedes the batch order from earlier sessions, which was ordered by *build ease* and
 *GitHub popularity*. This version is ordered by **actual container demand first**, then
 build effort.
@@ -70,7 +70,7 @@ by effort. Fills the catalog's thinnest categories (databases, proxies, apps).
 | [ ] | apisix | apache/apisix | 🟢 Apache-2.0 | C/Lua/OpenResty | 37M | 17k | API gateway (harder: OpenResty) |
 | [ ] | vaultwarden | dani-garcia/vaultwarden | 🟡 AGPL-3.0 | Rust | 304M | 64k | self-hosted Bitwarden |
 | [ ] | kvrocks | apache/kvrocks | 🟢 Apache-2.0 | C++ | 3.5M | 4k | Redis-on-RocksDB |
-| [ ] | patroni | patroni/patroni | 🟢 MIT | Python | — | 9k | Postgres HA (Python pattern — new) |
+| [x] | patroni | patroni/patroni | 🟢 MIT | Python | — | 9k | Postgres HA — shipped; first Python-daemon pattern |
 | [ ] | woodpecker | woodpecker-ci/woodpecker | 🟢 Apache-2.0 | Go+frontend | 2.7M | 7k | CI server (has web UI) |
 
 ## Deferred / heavier efforts (own project, not a batch)
@@ -111,7 +111,7 @@ Policy filter = buildable under the shell-less/minimal thesis: ✅ static-Go bin
 C daemon (no *runtime* compiler — the varnish lesson) · JVM-jlink · interpreter ·
 binary-repackage. Excluded from the 100-path: frontend-in-bwrap (grafana/argocd/uptime-kuma),
 runtime-compiler (varnish), tangled force-bump graphs, huge-disk C++ (clickhouse), and
-🔴 SSPL/BUSL/EULA. At the current 93-image catalog, 7 images remain to reach 100.
+🔴 SSPL/BUSL/EULA. At the current 96-image catalog, 4 images remain to reach 100.
 
 ### Batch F — static Go (the crank) → 88   [DONE]
 | Image | Upstream | License | Build notes |
@@ -130,19 +130,24 @@ runtime-compiler (varnish), tangled force-bump graphs, huge-disk C++ (clickhouse
 
 Fills thin **Infrastructure**.
 
-### Batch H — JVM-jlink (kafka/zookeeper template) → 91 done, → 92 remaining
+### Batch H — JVM-jlink (kafka/zookeeper template)
 cassandra (🟢 wide-column DB, Java-17 + jamm agent) · solr (🟢 search, Java-21) ·
-pulsar (🟢 messaging, Java-21) — **DONE → 91**. flink (🟢 stream processing, Java-21) remaining → 94.
+pulsar (🟢 messaging, Java-21) — **DONE**. flink (🟢 stream processing, Java-21) remaining.
 All Apache. Fills thin DB/search/messaging.
 
-### Batch I — Rust (qdrant/vector precedent, own effort each) → 96
-vector (🟢 MPL-2.0, observability pipeline) · vaultwarden (🟡 AGPL-3.0, Bitwarden server; ~304M pulls).
+### Batch I — Rust (qdrant/vector precedent, own effort each)
+vector (🟢 MPL-2.0, observability pipeline) — **DONE**. vaultwarden (🟡 AGPL-3.0, Bitwarden
+server; ~304M pulls) remaining.
 
-### Batch J — Erlang / Python → 98
-couchdb (🟢 Apache, Erlang — rabbitmq precedent) · patroni (🟢 MIT, Postgres HA — new Python-daemon pattern).
+### Batch J — Erlang / Python
+patroni (🟢 MIT, Postgres HA — new Python-daemon pattern) — **DONE**.
+couchdb (🟢 Apache, Erlang — rabbitmq precedent) remaining.
 
-### Batch K — own-effort revisit → 100
+### Batch K — own-effort revisit
 cmctl (🟢 Apache — revisit klone build) · + one of {cert-manager core (multi-image) / pomerium (Envoy fetch) / apisix (OpenResty)}.
+
+Batches H–K name more candidates than the 4 slots left to 100; the last slots go to
+whichever land first.
 
 **Beyond the 100-path (deliberate exceptions, not scheduled):** varnish (runtime cc), grafana/argocd/uptime-kuma
 (frontend-in-bwrap), clickhouse/kubescape (disk-cap). See the deferred table above.


### PR DESCRIPTION
Documentation only — no image build inputs touched.

The onboarding checklist still told every new image to name its melange package `<name>-minimal`. That is the exact pattern measured as unscannable: at an identical version, `haproxy-minimal` reported **0** grype findings and `haproxy` reported **14**. Both of grype's match paths break on the suffix — the Wolfi secdb has no entry for it, and the CPE syft derives from the apk name (`cpe:2.3:a:haproxy-minimal:haproxy-minimal:*`) matches nothing in NVD.

So until now, onboarding from the checklist was actively growing the backlog that `redis` (df7c509) started working off.

### Changes

- **`docs/onboarding.md`** — melange skeleton uses the upstream package name and `dependencies.provider-priority: 100`; new "Package naming and scanner visibility" section covering both broken match paths, why a melange `cpe:` block cannot fix it (syft's `apk-db-cataloger` reads `/usr/lib/apk/db/installed`, which carries no CPE field, and ignores the embedded SBOM under `/var/lib/db/sbom/`), and why Go images are only accidentally covered via the `go-module` cataloger.
- **`docs/package-rename-plan.md`** — now tracked, so the reference from onboarding.md resolves. Counts corrected to the measured state: 84 remaining (26 non-Go and fully blind, 58 Go and partially mitigated).
- **`docs/roadmap.md`** — status 93 → 96 to match `catalog.json`; `patroni` and `vector` marked shipped; removed the per-batch running totals, which had drifted and no longer summed to anything.

### Verification

- Counts re-measured from the tree, not carried over: 86 `*/melange.yaml`, 84 still suffixed (`redis` renamed, `cuda-python` was never suffixed).
- Roadmap checkboxes diffed against `catalog.json` in both directions; `patroni` was the only shipped-but-unchecked row, and no checked row was missing from the catalog.