### PR TITLE
fix(bundled-jars): lift whole jar families, not just the flagged members

### DIFF
--- a/.github/scripts/patch-bundled-jars.sh
+++ b/.github/scripts/patch-bundled-jars.sh
@@ -155,6 +155,7 @@ for i in $(seq 0 $((image_count - 1))); do
   # SWAPS lines: "artifact|group-path|installed|newver|sha256"
   SWAPS=""
   declare -A seen=()
+  declare -A seen2=()
   while IFS=$'\t' read -r artifact installed fix purl; do
     [ -n "$artifact" ] || continue
     [ -n "${seen[$artifact]:-}" ] && continue   # one swap per artifact (newest fix wins below)
@@ -195,7 +196,54 @@ for i in $(seq 0 $((image_count - 1))); do
     seen[$artifact]=1
     echo "  -> $artifact $inst -> $fixv ($sha)"
   done <<< "$fixes"
-  unset seen GROUP_MAX
+  unset seen seen2 GROUP_MAX
+
+  # --- family lift ------------------------------------------------------------
+  # Alignment above only reaches artifacts that APPEAR in the scan report. A
+  # sibling with no advisory of its own never appears, so it is never swapped
+  # and silently stays on the old version — opensearch lifted log4j-api to
+  # 2.25.5 while log4j-core and log4j-jul sat at 2.25.4, which is the mixed
+  # classpath that stops the JVM at startup.
+  #
+  # syft lists every package, not just vulnerable ones, so the rest of each
+  # upgraded family can be pulled up too — resolved and sha256-pinned exactly
+  # like any other swap, never guessed.
+  if command -v syft >/dev/null 2>&1; then
+    inv=$(mktemp)
+    if syft "$full_image" -o json >"$inv" 2>/dev/null; then
+      while IFS='|' read -r artifact gpath inst fixv sha; do
+        [ -n "$artifact" ] || continue
+        pfx="${artifact%%-*}"
+        series="$(printf '%s' "$inst" | cut -d. -f1,2)"
+        group="${gpath//\//.}"
+        # Same group, same prefix, same major.minor series, wrong version.
+        while IFS=$'\t' read -r sib sibver; do
+          [ -n "$sib" ] || continue
+          [ "$sib" = "$artifact" ] && continue
+          [ -n "${seen2[$sib]:-}" ] && continue
+          [ "$sibver" = "$fixv" ] && continue
+          case "$sib" in "$pfx"*) ;; *) continue ;; esac
+          [ "$(printf '%s' "$sibver" | cut -d. -f1,2)" = "$series" ] || continue
+          published "$gpath" "$sib" "$fixv" || {
+            echo "  family lift: $sib has no $fixv under $group, leaving it"; continue; }
+          tmp=$(mktemp)
+          curl -fsSL --retry 5 --retry-all-errors "$(maven_url "$gpath" "$sib" "$fixv")" -o "$tmp"
+          sha2=$(sha256sum "$tmp" | awk '{print $1}'); rm -f "$tmp"
+          SWAPS="${SWAPS}${sib}|${gpath}|${sibver}|${fixv}|${sha2}"$'\n'
+          seen2[$sib]=1
+          echo "  family lift: $sib $sibver -> $fixv (no CVE of its own)"
+        done < <(jq -r --arg g "$group" '
+            .artifacts[]? | select(.type == "java-archive")
+            | select((.purl // "") | test("pkg:maven/" + ($g | gsub("\\."; "\\.")) + "/"))
+            | [.name, .version] | @tsv' "$inv" 2>/dev/null)
+      done <<< "$SWAPS"
+    else
+      echo "  WARN: syft inventory failed; siblings without advisories may be missed"
+    fi
+    rm -f "$inv"
+  else
+    echo "  WARN: syft not installed; cannot lift families, only guard them"
+  fi
 
   [ -n "$SWAPS" ] || { echo "  Nothing to patch after filtering"; continue; }
 

--- a/.github/workflows/patch-deps.yml
+++ b/.github/workflows/patch-deps.yml
@@ -29,6 +29,7 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   GRYPE_VERSION: v0.109.1
+  SYFT_VERSION: v1.51.0
 
 jobs:
   plan:
@@ -103,6 +104,25 @@ jobs:
             "https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz"
           tar -xzf /tmp/grype.tar.gz -C /usr/local/bin grype
           rm -f /tmp/grype.tar.gz
+
+      - name: Cache Syft binary
+        id: syft-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: /usr/local/bin/syft
+          key: syft-${{ env.SYFT_VERSION }}-linux-amd64
+
+      - name: Install Syft
+        # grype -o json reports only MATCHES, so a family member with no
+        # advisory of its own is invisible to the patcher. syft lists every
+        # package, which is what lets a whole jar family be lifted together
+        # instead of leaving siblings behind on the old version.
+        if: steps.syft-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -fL --retry 5 --retry-all-errors -o /tmp/syft.tar.gz \
+            "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz"
+          tar -xzf /tmp/syft.tar.gz -C /usr/local/bin syft
+          rm -f /tmp/syft.tar.gz
 
       - name: Log in to GHCR
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
Fixes the failure in #552.

## What broke

The first auto-generated run after `coord-map` was retired lifted `log4j-api` to 2.25.5 while `log4j-core` and `log4j-jul` stayed at 2.25.4. The sibling guard stopped the build:

```
WARN .../lib/log4j-jul-2.25.4.jar
WARN .../lib/log4j-api-2.25.5.jar
WARN .../lib/log4j-core-2.25.4.jar
```

That mixed classpath is what leaves solr building clean and refusing to start. **The guard did its job** — what it couldn't do was repair the set.

## Why alignment missed it

The gap is an input, not logic. Family alignment only reaches artifacts that appear in the scan report, and `grype -o json` reports **matches only**. `log4j-core@2.25.4` had no advisory of its own — it was already fixed — so it was never listed, so nothing lifted it.

## The fix

`syft` lists every package rather than only vulnerable ones. It's now installed alongside grype (same cached-binary pattern) and used to enumerate each upgraded family.

A sibling is lifted when it shares the **group**, the **artifact-id prefix** and the **major.minor series**, but sits on the wrong version. Each one is resolved against Maven Central, **sha256-pinned**, and swapped exactly like any other entry — never guessed, and skipped with a message when no matching release exists:

```
family lift: log4j-core 2.25.4 -> 2.25.5 (no CVE of its own)
family lift: log4j-jul  2.25.4 -> 2.25.5 (no CVE of its own)
```

The guard stays as the backstop. It now catches only what the lift genuinely cannot fix, rather than every family with a quiet sibling.

## After this merges

`#552` should be closed and regenerated rather than hand-edited — the point of #548 was to stop hand-patching this class. The regenerated PR should carry the whole log4j family and pass.

Degrades safely: if syft is unavailable the script warns and falls back to guard-only behaviour, which is today's state.
