### PR TITLE
fix(flink): bump the vendored log4j family 2.25.3 → 2.25.5

### DIFF
--- a/flink/melange.yaml
+++ b/flink/melange.yaml
@@ -100,6 +100,112 @@ pipeline:
       sed -i 's/^\( *\)address: localhost/\1address: 0.0.0.0/' "$CONF"
       grep -q "bind-host: 0.0.0.0" "$CONF"
 
+      # Bump the vendored log4j family. Flink ships 2.25.3, which carries 6
+      # advisories; upstream will not rebuild for them on our schedule.
+      JARROOT="${{targets.destdir}}/opt/flink"
+      # patch-java-deps: auto-generated — do not edit manually
+      #
+      # Upstream ships prebuilt JARs; these are the vendored copies grype flags.
+      # Each swap replaces one vulnerable JAR with the fixed release from Maven
+      # Central. A swap that finds no matching file is a hard error: it means the
+      # bundled version moved and this block is stale, which must not be mistaken
+      # for "nothing to do".
+      jar_swap() {
+        _g="$1"; _a="$2"; _old="$3"; _new="$4"; _cls="${5:-}"
+        _sfx=""; [ -n "$_cls" ] && _sfx="-$_cls"
+        _url="https://repo1.maven.org/maven2/$(echo "$_g" | tr . /)/$_a/$_new/$_a-$_new$_sfx.jar"
+        _n=0
+        for _f in $(find "$JARROOT" -name "$_a-$_old$_sfx.jar"); do
+          _d=$(dirname "$_f")
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+            "$_url" -o "$_d/$_a-$_new$_sfx.jar"
+          # A truncated or HTML error body would install silently and only fail at
+          # runtime; every JAR is a zip, so check the magic bytes before deleting
+          # the copy we are replacing.
+          case "$(head -c2 "$_d/$_a-$_new$_sfx.jar")" in
+            PK) ;;
+            *) echo "patch-java-deps: $_a-$_new$_sfx.jar is not a zip" >&2; exit 1 ;;
+          esac
+          rm -f "$_f"
+          _n=$((_n + 1))
+        done
+        if [ "$_n" -eq 0 ]; then
+          echo "patch-java-deps: no $_a-$_old$_sfx.jar found under $JARROOT" >&2
+          exit 1
+        fi
+        echo "patch-java-deps: $_a $_old -> $_new ($_n file(s))"
+      }
+      
+      jar_swap org.apache.logging.log4j log4j-1.2-api 2.25.3 2.25.5 
+      jar_swap org.apache.logging.log4j log4j-api 2.25.3 2.25.5 
+      jar_swap org.apache.logging.log4j log4j-core 2.25.3 2.25.5 
+      jar_swap org.apache.logging.log4j log4j-layout-template-json 2.25.3 2.25.5 
+      
+      # Sweep the rest of each upgraded family. Siblings with no CVE of their own
+      # never appear in a scan report — log4j-api, log4j-web and log4j-slf4j2-impl
+      # sat at 2.25.3 while log4j-core moved to 2.25.4, and log4j-core against a
+      # mismatched log4j-api is a LoggerContext failure at startup. Anything still
+      # at the old version is pulled up to the same target.
+      family_sweep() {
+        _g="$1"; _old="$2"; _new="$3"; _p="$4"
+        # Match the family by major.minor SERIES, not by exact version and not by
+        # prefix alone. Exact missed jackson-annotations, which sits at 2.20 while
+        # databind is 2.20.0 — Solr died with NoClassDefFoundError JsonSerializeAs.
+        # Prefix alone was too wide: netty-tcnative-boringssl-static shares the
+        # netty prefix and the io.netty group but versions independently at 2.0.x,
+        # and forcing it to 4.2.16.Final has no release to point at.
+        _series=$(echo "$_old" | cut -d. -f1,2)
+        for _f in $(find "$JARROOT" -name "$_p*.jar"); do
+          _b=$(basename "$_f" .jar)
+          _v="${_b##*-}"
+          # Trailing field is a classifier, not a version (…-linux-x86_64.jar).
+          case "$_v" in [0-9]*) ;; *) continue ;; esac
+          [ "$_v" = "$_new" ] && continue
+          # Different release line under the same prefix — not this family.
+          [ "$(echo "$_v" | cut -d. -f1,2)" = "$_series" ] || continue
+          _a="${_b%-$_v}"
+          _tok=$(echo "$_a" | cut -d- -f2)
+          _found=0
+          # Target: exact, then patch-trimmed (2.21.5 -> 2.21) for artifacts that
+          # release on major.minor only.
+          for _tv in "$_new" "${_new%.*}"; do
+            # Group: as given, then the two split-family shapes (jackson replaces
+            # the last segment, jetty appends).
+            for _cand in "$_g" "${_g%.*}.$_tok" "$_g.$_tok"; do
+              _u="https://repo1.maven.org/maven2/$(echo "$_cand" | tr . /)/$_a/$_tv/$_a-$_tv.jar"
+              if curl -sfI --connect-timeout 10 --max-time 30 "$_u" -o /dev/null; then
+                _found=1; break
+              fi
+            done
+            [ "$_found" -eq 1 ] && break
+          done
+          if [ "$_found" -eq 0 ]; then
+            echo "patch-java-deps: no release of $_a for family target $_new" >&2
+            exit 1
+          fi
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+            "$_u" -o "$(dirname "$_f")/$_a-$_tv.jar"
+          case "$(head -c2 "$(dirname "$_f")/$_a-$_tv.jar")" in
+            PK) ;;
+            *) echo "patch-java-deps: $_a-$_tv.jar is not a zip" >&2; exit 1 ;;
+          esac
+          [ "$_f" = "$(dirname "$_f")/$_a-$_tv.jar" ] || rm -f "$_f"
+          echo "patch-java-deps: swept $_a $_v -> $_tv"
+        done
+      }
+      family_sweep org.apache.logging.log4j 2.25.3 2.25.5 log4j
+      
+      # Backstop: report every remaining mismatch in one pass. Exiting at the first
+      # one costs a full CI cycle per family to discover the next.
+      stragglers=""
+      stragglers="$stragglers$(find "$JARROOT" -name "log4j*-2.25.3.jar" -o -name "log4j*-2.25.3-*.jar")"
+      if [ -n "$stragglers" ]; then
+        echo "patch-java-deps: JARs still at a superseded version:" >&2
+        echo "$stragglers" >&2
+        exit 1
+      fi
+      # end-patch-java-deps
+
   - runs: |
       # Entrypoint mirrors the official image's command surface: `jobmanager`
       # (default) or `taskmanager`, both in the foreground so the container's


### PR DESCRIPTION
Follow-up to #547 (which took the catalog to 100). Flink ships **log4j 2.25.3**, which accounts for **all 6** of the image's findings:

| jar | advisories | fixed in |
|---|---:|---|
| `log4j-core@2.25.3` | 3 | 2.25.4 |
| `log4j-api@2.25.3` | 1 | 2.25.5 |
| `log4j-1.2-api@2.25.3` | 1 | 2.25.4 |
| `log4j-layout-template-json@2.25.3` | 1 | 2.25.4 |

These are genuinely stale vendored dependencies — not the Wolfi epoch drift behind kube-state-metrics's findings. flink is registered `report-only` in `patch-deps.yaml` (matching cassandra/solr/pulsar), so nothing patches them automatically by design.

## Family alignment matters here

The whole family is lifted to **2.25.5**, the group maximum, rather than each artifact taking its own minimum fix. `log4j-core 2.25.4` beside `log4j-api 2.25.5` is precisely the mismatch that left solr building clean and failing to start with `NoClassDefFoundError`. A family sweep also pulls siblings that carry no advisory of their own (`log4j-slf4j2-impl`) to the same version, scoped to the 2.25 series so unrelated jars are untouched.

## Note on the diff

The branch previously showed 12 files and a conflict: #547 was squash-merged from an earlier branch state, so GitHub diffed against the pre-merge base and replayed already-merged work. Rebuilt on current main — content-wise only `flink/melange.yaml` differs, as a pure addition.

Both melange builds passed on this content before the rebuild. The smoke test starts a real jobmanager and polls `/overview`, so a broken logging classpath fails the build rather than shipping.

Expected result: flink goes from 6 findings to **0**.
