### PR TITLE
feat(vaultwarden): onboard Vaultwarden (99)

### DIFF
--- a/.github/patch-deps.yaml
+++ b/.github/patch-deps.yaml
@@ -51,6 +51,7 @@
     commands in each image's melange.yaml.
   images:
     - { name: qdrant, src-root: "/home/build/qdrant-<<PKG_VERSION>>", build-marker: "cargo build --release" }
+    - { name: vaultwarden, src-root: "/home/build/vaultwarden-<<PKG_VERSION>>", build-marker: "cargo build --release" }
 
 - name: maven
   artifact-type: java-archive

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -419,6 +419,18 @@
     releases: "https://github.com/oliver006/redis_exporter/releases"
     notes: "https://github.com/oliver006/redis_exporter/releases/tag/v{version}"
 
+- name: vaultwarden
+  cron-enabled: true   # onboarded 2026-08-14 (dispatch-validated: current=1.37.1 latest=1.37.1)
+  files: [vaultwarden/melange.yaml]
+  # pattern is mandatory for github-tags (check-upstream.sh exits 1 without it).
+  # Upstream tags are bare versions with no leading v, so no strip-prefix.
+  source: { type: github-tags, repo: dani-garcia/vaultwarden, pattern: '^[0-9]+\.[0-9]+\.[0-9]+$', pin-major: 1 }
+  tarball: { url: "https://github.com/dani-garcia/vaultwarden/archive/refs/tags/{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/dani-garcia/vaultwarden/releases"
+    notes: "https://github.com/dani-garcia/vaultwarden/releases/tag/{version}"
+
 - name: blackbox-exporter
   cron-enabled: true   # wave 8 (dispatch-validated 2026-07-08)
   files: [blackbox-exporter/melange.yaml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             {"name":"traefik","variants":["prod","dev"]},{"name":"rabbitmq","variants":["prod","dev"]},{"name":"minio","variants":["prod","dev"]},
             {"name":"prometheus","variants":["prod","dev"]},{"name":"alertmanager","variants":["prod","dev"]},{"name":"mariadb","variants":["prod","dev"]},{"name":"etcd","variants":["prod","dev"]},
             {"name":"victoria-metrics","variants":["prod","dev"]},{"name":"jaeger","variants":["prod","dev"]},{"name":"otelcol","variants":["prod","dev"]},
-            {"name":"qdrant","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
+            {"name":"qdrant","variants":["prod","dev"]},{"name":"vaultwarden","variants":["prod","dev"]},{"name":"envoy","variants":["prod","dev"]},{"name":"gitea","variants":["prod","dev"]},
             {"name":"coredns","variants":["prod","dev"]},{"name":"openbao","variants":["prod","dev"]},{"name":"loki","variants":["prod","dev"]},
             {"name":"fluent-bit","variants":["prod","dev"]},{"name":"keycloak","variants":["prod","dev"]},
             {"name":"registry","variants":["prod","dev"]},{"name":"mailpit","variants":["prod","dev"]},

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ FLUENT_BIT_VERSION ?= $(call melange_version,fluent-bit/melange.yaml)
 
 # --- Search/AI ---
 QDRANT_VERSION ?= $(call melange_version,qdrant/melange.yaml)
+VAULTWARDEN_VERSION ?= $(call melange_version,vaultwarden/melange.yaml)
 OPENSEARCH_VERSION ?= $(call melange_version,opensearch/melange.yaml)
 
 # --- Registries ---
@@ -223,6 +224,7 @@ endef
 .PHONY: thanos thanos-melange test-thanos
 .PHONY: node-exporter node-exporter-melange test-node-exporter
 .PHONY: blackbox-exporter blackbox-exporter-melange test-blackbox-exporter
+.PHONY: vaultwarden vaultwarden-melange test-vaultwarden
 .PHONY: redis-exporter redis-exporter-melange test-redis-exporter
 .PHONY: kube-state-metrics kube-state-metrics-melange test-kube-state-metrics
 .PHONY: pushgateway pushgateway-melange test-pushgateway
@@ -233,7 +235,7 @@ endef
 all: build scan
 
 # Build all images
-build: python node-slim bun go java ruby php dotnet deno mysql mariadb postgres-slim pgbouncer unbound dnsmasq keepalived vector patroni metrics-server external-dns velero kaniko step-ca skopeo sqlite opensearch redis-slim valkey memcached kafka zookeeper cassandra solr pulsar tomcat rabbitmq nats mosquitto nginx httpd caddy haproxy traefik envoy oauth2-proxy prometheus alertmanager victoria-metrics thanos mimir jaeger loki tempo otelcol fluent-bit telegraf node-exporter blackbox-exporter kube-state-metrics redis-exporter pushgateway coredns etcd openbao keycloak qdrant registry consul helm kubectl opentofu trivy cosign syft grype osv-scanner oras notation conftest kubeconform kube-bench trufflehog flux kustomize sops crane kubeseal helmfile regctl stern gitleaks step-cli opa jenkins gitea minio rails mailpit
+build: python node-slim bun go java ruby php dotnet deno mysql mariadb postgres-slim pgbouncer unbound dnsmasq keepalived vector patroni metrics-server external-dns velero kaniko step-ca skopeo sqlite opensearch redis-slim valkey memcached kafka zookeeper cassandra solr pulsar tomcat rabbitmq nats mosquitto nginx httpd caddy haproxy traefik envoy oauth2-proxy prometheus alertmanager victoria-metrics thanos mimir jaeger loki tempo otelcol fluent-bit telegraf node-exporter blackbox-exporter kube-state-metrics redis-exporter pushgateway coredns etcd openbao keycloak qdrant vaultwarden registry consul helm kubectl opentofu trivy cosign syft grype osv-scanner oras notation conftest kubeconform kube-bench trufflehog flux kustomize sops crane kubeseal helmfile regctl stern gitleaks step-cli opa jenkins gitea minio rails mailpit
 
 #------------------------------------------------------------------------------
 # SIGNING KEY (required for melange packages)
@@ -305,6 +307,7 @@ $(eval $(call DEV_IMAGE_RULE,jenkins,jenkins-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,openbao,openbao-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mysql,mysql-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,qdrant,qdrant-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,vaultwarden,vaultwarden-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,keycloak,keycloak-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,registry,registry-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,mailpit,mailpit-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
@@ -2420,6 +2423,32 @@ redis-exporter: redis-exporter-melange
 	@echo "✓ minimal-redis-exporter built (source build)"
 
 #------------------------------------------------------------------------------
+# VAULTWARDEN IMAGE (melange Rust source build + apko; Bitwarden-compatible server)
+#------------------------------------------------------------------------------
+vaultwarden-melange: keygen
+	@echo "Building vaultwarden $(VAULTWARDEN_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build vaultwarden/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ vaultwarden package built from source"
+
+vaultwarden: vaultwarden-melange
+	@echo "Assembling minimal-vaultwarden image with apko..."
+	apko build vaultwarden/apko/vaultwarden.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-vaultwarden:$(VERSION) \
+		vaultwarden.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < vaultwarden.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-vaultwarden:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-vaultwarden:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-vaultwarden:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-vaultwarden:latest
+	@rm -f vaultwarden.tar sbom-*.spdx.json
+	@echo "✓ minimal-vaultwarden built (source build)"
+
+#------------------------------------------------------------------------------
 # PUSHGATEWAY IMAGE (melange Go source build + apko; Prometheus push gateway)
 #------------------------------------------------------------------------------
 pushgateway-melange: keygen
@@ -3884,6 +3913,12 @@ test-otelcol:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-otelcol:latest" && \
 		otelcol/test.sh
 	@echo "✓ OTel Collector tests passed"
+
+test-vaultwarden:
+	@echo "Testing vaultwarden image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-vaultwarden:latest" && \
+		vaultwarden/test.sh
+	@echo "✓ vaultwarden tests passed"
 
 test-qdrant:
 	@echo "Testing Qdrant image..."

--- a/catalog.json
+++ b/catalog.json
@@ -83,6 +83,7 @@
     { "name": "openbao", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "openbao", "upstream_url": "https://openbao.org", "summary": "OpenBao secret management server (Vault fork, MPL 2.0)." },
     { "name": "keycloak", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "keycloak", "upstream_url": "https://www.keycloak.org", "summary": "Keycloak identity and access management server." },
     { "name": "qdrant", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "qdrant", "upstream_url": "https://qdrant.tech", "summary": "Qdrant vector search engine built from source via melange." },
+    { "name": "vaultwarden", "category": "Apps", "variants": ["prod", "dev"], "primary_package": "vaultwarden", "upstream_url": "https://github.com/dani-garcia/vaultwarden", "summary": "Shell-less Vaultwarden Bitwarden-compatible server built from source." },
     { "name": "registry", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "registry", "upstream_url": "https://distribution.github.io/distribution/", "summary": "Shell-less OCI distribution registry (Docker Registry v2)." },
     { "name": "consul", "category": "Infrastructure", "variants": ["prod", "dev"], "primary_package": "consul", "upstream_url": "https://www.consul.io", "summary": "Shell-less HashiCorp Consul (BUSL-1.1) built from source via melange." },
 

--- a/vaultwarden/apko/vaultwarden-dev.yaml
+++ b/vaultwarden/apko/vaultwarden-dev.yaml
@@ -1,0 +1,73 @@
+# Development variant of minimal-vaultwarden.
+# Same vaultwarden binary and web vault (source-built via melange) as prod,
+# plus a shell and HTTP/TLS debugging tools for poking at the Rocket API.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - vaultwarden
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+    # sqlite CLI is a genuine debugging aid here: the prod image links SQLite
+    # statically into the binary, so there is no other way to inspect db.sqlite3.
+    - sqlite
+
+accounts:
+  groups:
+    - groupname: vaultwarden
+      gid: 65532
+  users:
+    - username: vaultwarden
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/vaultwarden
+
+work-dir: /data
+
+environment:
+  PATH: /usr/bin:/bin
+  DATA_FOLDER: /data
+  WEB_VAULT_FOLDER: /usr/share/vaultwarden/web-vault
+  ROCKET_ADDRESS: 0.0.0.0
+  ROCKET_PORT: "8080"
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-vaultwarden-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-vaultwarden: same server + shell and debug tools. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/vaultwarden"
+  org.opencontainers.image.licenses: "AGPL-3.0-only AND GPL-3.0-only"
+
+archs:
+  - x86_64
+  - aarch64

--- a/vaultwarden/apko/vaultwarden.yaml
+++ b/vaultwarden/apko/vaultwarden.yaml
@@ -1,0 +1,67 @@
+# Minimal Vaultwarden image - built from source via melange
+# Unofficial Bitwarden-compatible password manager server
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  packages:
+    - wolfi-baselayout
+    - vaultwarden
+    - glibc
+    - glibc-locale-posix
+    - ld-linux
+    - libgcc
+    - libssl3
+    - libcrypto3
+    - ca-certificates-bundle
+    # No sqlite package: the sqlite cargo feature statically links SQLite into
+    # the binary, so there is nothing to load at runtime.
+
+accounts:
+  groups:
+    - groupname: vaultwarden
+      gid: 65532
+  users:
+    - username: vaultwarden
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+entrypoint:
+  command: /usr/bin/vaultwarden
+
+work-dir: /data
+
+environment:
+  PATH: /usr/bin:/bin
+  DATA_FOLDER: /data
+  # Absolute path: vaultwarden resolves WEB_VAULT_FOLDER relative to the
+  # working directory otherwise, and /data is a mounted volume that does not
+  # contain the assets.
+  WEB_VAULT_FOLDER: /usr/share/vaultwarden/web-vault
+  ROCKET_ADDRESS: 0.0.0.0
+  # Upstream defaults to 80, which uid 65532 cannot bind — a nonroot container
+  # would fail to start. 8080 is unprivileged; publish it as :80 if wanted.
+  ROCKET_PORT: "8080"
+
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+
+annotations:
+  org.opencontainers.image.title: "minimal-vaultwarden"
+  org.opencontainers.image.description: "Hardened shell-less Vaultwarden (Bitwarden-compatible server) built from source via melange"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/vaultwarden"
+  # The server is AGPL-3.0; the bundled web vault is Bitwarden's OSS (GPL-3.0)
+  # build. Both ship in this image, so both are declared.
+  org.opencontainers.image.licenses: "AGPL-3.0-only AND GPL-3.0-only"
+
+archs:
+  - x86_64
+  - aarch64

--- a/vaultwarden/melange.yaml
+++ b/vaultwarden/melange.yaml
@@ -1,0 +1,112 @@
+# Melange build configuration for minimal Vaultwarden
+# Builds the Vaultwarden server from source (Rust) and bundles the prebuilt
+# web vault. Unofficial Bitwarden-compatible server; ~316M pulls upstream.
+
+package:
+  # Named `vaultwarden` — what upstream calls it and what NVD indexes. Never
+  # `vaultwarden-minimal`: syft derives the CPE from the apk name, so a suffix
+  # produces cpe:2.3:a:vaultwarden-minimal:vaultwarden-minimal:* which matches
+  # nothing in NVD and has no Wolfi secdb entry, and grype then reports zero
+  # findings for an unscanned image.
+  name: vaultwarden
+  version: 1.37.1
+  epoch: 0
+  description: "Minimal Vaultwarden (Bitwarden-compatible server) built from source"
+  copyright:
+    # Two licenses ship in this image: the server is AGPL-3.0, and the bundled
+    # web vault is Bitwarden's OSS build (GPL-3.0). bw_web_builds compiles it
+    # with `npm run dist:oss:selfhost`, Bitwarden's `oss:` target — not the
+    # `bit:` target, which is the proprietary bitwarden_license tree. So no
+    # source-available/EULA code is redistributed here.
+    - license: AGPL-3.0-only
+    - license: GPL-3.0-only
+  dependencies:
+    # apko resolves a top-level package name across ALL repositories and picks
+    # the highest version — it does not prefer our local repo (apko v1.1.6
+    # pkg/apk/apk/repo.go, comparePackages: `compare` is nil for a top-level
+    # request, so the repository-matching tiebreak never runs). Wolfi has no
+    # bare `vaultwarden` today, but if it ever adds one at a higher version apk
+    # would silently install it instead of this source-built one.
+    provider-priority: 100
+
+vars:
+  sha256: 32c43436517fe67bdf207cf9e803a3b71e87703f384604588d360f7e6724f045
+  # The web vault is a separate prebuilt release, not built here. Building it
+  # would mean running the Bitwarden npm/Angular toolchain inside bwrap — the
+  # frontend quagmire that keeps grafana and argocd off the catalog. Upstream
+  # publishes sha256sums.txt with the release, so the artifact is verifiable.
+  web_vault_version: 2026.6.4
+  web_vault_sha256: d47f16ed4e756c73c88143047281f8881f1a6fb680d9bf0dd24c8adae6799592
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - rust
+      - openssl-dev
+      - pkgconf
+      # No sqlite-dev: the `sqlite` cargo feature pulls libsqlite3-sys/bundled,
+      # which compiles SQLite into the binary. That needs a C compiler at build
+      # time (build-base) but leaves no SQLite runtime dependency.
+
+pipeline:
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/dani-garcia/vaultwarden/archive/refs/tags/${{package.version}}.tar.gz" \
+        -o /home/build/vaultwarden.tar.gz
+      echo "${{vars.sha256}}  /home/build/vaultwarden.tar.gz" | sha256sum -c -
+      cd /home/build && tar xzf vaultwarden.tar.gz && rm vaultwarden.tar.gz
+
+  - runs: |
+      curl -fsSL --retry 5 --retry-all-errors \
+        "https://github.com/dani-garcia/bw_web_builds/releases/download/v${{vars.web_vault_version}}/bw_web_v${{vars.web_vault_version}}.tar.gz" \
+        -o /home/build/web-vault.tar.gz
+      echo "${{vars.web_vault_sha256}}  /home/build/web-vault.tar.gz" | sha256sum -c -
+
+  - runs: |
+      cd /home/build/vaultwarden-${{package.version}}
+      # `default = []` upstream — no database backend is compiled in unless one
+      # is named, and the server refuses to start without one. sqlite only:
+      # mysql/postgresql would add libmariadb/libpq runtime dependencies for
+      # backends a single-container deployment does not use.
+      cargo build --release --features sqlite --bin vaultwarden
+
+  - runs: |
+      cd /home/build/vaultwarden-${{package.version}}
+
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp target/release/vaultwarden "${{targets.destdir}}/usr/bin/"
+      strip --strip-unneeded "${{targets.destdir}}/usr/bin/vaultwarden"
+
+      # The tarball unpacks a top-level web-vault/ directory.
+      mkdir -p "${{targets.destdir}}/usr/share/vaultwarden"
+      tar xzf /home/build/web-vault.tar.gz -C "${{targets.destdir}}/usr/share/vaultwarden"
+      test -f "${{targets.destdir}}/usr/share/vaultwarden/web-vault/index.html"
+
+      # Drop the cargo registry cache: melange's license scanner runs as the
+      # host user after the sandbox exits and cannot chmod registry sources,
+      # which fails the post-build check (same trap as qdrant).
+      rm -rf /home/build/.cargo/registry
+
+  - runs: |
+      echo "Verifying Vaultwarden build..."
+      "${{targets.destdir}}/usr/bin/vaultwarden" --version
+      ls -lh "${{targets.destdir}}/usr/bin/vaultwarden"
+      ls "${{targets.destdir}}/usr/share/vaultwarden/web-vault/" | head -5
+
+update:
+  enabled: true
+  github:
+    identifier: dani-garcia/vaultwarden
+    use-tag: true
+    # Upstream tags are bare versions (1.37.1), with no leading v.
+    tag-filter: "1."
+    strip-prefix: ""

--- a/vaultwarden/test-dev.sh
+++ b/vaultwarden/test-dev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+cleanup() { docker rm -f vaultwarden-dev-test >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "Testing vaultwarden version (parity with prod)..."
+ver=$(docker run --rm --entrypoint /usr/bin/vaultwarden "$IMAGE" --version)
+echo "$ver" | grep -qi "vaultwarden" || { echo "$ver"; exit 1; }
+
+echo "Testing dev tooling is present..."
+for tool in /bin/sh /bin/bash /usr/bin/curl /usr/bin/jq /usr/bin/sqlite3; do
+  docker run --rm --entrypoint /bin/sh "$IMAGE" -c "test -x $tool" \
+    || { echo "missing dev tool: $tool"; exit 1; }
+done
+
+echo "Testing the web vault assets are bundled..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" \
+  -c "test -f /usr/share/vaultwarden/web-vault/index.html"
+
+echo "Testing Vaultwarden starts and serves its API..."
+docker run -d --name vaultwarden-dev-test "$IMAGE" >/dev/null
+
+ready=0
+for _ in $(seq 1 30); do
+  sleep 2
+  docker ps --format '{{.Names}}' | grep -q '^vaultwarden-dev-test$' || break
+  IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vaultwarden-dev-test)
+  if curl -sf "http://${IP}:8080/alive" >/dev/null 2>&1; then ready=1; break; fi
+done
+
+if [ "$ready" -ne 1 ]; then
+  echo "Vaultwarden (dev) did not become ready"
+  docker logs vaultwarden-dev-test 2>&1 | tail -30 || true
+  exit 1
+fi
+
+# sqlite3 is in this image specifically to inspect the database the prod image
+# links statically — check it can actually open what the server created.
+tables=$(docker exec vaultwarden-dev-test /bin/sh -c \
+  "test -f /data/db.sqlite3 && sqlite3 /data/db.sqlite3 '.tables'")
+echo "$tables" | grep -qi "users" \
+  || { echo "sqlite3 could not read the vaultwarden database: $tables"; exit 1; }
+
+echo "✓ All vaultwarden-dev smoke tests passed"

--- a/vaultwarden/test.sh
+++ b/vaultwarden/test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+cleanup() { docker rm -f vaultwarden-test >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "Testing Vaultwarden version..."
+docker run --rm --entrypoint /usr/bin/vaultwarden "$IMAGE" --version
+
+echo "Testing the web vault assets are bundled..."
+# vaultwarden --version prints the web vault version it resolved from
+# WEB_VAULT_FOLDER, so this proves the server can actually locate the assets —
+# strictly stronger than checking a file exists on disk.
+#
+# The previous check piped `docker export` into `tar -t | grep -q`. grep -q
+# exits on first match, tar takes SIGPIPE and returns non-zero, and pipefail
+# then failed the test on an image that was completely fine.
+ver=$(docker run --rm --entrypoint /usr/bin/vaultwarden "$IMAGE" --version)
+echo "$ver" | grep -q "Web-Vault" \
+  || { echo "vaultwarden could not resolve the bundled web vault"; echo "$ver"; exit 1; }
+
+echo "Testing Vaultwarden starts and serves its API..."
+docker run -d --name vaultwarden-test "$IMAGE" >/dev/null
+
+ready=0
+for _ in $(seq 1 30); do
+  sleep 2
+  docker ps --format '{{.Names}}' | grep -q '^vaultwarden-test$' || break
+  IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vaultwarden-test)
+  # /alive is Vaultwarden's liveness endpoint; it returns a JSON timestamp.
+  if curl -sf "http://${IP}:8080/alive" >/dev/null 2>&1; then ready=1; break; fi
+done
+
+if [ "$ready" -ne 1 ]; then
+  echo "Vaultwarden did not become ready"
+  docker logs vaultwarden-test 2>&1 | tail -30 || true
+  exit 1
+fi
+
+IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' vaultwarden-test)
+# The web vault is served at /, so a 200 here proves the bundled assets are
+# wired up, not merely present on disk.
+# Capture before matching: `curl | grep -q` makes grep exit at the first match,
+# curl takes SIGPIPE, and pipefail then fails the test on a working server.
+body=$(curl -sf "http://${IP}:8080/")
+echo "$body" | grep -qi "<html" \
+  || { echo "web vault not served at /"; docker logs vaultwarden-test 2>&1 | tail -20; exit 1; }
+
+# SQLite is compiled in; a fresh start must create the database rather than
+# fail on a missing backend (upstream's default features enable none). A
+# reachable /alive already proves that — the server exits at startup if it has
+# no usable database — so assert on the specific failure rather than grepping
+# the log for "error", which matches benign lines and fails at random.
+logs=$(docker logs vaultwarden-test 2>&1)
+if echo "$logs" | grep -qiE "no database backend|error connecting to|migration.*failed"; then
+  echo "database backend problem at startup:"; echo "$logs" | tail -20; exit 1
+fi
+
+echo "✓ All Vaultwarden tests passed"

--- a/vex/vaultwarden.openvex.json
+++ b/vex/vaultwarden.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/vaultwarden",
+  "author": "rtvkiz",
+  "timestamp": "2026-08-14T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Catalog **98 → 99**. Bitwarden-compatible server, ~316M pulls, no free hardened equivalent.

## Two things that could have gone badly, checked rather than assumed

**No database backend compiles in by default.** Upstream `Cargo.toml` has `default = []` and the server refuses to start without one. Built `--features sqlite`, which pulls `libsqlite3-sys/bundled` and statically links SQLite — so the prod image ships no sqlite package at all.

**The web vault is not built here.** It ships as a prebuilt release from `dani-garcia/bw_web_builds` with a published `sha256sums.txt`. Building it would mean running Bitwarden's npm/Angular toolchain inside bwrap — the frontend quagmire that keeps grafana and argocd off the catalog.

## License verified, not taken from the roadmap

`bitwarden/clients` reports `NOASSERTION` — it is mixed-licensed, with a `bitwarden_license/` tree under a proprietary agreement that would be 🔴 under our policy. Traced the build:

```
bw_web_builds:  npm run dist:oss:selfhost
bitwarden:      dist:oss:selfhost → build:oss:selfhost:prod → build:oss → webpack
```

Bitwarden maintains parallel `oss:` and `bit:` targets; `bit:` is the proprietary one. This uses `oss:`, so the image redistributes **AGPL-3.0** (server) and **GPL-3.0** (web vault) only. Both are declared in `copyright:` and the apko `licenses` annotation, since both ship in one image.

## Runtime details

- `ROCKET_PORT=8080` — upstream defaults to 80, which uid 65532 cannot bind, so a nonroot container would not start.
- `WEB_VAULT_FOLDER` is absolute; vaultwarden resolves it relative to the working directory otherwise, and `/data` is a mounted volume without the assets.
- Wolfi's virtual `rust` resolves to 1.97.1, meeting upstream's 1.95.0 floor without pinning a toolchain that would go stale.

## Registration

Every point in `docs/onboarding.md`: Makefile, build.yml matrix, catalog.json, versions.yaml, and `patch-deps.yaml` under the **rust** row (qdrant precedent), not patch-go-deps.

`check-packages`, `check-autoupdate` and `lint-workflows` all pass.

## Validation

The versions row was dispatch-validated before enabling cron (`current=1.37.1 latest=1.37.1`). That surfaced a real bug first: `check-upstream.sh` requires `source.pattern` for `github-tags` and exits 1 without it, with no other diagnostic.

CI is the build validator — a Rust build of this size is not a laptop job.