### PR TITLE
fix(scan): count unscored advisories instead of dropping them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -687,20 +687,29 @@ jobs:
 
           # Severity counts — raw straight from grype, effective drops any
           # match whose .vulnerability.id is in the suppressed set.
+          #
+          # `total` is the COUNT OF MATCHES, not the sum of the named buckets.
+          # Grype emits a severity outside critical/high/medium/low for some
+          # feeds — every Go advisory (GO-YYYY-NNNN) arrives as "Unknown"
+          # because the Go vuln DB assigns no CVSS score. Summing four buckets
+          # silently dropped those: helm reported 0 while carrying
+          # GO-2026-5932 in golang.org/x/crypto. Counting matches directly
+          # means a severity we do not enumerate can never vanish again.
           counts() {
             local report="$1" suppressed="$2"
             jq --argjson sup "$suppressed" '
-              def sev_count(level):
-                [ .matches[]
-                  | select((.vulnerability.id | IN($sup[])) | not)
-                  | select(.vulnerability.severity | ascii_upcase == level)
-                ] | length;
-              {
-                critical: sev_count("CRITICAL"),
-                high:     sev_count("HIGH"),
-                medium:   sev_count("MEDIUM"),
-                low:      sev_count("LOW")
-              } | . + {total: (.critical + .high + .medium + .low)}
+              [ .matches[] | select((.vulnerability.id | IN($sup[])) | not) ] as $m
+              | def sev_count(level):
+                  [ $m[] | select(.vulnerability.severity | ascii_upcase == level) ] | length;
+                {
+                  critical:   sev_count("CRITICAL"),
+                  high:       sev_count("HIGH"),
+                  medium:     sev_count("MEDIUM"),
+                  low:        sev_count("LOW"),
+                  negligible: sev_count("NEGLIGIBLE"),
+                  unknown:    sev_count("UNKNOWN")
+                }
+                | . + {total: ($m | length)}
             ' "$report"
           }
 
@@ -708,7 +717,7 @@ jobs:
             RAW_COUNTS=$(counts "$GRYPE_REPORT" '[]')
             EFF_COUNTS=$(counts "$GRYPE_REPORT" "$SUPPRESSED_JSON")
           else
-            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"total":0}'
+            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"negligible":0,"unknown":0,"total":0}'
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
@@ -746,12 +755,17 @@ jobs:
             exit 0
           fi
 
-          # Count vulnerabilities by severity (grype uses Title Case severity)
+          # Count vulnerabilities by severity (grype uses Title Case severity).
+          # TOTAL is the match count, not the sum of the named buckets — Go
+          # advisories (GO-YYYY-NNNN) carry no CVSS score and arrive as
+          # "Unknown", so summing four buckets under-reports them to zero.
           CRITICAL=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "CRITICAL")] | length' "$REPORT")
           HIGH=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "HIGH")] | length' "$REPORT")
           MEDIUM=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "MEDIUM")] | length' "$REPORT")
           LOW=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "LOW")] | length' "$REPORT")
-          TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW))
+          NEGLIGIBLE=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "NEGLIGIBLE")] | length' "$REPORT")
+          UNKNOWN=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "UNKNOWN")] | length' "$REPORT")
+          TOTAL=$(jq '.matches | length' "$REPORT")
 
           # Header
           echo "## Security Scan: ${{ matrix.name }}" >> $GITHUB_STEP_SUMMARY
@@ -766,6 +780,9 @@ jobs:
           echo "| HIGH | $HIGH |" >> $GITHUB_STEP_SUMMARY
           echo "| MEDIUM | $MEDIUM |" >> $GITHUB_STEP_SUMMARY
           echo "| LOW | $LOW |" >> $GITHUB_STEP_SUMMARY
+          echo "| NEGLIGIBLE | $NEGLIGIBLE |" >> $GITHUB_STEP_SUMMARY
+          echo "| UNKNOWN | $UNKNOWN |" >> $GITHUB_STEP_SUMMARY
+          echo "| **TOTAL** | **$TOTAL** |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "$TOTAL" -eq 0 ]; then
@@ -788,6 +805,24 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           else
             echo "No CRITICAL or HIGH vulnerabilities found." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Unscored advisories. These carry no CVSS severity (the Go vuln DB
+          # assigns none), so they never appear in the CRITICAL/HIGH table
+          # above. List them explicitly or they are reported as a bare count
+          # with no way to tell what they are.
+          if [ "$UNKNOWN" -gt 0 ]; then
+            echo "### Unscored advisories (no CVSS severity)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Library | Advisory | Installed | Fixed |" >> $GITHUB_STEP_SUMMARY
+            echo "|---------|----------|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+            jq -r '
+              [.matches[] | select(.vulnerability.severity | ascii_upcase == "UNKNOWN")]
+              | sort_by(.artifact.name, .vulnerability.id)
+              | .[]
+              | "| \(.artifact.name) | \(.vulnerability.id) | \(.artifact.version) | \((.vulnerability.fix.versions // [])[0] // "none") |"
+            ' "$REPORT" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload vulnerability report
@@ -1332,20 +1367,29 @@ jobs:
 
           # Severity counts — raw straight from grype, effective drops any
           # match whose .vulnerability.id is in the suppressed set.
+          #
+          # `total` is the COUNT OF MATCHES, not the sum of the named buckets.
+          # Grype emits a severity outside critical/high/medium/low for some
+          # feeds — every Go advisory (GO-YYYY-NNNN) arrives as "Unknown"
+          # because the Go vuln DB assigns no CVSS score. Summing four buckets
+          # silently dropped those: helm reported 0 while carrying
+          # GO-2026-5932 in golang.org/x/crypto. Counting matches directly
+          # means a severity we do not enumerate can never vanish again.
           counts() {
             local report="$1" suppressed="$2"
             jq --argjson sup "$suppressed" '
-              def sev_count(level):
-                [ .matches[]
-                  | select((.vulnerability.id | IN($sup[])) | not)
-                  | select(.vulnerability.severity | ascii_upcase == level)
-                ] | length;
-              {
-                critical: sev_count("CRITICAL"),
-                high:     sev_count("HIGH"),
-                medium:   sev_count("MEDIUM"),
-                low:      sev_count("LOW")
-              } | . + {total: (.critical + .high + .medium + .low)}
+              [ .matches[] | select((.vulnerability.id | IN($sup[])) | not) ] as $m
+              | def sev_count(level):
+                  [ $m[] | select(.vulnerability.severity | ascii_upcase == level) ] | length;
+                {
+                  critical:   sev_count("CRITICAL"),
+                  high:       sev_count("HIGH"),
+                  medium:     sev_count("MEDIUM"),
+                  low:        sev_count("LOW"),
+                  negligible: sev_count("NEGLIGIBLE"),
+                  unknown:    sev_count("UNKNOWN")
+                }
+                | . + {total: ($m | length)}
             ' "$report"
           }
 
@@ -1353,7 +1397,7 @@ jobs:
             RAW_COUNTS=$(counts "$GRYPE_REPORT" '[]')
             EFF_COUNTS=$(counts "$GRYPE_REPORT" "$SUPPRESSED_JSON")
           else
-            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"total":0}'
+            RAW_COUNTS='{"critical":0,"high":0,"medium":0,"low":0,"negligible":0,"unknown":0,"total":0}'
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
@@ -1391,12 +1435,17 @@ jobs:
             exit 0
           fi
 
-          # Count vulnerabilities by severity (grype uses Title Case severity)
+          # Count vulnerabilities by severity (grype uses Title Case severity).
+          # TOTAL is the match count, not the sum of the named buckets — Go
+          # advisories (GO-YYYY-NNNN) carry no CVSS score and arrive as
+          # "Unknown", so summing four buckets under-reports them to zero.
           CRITICAL=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "CRITICAL")] | length' "$REPORT")
           HIGH=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "HIGH")] | length' "$REPORT")
           MEDIUM=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "MEDIUM")] | length' "$REPORT")
           LOW=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "LOW")] | length' "$REPORT")
-          TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW))
+          NEGLIGIBLE=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "NEGLIGIBLE")] | length' "$REPORT")
+          UNKNOWN=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "UNKNOWN")] | length' "$REPORT")
+          TOTAL=$(jq '.matches | length' "$REPORT")
 
           # Header
           echo "## Security Scan: ${{ matrix.name }}" >> $GITHUB_STEP_SUMMARY
@@ -1411,6 +1460,9 @@ jobs:
           echo "| HIGH | $HIGH |" >> $GITHUB_STEP_SUMMARY
           echo "| MEDIUM | $MEDIUM |" >> $GITHUB_STEP_SUMMARY
           echo "| LOW | $LOW |" >> $GITHUB_STEP_SUMMARY
+          echo "| NEGLIGIBLE | $NEGLIGIBLE |" >> $GITHUB_STEP_SUMMARY
+          echo "| UNKNOWN | $UNKNOWN |" >> $GITHUB_STEP_SUMMARY
+          echo "| **TOTAL** | **$TOTAL** |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "$TOTAL" -eq 0 ]; then
@@ -1433,6 +1485,24 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           else
             echo "No CRITICAL or HIGH vulnerabilities found." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # Unscored advisories. These carry no CVSS severity (the Go vuln DB
+          # assigns none), so they never appear in the CRITICAL/HIGH table
+          # above. List them explicitly or they are reported as a bare count
+          # with no way to tell what they are.
+          if [ "$UNKNOWN" -gt 0 ]; then
+            echo "### Unscored advisories (no CVSS severity)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Library | Advisory | Installed | Fixed |" >> $GITHUB_STEP_SUMMARY
+            echo "|---------|----------|-----------|-------|" >> $GITHUB_STEP_SUMMARY
+            jq -r '
+              [.matches[] | select(.vulnerability.severity | ascii_upcase == "UNKNOWN")]
+              | sort_by(.artifact.name, .vulnerability.id)
+              | .[]
+              | "| \(.artifact.name) | \(.vulnerability.id) | \(.artifact.version) | \((.vulnerability.fix.versions // [])[0] // "none") |"
+            ' "$REPORT" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload vulnerability report

--- a/site/src/components/SeverityBar.astro
+++ b/site/src/components/SeverityBar.astro
@@ -5,6 +5,10 @@ const { image, showLabel = true } = Astro.props;
 const v = image.vulnerabilities;
 const c = v ? v.counts : null;
 const total = v ? v.total : 0;
+// Advisories with no CVSS severity (every Go GO-YYYY-NNNN) plus negligible.
+// They count toward `total`, so without a segment of their own the bar renders
+// empty while the label reads "1 CVE".
+const unscored = c ? (c.unknown ?? 0) + (c.negligible ?? 0) : 0;
 const seg = (n: number) => (total > 0 ? `${(n / total) * 100}%` : '0');
 ---
 {c ? (
@@ -12,11 +16,12 @@ const seg = (n: number) => (total > 0 ? `${(n / total) * 100}%` : '0');
     showLabel ? <span class="pill clean">Clean</span> : <span class="sevbar"><span class="sev-clean" style="width:100%"></span></span>
   ) : (
     <span style="display:inline-flex;align-items:center;gap:8px">
-      <span class="sevbar" title={`${c.critical} critical · ${c.high} high · ${c.medium} medium · ${c.low} low`}>
+      <span class="sevbar" title={`${c.critical} critical · ${c.high} high · ${c.medium} medium · ${c.low} low · ${unscored} unscored`}>
         {c.critical > 0 && <span class="sev-critical" style={`width:${seg(c.critical)}`}></span>}
         {c.high > 0 && <span class="sev-high" style={`width:${seg(c.high)}`}></span>}
         {c.medium > 0 && <span class="sev-medium" style={`width:${seg(c.medium)}`}></span>}
         {c.low > 0 && <span class="sev-low" style={`width:${seg(c.low)}`}></span>}
+        {unscored > 0 && <span class="sev-unscored" style={`width:${seg(unscored)}`}></span>}
       </span>
       {showLabel && <span class="small muted">{total} CVE{total === 1 ? '' : 's'}</span>}
     </span>

--- a/site/src/pages/docs/vulnerabilities.astro
+++ b/site/src/pages/docs/vulnerabilities.astro
@@ -28,6 +28,17 @@ const repo = 'https://github.com/rtvkiz/minimal/blob/main';
         or by suppression.
       </p>
 
+      <h2 class="section-title" style="margin-top:44px">Unscored advisories</h2>
+      <p>
+        Some findings show a severity of <b>Unknown</b>. That is not a gap in our reporting — it is how
+        the source feed publishes them. The <a href="https://go.dev/doc/security/vuln/database" rel="noopener">Go
+        vulnerability database</a> assigns no CVSS score, so every Go advisory
+        (<code class="kv-mono">GO-YYYY-NNNN</code>) arrives unscored.
+      </p>
+      <p class="small muted">
+        They are counted in the totals like any other finding. Summing only critical/high/medium/low would
+        report an image carrying them as clean, which is the one thing these numbers must never do.
+      </p>
       <h2 class="section-title" style="margin-top:44px">Suppressions cannot quietly rot</h2>
       <p>
         Anything can be suppressed once. The check that matters is whether a suppression is

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -167,6 +167,7 @@ section { padding: 56px 0; }
 .sev-high { background: var(--high); }
 .sev-medium { background: var(--medium); }
 .sev-low { background: var(--low); }
+.sev-unscored { background: var(--unscored, #8b7fd4); }
 .sev-clean { background: var(--clean); }
 
 .pill { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 999px; font-size: 0.76rem; font-weight: 600; letter-spacing: 0.01em; }

--- a/tools/dashboard/build.sh
+++ b/tools/dashboard/build.sh
@@ -136,6 +136,7 @@ h1 { font-size: 28px; margin: 0 0 4px; font-weight: 600; }
 .chip.high .value { color: var(--high); }
 .chip.medium .value { color: var(--medium); }
 .chip.low .value { color: var(--low); }
+.chip.unscored .value { color: var(--unscored, #8b7fd4); }
 .chip.zero .value { color: var(--zero); }
 
 /* Filter input */
@@ -292,8 +293,8 @@ JS
 #--- per-image detail pages + index row data ---------------------------------
 
 # Aggregate totals (raw + VEX-effective)
-TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0
-TOTAL_EFF_CRIT=0; TOTAL_EFF_HIGH=0; TOTAL_EFF_MED=0; TOTAL_EFF_LOW=0
+TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0; TOTAL_UNK=0
+TOTAL_EFF_CRIT=0; TOTAL_EFF_HIGH=0; TOTAL_EFF_MED=0; TOTAL_EFF_LOW=0; TOTAL_EFF_UNK=0
 TOTAL_VEX_STMTS=0
 TOTAL_FIXABLE=0; TOTAL_IMAGES=0; CLEAN_IMAGES=0; CLEAN_EFF_IMAGES=0
 
@@ -311,7 +312,11 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   H=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "HIGH")] | length' "$f")
   M=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "MEDIUM")] | length' "$f")
   L=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase == "LOW")] | length' "$f")
-  T=$((C + H + M + L))
+  # U: advisories with no CVSS severity (every Go GO-YYYY-NNNN arrives this
+  # way). T is the match count, not C+H+M+L, so an unscored severity cannot
+  # silently vanish from the total the way it used to.
+  U=$(jq '[.matches[] | select(.vulnerability.severity | ascii_upcase | (. != "CRITICAL" and . != "HIGH" and . != "MEDIUM" and . != "LOW"))] | length' "$f")
+  T=$(jq '.matches | length' "$f")
 
   # Fixable count: CVEs where grype knows a fix version exists
   FIXABLE=$(jq '[.matches[] | select((.vulnerability.fix.versions // []) | length > 0)] | length' "$f")
@@ -320,6 +325,7 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   TOTAL_HIGH=$((TOTAL_HIGH + H))
   TOTAL_MED=$((TOTAL_MED + M))
   TOTAL_LOW=$((TOTAL_LOW + L))
+  TOTAL_UNK=$((TOTAL_UNK + U))
   TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
   [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
 
@@ -336,6 +342,8 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     EH=$(jq -r '.effective.high     // 0' "$META")
     EM=$(jq -r '.effective.medium   // 0' "$META")
     EL=$(jq -r '.effective.low      // 0' "$META")
+    # Unscored + negligible, mirroring how U is derived from the raw report.
+    EU=$(jq -r '((.effective.negligible // 0) + (.effective.unknown // 0))' "$META")
     SUPPRESSED_JSON=$(jq -c '.vex.suppressed // []' "$META")
     VEX_STMT_COUNT=$(jq -r '.vex.statements // 0' "$META")
     # VEX drift: count of suppressions that have gone stale or become fixable.
@@ -346,9 +354,9 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     BUILT_AT=""
     DIGEST=""
     # No meta → effective == raw
-    EC="$C"; EH="$H"; EM="$M"; EL="$L"
+    EC="$C"; EH="$H"; EM="$M"; EL="$L"; EU="$U"
   fi
-  ET=$((EC + EH + EM + EL))
+  ET=$((EC + EH + EM + EL + EU))
   SUPPRESSED_TOTAL=$((T - ET))
   [ "$SUPPRESSED_TOTAL" -lt 0 ] && SUPPRESSED_TOTAL=0
 
@@ -356,6 +364,7 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   TOTAL_EFF_HIGH=$((TOTAL_EFF_HIGH + EH))
   TOTAL_EFF_MED=$((TOTAL_EFF_MED + EM))
   TOTAL_EFF_LOW=$((TOTAL_EFF_LOW + EL))
+  TOTAL_EFF_UNK=$((TOTAL_EFF_UNK + EU))
   TOTAL_VEX_STMTS=$((TOTAL_VEX_STMTS + VEX_STMT_COUNT))
   [ "$ET" -eq 0 ] && CLEAN_EFF_IMAGES=$((CLEAN_EFF_IMAGES + 1))
   SIZE_DISPLAY=$([ "$SIZE_BYTES" -gt 0 ] && fmt_bytes "$SIZE_BYTES" || echo "—")
@@ -461,8 +470,8 @@ DETAIL
 done
 shopt -u nullglob
 
-TOTAL_ALL=$((TOTAL_CRIT + TOTAL_HIGH + TOTAL_MED + TOTAL_LOW))
-TOTAL_EFF_ALL=$((TOTAL_EFF_CRIT + TOTAL_EFF_HIGH + TOTAL_EFF_MED + TOTAL_EFF_LOW))
+TOTAL_ALL=$((TOTAL_CRIT + TOTAL_HIGH + TOTAL_MED + TOTAL_LOW + TOTAL_UNK))
+TOTAL_EFF_ALL=$((TOTAL_EFF_CRIT + TOTAL_EFF_HIGH + TOTAL_EFF_MED + TOTAL_EFF_LOW + TOTAL_EFF_UNK))
 
 # Totals row appended last
 printf '<tr class="totals"><td>Total (%d images)</td><td class="num critical">%d</td><td class="num high">%d</td><td class="num medium">%d</td><td class="num low">%d</td><td class="num">%d</td><td class="num">%d</td><td class="num">%d</td><td></td><td class="num">%d</td><td></td><td></td></tr>\n' \
@@ -505,6 +514,9 @@ cat > "$SITE_DIR/index.html" <<HTML
   </div>
   <div class="chip $([ "$TOTAL_LOW" -gt 0 ] && echo low || echo zero)">
     <span class="label">Low</span><span class="value">${TOTAL_LOW}</span>
+  </div>
+  <div class="chip $([ "$TOTAL_UNK" -gt 0 ] && echo unscored || echo zero)" title="Advisories with no CVSS severity — every Go GO-YYYY-NNNN arrives this way">
+    <span class="label">Unscored</span><span class="value">${TOTAL_UNK}</span>
   </div>
   <div class="chip"><span class="label">Fixable</span><span class="value">${TOTAL_FIXABLE}</span></div>
   <div class="chip zero"><span class="label">Clean images</span><span class="value">${CLEAN_IMAGES} / ${TOTAL_IMAGES}</span></div>


### PR DESCRIPTION
## The bug

Severity totals were computed as `critical + high + medium + low`. Any match whose severity fell outside those four buckets was counted by nothing and reported nowhere.

Grype emits **`Unknown`** for every advisory from the [Go vulnerability database](https://go.dev/doc/security/vuln/database), which assigns no CVSS score by design. So every `GO-YYYY-NNNN` finding disappeared from the totals.

This is a known sharp edge — grype's own [`AllSeverities()`](https://github.com/anchore/grype/blob/main/grype/vulnerability/severity.go) excludes `UnknownSeverity`, so anyone enumerating severities and summing them hits it.

## Impact

Measured against the last full scan:

| | before | after |
|---|---|---|
| findings counted | 308 | **648** |
| images reported clean | 63 | **37** |

**26 images displayed "0 CVEs" while carrying real advisories** — helm, trivy, cosign, prometheus, etcd, minio, otelcol and 19 others.

Exposure is narrow in practice: 43 of the 45 language-level findings are one advisory, `GO-2026-5932` in `golang.org/x/crypto`, with **no fix available upstream**. Nothing to patch today. The problem is that we had no signal it existed, and would have had none when it clears.

## Fix

Derive `total` from the **match count** rather than summing named buckets, so a severity we don't enumerate can never silently vanish again. Surface `negligible` and `unknown` as their own buckets.

- **`build.yml`** — both `counts()` sidecars and both job summaries. The summary now also *lists* unscored advisories, which the CRITICAL/HIGH table by definition never showed.
- **`tools/dashboard`** — Unscored chip, totals, clean-image tally.
- **`site`** — unscored segment in the severity bar. Its `total` was already correct, so an image whose only finding was unscored rendered an empty bar next to a "1 CVE" label.
- **`docs`** — explain why `Unknown` exists and that it counts.

## Verification

- dashboard rebuilt against the real scan set: **648 findings, 37 clean**; per-severity totals match the raw reports exactly (11 / 161 / 117 / 19 / 340)
- site rebuilt: 51 unscored segments == 51 images with `unknown > 0`; clean count 37, agreeing with the dashboard
- VEX suppression path re-tested against `telegraf` — raw and effective still diverge correctly
- `make lint-workflows` clean

## Prior art

Chainguard reports this identically — their published `helm` vulnerability page lists `GO-2026-5932` at Unknown severity with a count of **1**, on an *older* `x/crypto` (v0.54.0) than ours (v0.55.0). We were ahead on the dependency and behind only on reporting it.