### PR TITLE
fix(bundled-jars): derive Maven groups from purl, align families, guard siblings

### DIFF
--- a/.github/patch-deps.yaml
+++ b/.github/patch-deps.yaml
@@ -116,6 +116,12 @@
     tarball, so the maven patcher can't reach them) with grype, finds
     java-archive CVEs whose fix is a published Maven Central artifact, and
     splices sha256-pinned jar-swap blocks into each image's melange.yaml.
+  # coord-map is now an OVERRIDE, not a requirement: the group is derived from
+  # grype's purl (pkg:maven/<group>/<artifact>@<ver>). Before that, every
+  # artifact needed an entry here and only one existed, so all other fixable
+  # jars were skipped with "no coord-map entry" — flink kept log4j 2.25.3 and
+  # its six advisories for exactly that reason. Add an entry only when an
+  # artifact's purl is missing or wrong.
   coord-map:
     jackson-databind: com.fasterxml.jackson.core:jackson-databind
   images:

--- a/.github/scripts/patch-bundled-jars.sh
+++ b/.github/scripts/patch-bundled-jars.sh
@@ -113,13 +113,21 @@ for i in $(seq 0 $((image_count - 1))); do
 
   # grype → "artifact<TAB>installed<TAB>fix" for java-archive matches whose
   # artifact is in coord-map and that actually have a fix version.
-  fixes=$(jq -r --argjson cm "$(jq -c '.["coord-map"]' <<<"$row")" '
+  # Group comes from grype's purl (pkg:maven/<group>/<artifact>@<ver>), so a
+  # new artifact needs no hand-written coord-map entry. coord-map remains an
+  # override for the rare artifact whose purl is missing or wrong.
+  #
+  # This was the real blocker: the map had exactly one entry (jackson-databind),
+  # so every other fixable jar was skipped with "no coord-map entry" — flink
+  # shipped log4j 2.25.3 with six advisories for that reason alone.
+  fixes=$(jq -r '
       [ .matches[]
         | select(.artifact.type == "java-archive")
-        | select(.artifact.name as $n | $cm | has($n))
         | select((.vulnerability.fix.versions | length) > 0)
-        | { name: .artifact.name, installed: .artifact.version, fix: .vulnerability.fix.versions[0] }
-      ] | unique_by(.name + .installed + .fix) | .[] | "\(.name)\t\(.installed)\t\(.fix)"
+        | { name: .artifact.name, installed: .artifact.version,
+            fix: .vulnerability.fix.versions[0], purl: (.artifact.purl // "") }
+      ] | unique_by(.name + .installed + .fix) | .[]
+        | "\(.name)\t\(.installed)\t\(.fix)\t\(.purl)"
     ' "$scan_json" 2>/dev/null | sort -t"$(printf '\t')" -k1,1 -k3,3rV || true)
   rm -f "$scan_json"
   # Highest fix version per artifact is tried first; the loop takes the first
@@ -127,17 +135,46 @@ for i in $(seq 0 $((image_count - 1))); do
 
   [ -n "$fixes" ] || { echo "  No fixable bundled-jar CVEs"; continue; }
 
+  # Align every artifact in a group to that group's HIGHEST fix version before
+  # resolving. Netty, Jetty, Jackson and Log4j release in lockstep and throw
+  # NoSuchMethodError / NoClassDefFoundError on a mixed classpath, so taking
+  # each artifact's own minimum fix builds an image that scans clean and will
+  # not start. Solr proved this: log4j-core at 2.25.4 beside log4j-api at
+  # 2.25.5 is exactly the pair that broke it.
+  declare -A GROUP_MAX=()
+  while IFS=$'\t' read -r a_ i_ f_ p_; do
+    [ -n "$a_" ] || continue
+    c_=$(jq -r --arg a "$a_" '.["coord-map"][$a] // ""' <<<"$row")
+    if [ -n "$c_" ]; then g_="${c_%:*}"; else ga_="${p_#pkg:maven/}"; ga_="${ga_%@*}"; g_="${ga_%/*}"; fi
+    [ -n "$g_" ] || continue
+    cur_="${GROUP_MAX[$g_]:-}"
+    if [ -z "$cur_" ] || ver_gt "$f_" "$cur_"; then GROUP_MAX[$g_]="$f_"; fi
+  done <<< "$fixes"
+
   # Resolve each fix to the newest *published* version that clears it, pin sha256.
   # SWAPS lines: "artifact|group-path|installed|newver|sha256"
   SWAPS=""
   declare -A seen=()
-  while IFS=$'\t' read -r artifact installed fix; do
+  while IFS=$'\t' read -r artifact installed fix purl; do
     [ -n "$artifact" ] || continue
     [ -n "${seen[$artifact]:-}" ] && continue   # one swap per artifact (newest fix wins below)
     coord=$(jq -r --arg a "$artifact" '.["coord-map"][$a] // ""' <<<"$row")
-    [ -n "$coord" ] || { echo "  skip $artifact: no coord-map entry"; continue; }
-    group="${coord%:*}"; gpath="${group//.//}"
+    if [ -n "$coord" ]; then
+      group="${coord%:*}"
+    else
+      # pkg:maven/<group>/<artifact>@<version>
+      ga="${purl#pkg:maven/}"; ga="${ga%@*}"; group="${ga%/*}"
+    fi
+    [ -n "$group" ] && [ "$group" != "$artifact" ] \
+      || { echo "  skip $artifact: no group from coord-map or purl ($purl)"; continue; }
+    gpath="${group//.//}"
     inst="${installed#v}"; fixv="${fix#v}"
+    # Lift to the group target so the whole family lands on one version.
+    gmax="${GROUP_MAX[$group]:-}"
+    if [ -n "$gmax" ] && ver_gt "${gmax#v}" "$fixv"; then
+      echo "  $artifact: raising $fixv -> ${gmax#v} to match the $group family"
+      fixv="${gmax#v}"
+    fi
 
     # Refuse a major-version jump — bundled deps are API-coupled to the distro
     # (e.g. jline 3.x -> 4.x would break kafka). Only same-major bumps.
@@ -158,7 +195,7 @@ for i in $(seq 0 $((image_count - 1))); do
     seen[$artifact]=1
     echo "  -> $artifact $inst -> $fixv ($sha)"
   done <<< "$fixes"
-  unset seen
+  unset seen GROUP_MAX
 
   [ -n "$SWAPS" ] || { echo "  Nothing to patch after filtering"; continue; }
 
@@ -209,6 +246,29 @@ for i in $(seq 0 $((image_count - 1))); do
       printf '      _swap %s %s %s %s %s %s\n' "$artifact" "$gpath" "$inst" "$fixv" "$sha" "$strategy"
       count=$((count + 1))
     done <<< "$SWAPS"
+    # Sibling guard. A family member with no CVE of its own never appears in a
+    # scan report, so it is never swapped and silently stays behind — that is
+    # how solr ended up with log4j-core 2.25.4 beside log4j-api 2.25.3 and died
+    # at startup with NoClassDefFoundError. Fail the build and name the file
+    # instead of shipping a mixed classpath. Scoped to the artifact prefix and
+    # the old major.minor series so unrelated jars that merely share a version
+    # string are left alone (calcite-core and opentelemetry-semconv were both
+    # 1.37.0).
+    if [ "$strategy" != "keep-filename" ]; then
+      printf '      _stragglers=""\n'
+      while IFS='|' read -r artifact gpath inst fixv sha; do
+        [ -n "$artifact" ] || continue
+        pfx="${artifact%%-*}"
+        series="$(printf '%s' "$inst" | cut -d. -f1,2)"
+        printf '      _stragglers="$_stragglers$(find "${{targets.destdir}}/%s" -name "%s*-%s.*.jar" -o -name "%s*-%s.jar" 2>/dev/null)"\n' \
+          "$jar_root" "$pfx" "$series" "$pfx" "$series"
+      done <<< "$SWAPS"
+      printf '      if [ -n "$_stragglers" ]; then\n'
+      printf '        echo "patch-bundled-jars: jars left on a superseded version:" >&2\n'
+      printf '        echo "$_stragglers" >&2\n'
+      printf '        exit 1\n'
+      printf '      fi\n'
+    fi
     printf '  # end-%s\n' "$marker_id"
     tail -n +"$marker_line" "$melange"
   } > "${melange}.tmp"


### PR DESCRIPTION
## The actual root cause

The bundled-jar patcher already runs on schedule (`patch-deps.yml` → `patch-deps.sh` → `patch-bundled-jars.sh`) and already covers opensearch, keycloak, cassandra, solr and pulsar. It just couldn't act: every artifact needed a hand-written `coord-map` entry, and **exactly one existed**.

Its own logs said so, run after run:

```
Skipping jackson-core@2.21.4: no coord-map entry
Skipping micrometer-core@1.16.6: no coord-map entry
Skipping postgresql@42.7.12: no coord-map entry
```

That is why flink shipped log4j 2.25.3 with six advisories, and why I ended up patching it by hand. The pipeline was working and telling us it was blind.

## Changes

**Group derived from grype's purl.** `pkg:maven/<group>/<artifact>@<ver>` already carries the group, so a newly fixable artifact needs no mapping. `coord-map` stays as an override for artifacts whose purl is missing or wrong.

**Family alignment.** Every artifact in a group is lifted to that group's highest fix version before resolution. Netty, Jetty, Jackson and Log4j release in lockstep and throw `NoSuchMethodError`/`NoClassDefFoundError` on a mixed classpath — `log4j-core 2.25.4` beside `log4j-api 2.25.5` is the exact pair that stopped solr from starting.

**Sibling guard.** Fails the build when a jar of the same artifact prefix and `major.minor` series is left behind. Family members with no CVE of their own never appear in a scan, so they are never swapped — that is how the solr mismatch arose. Scoped to prefix+series so unrelated jars sharing a version string are untouched (`calcite-core` and `opentelemetry-semconv` were both `1.37.0`). Skipped for `keep-filename` images, where filenames don't carry the version.

sha256 pinning and the same-major-only rule are unchanged.

## Blast radius — please review before merging

| image | policy | effect |
|---|---|---|
| cassandra, solr, pulsar, flink | `report-only` | no block generated; reporting only |
| keycloak | `keep-filename` | more artifacts now eligible; sibling guard skipped |
| **opensearch** | `auto` + `rename` | **the real exposure** |

opensearch is the one image that will now auto-patch far more than before — previously only `jackson-databind` could match, now anything with a purl. Its next scheduled run may produce a much larger PR, and it is the only image the new sibling guard can fail.

That is the intended effect, but it deserves eyes on the first generated PR rather than trusting auto-merge.

## Also supersedes

`tools/patch-java-deps/generate.sh`, which I wrote for solr without discovering this script first. It should be deleted once this lands — the capabilities it had that this lacked (purl groups, alignment, sibling handling) are now here, and the capabilities this has that it lacked (sha256 pinning, same-major guard) were always better.
