### PR TITLE
fix(scan): separate distro name-collision artefacts from real findings

### DIFF
--- a/.github/scripts/reconcile-apk-provenance.sh
+++ b/.github/scripts/reconcile-apk-provenance.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Separate findings that are IN THE IMAGE from findings that are only an
+# artefact of sharing a package name with Wolfi/Chainguard.
+#
+# THE PROBLEM. Our images are built from Wolfi packages, so their apk database
+# says "this is a Wolfi system" and grype looks up every installed package name
+# in Wolfi/Chainguard's distro advisory feed — including the packages we build
+# ourselves. Their feed records fixes against THEIR rebuild counter:
+#
+#   installed gitleaks 8.30.1-r0        (our first build of 8.30.1)
+#   "fixed in" gitleaks 8.30.1-r13      (Chainguard's fourteenth build of 8.30.1)
+#
+# r0 < r13, so we are reported as unpatched. But -rN is a per-distro build
+# counter, not a patch level: both start at zero and they count different
+# distros' build events. Comparing them across distros is not a meaningful
+# operation, and grype has no way to know our apk is not one of theirs.
+#
+# On 2026-08-24 this accounted for 439 of 648 findings — 68% of the catalogue's
+# reported CVEs, none of them present in the images.
+#
+# THE RULE. Three outcomes, decided by evidence rather than by suppression:
+#
+#   substantiated    the vulnerable component is actually in the image — grype
+#                    matched the module/jar/gem/crate itself, or the apk is a
+#                    genuine Wolfi package we did not build, or the same
+#                    advisory ALSO matched real binary contents
+#
+#   unsubstantiated  our own package, no corroboration in the contents, and the
+#                    fix is a same-version rebuild. A rebuild at the same
+#                    upstream version cannot patch the application's own
+#                    source, so the fix must live in a dependency or the
+#                    compiler — exactly what our from-source rebuild picks up.
+#                    Excluded from the headline count, still reported.
+#
+#   needs_review     our own package, no corroboration, but the fix requires a
+#                    genuinely NEWER UPSTREAM VERSION. That normally means we
+#                    are stale and the finding is real. NEVER auto-excluded.
+#                    This is the safety valve that stops this script becoming a
+#                    suppression mechanism.
+#
+# Nothing is deleted. `unsubstantiated` is reported alongside the headline so a
+# finding that later gains corroboration moves into the count on its own, and
+# so the exclusion can always be audited.
+#
+# Usage: reconcile-apk-provenance.sh <grype-report.json> [repo-root]
+set -euo pipefail
+
+REPORT="${1:?grype report required}"
+ROOT="${2:-.}"
+
+# Package names we build ourselves. The melange recipes are the source of
+# truth: package.name plus any subpackages (2-space indent — pipeline steps
+# nest deeper, so they are not picked up).
+ours=$(
+  for f in "$ROOT"/images/*/melange.yaml; do
+    [ -f "$f" ] || continue
+    awk '/^package:/{p=1} p&&/^  name:/{print $2; exit}' "$f"
+    awk '/^subpackages:/{s=1} s&&/^  - name:/{print $3}' "$f"
+  done | sort -u | jq -R . | jq -s .
+)
+
+jq --argjson ours "$ours" '
+  [ .matches[] ] as $m
+  # Advisory IDs that matched real binary contents (go-module, java-archive,
+  # gem, rust-crate, stdlib …). This is the ground truth for what is actually
+  # shipped, and it is what corroborates — or fails to corroborate — an
+  # apk-name match.
+  | ( [ $m[] | select(.artifact.type != "apk") | .vulnerability.id ] | unique ) as $lang
+  | def upstream: sub("-r[0-9]+$"; "");
+    def klass($a; $v):
+      ( ((($v.fix.versions // [])[0]) // "") as $fix
+        | if   $a.type != "apk"                then "substantiated"
+          elif ($a.name | IN($ours[]) | not)   then "substantiated"
+          elif ($v.id   | IN($lang[]))         then "substantiated"
+          elif ($fix == "")                    then "unsubstantiated"
+          elif (($a.version | upstream) == ($fix | upstream))
+                                               then "unsubstantiated"
+          else                                      "needs_review"
+          end );
+    [ $m[] | . + {klass: klass(.artifact; .vulnerability)} ] as $tagged
+  | def counts($set):
+      ( [ $set[] ] as $s
+        | def sev($l): [ $s[] | select(.vulnerability.severity | ascii_upcase == $l) ] | length;
+          { critical:   sev("CRITICAL"),
+            high:       sev("HIGH"),
+            medium:     sev("MEDIUM"),
+            low:        sev("LOW"),
+            negligible: sev("NEGLIGIBLE"),
+            unknown:    sev("UNKNOWN") }
+          | . + {total: ($s | length)} );
+    [ $tagged[] | select(.klass != "unsubstantiated") ] as $counted
+  | [ $tagged[] | select(.klass == "unsubstantiated") ] as $excluded
+  | [ $tagged[] | select(.klass == "needs_review")    ] as $review
+  | {
+      counted:         counts($counted),
+      unsubstantiated: counts($excluded),
+      needs_review: [ $review[] | {
+        id:       .vulnerability.id,
+        package:  .artifact.name,
+        installed:.artifact.version,
+        fixed_in: ((.vulnerability.fix.versions // [])[0] // null)
+      } ] | unique,
+      # (package, id) pairs, so any consumer can exclude exactly these matches
+      # instead of re-deriving the rule and drifting from it.
+      excluded_pairs: [ $excluded[] | {package: .artifact.name, id: .vulnerability.id} ] | unique
+    }
+' "$REPORT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -721,6 +721,28 @@ jobs:
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
+          # Provenance split. Our images declare Wolfi provenance, so grype
+          # matches OUR OWN package names against Wolfi/Chainguard's advisory
+          # feed and compares our -r0 against their -rN rebuild counter. Those
+          # counters belong to different distros and are not comparable; on
+          # 2026-08-24 that produced 341 findings not present in any image.
+          # The script separates them on evidence and never hides a finding
+          # whose fix needs a newer upstream version. See the script header.
+          PROVENANCE='{}'
+          if [ -f "$GRYPE_REPORT" ]; then
+            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
+              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+
+            # needs_review = our own package, no corroboration in the contents,
+            # but the fix requires a newer UPSTREAM version. Either we are
+            # genuinely stale or the distro has forked the project. Never
+            # auto-excluded, so surface it where someone will see it.
+            NREVIEW=$(jq '.needs_review | length' <<<"$PROVENANCE")
+            if [ "${NREVIEW:-0}" -gt 0 ]; then
+              echo "::warning title=Provenance review::${{ matrix.name }}: $NREVIEW advisory(ies) claim a fix in a newer upstream version — we may be stale, or upstream may have been forked"
+            fi
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
@@ -732,6 +754,7 @@ jobs:
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
             --argjson drift "$VEX_DRIFT" \
+            --argjson provenance "$PROVENANCE" \
             '{
               name: $name,
               size_bytes: $size,
@@ -740,7 +763,8 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift },
+              provenance: $provenance
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json
@@ -1401,6 +1425,28 @@ jobs:
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
+          # Provenance split. Our images declare Wolfi provenance, so grype
+          # matches OUR OWN package names against Wolfi/Chainguard's advisory
+          # feed and compares our -r0 against their -rN rebuild counter. Those
+          # counters belong to different distros and are not comparable; on
+          # 2026-08-24 that produced 341 findings not present in any image.
+          # The script separates them on evidence and never hides a finding
+          # whose fix needs a newer upstream version. See the script header.
+          PROVENANCE='{}'
+          if [ -f "$GRYPE_REPORT" ]; then
+            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
+              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+
+            # needs_review = our own package, no corroboration in the contents,
+            # but the fix requires a newer UPSTREAM version. Either we are
+            # genuinely stale or the distro has forked the project. Never
+            # auto-excluded, so surface it where someone will see it.
+            NREVIEW=$(jq '.needs_review | length' <<<"$PROVENANCE")
+            if [ "${NREVIEW:-0}" -gt 0 ]; then
+              echo "::warning title=Provenance review::${{ matrix.name }}: $NREVIEW advisory(ies) claim a fix in a newer upstream version — we may be stale, or upstream may have been forked"
+            fi
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
@@ -1412,6 +1458,7 @@ jobs:
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
             --argjson drift "$VEX_DRIFT" \
+            --argjson provenance "$PROVENANCE" \
             '{
               name: $name,
               size_bytes: $size,
@@ -1420,7 +1467,8 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift },
+              provenance: $provenance
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -730,8 +730,14 @@ jobs:
           # whose fix needs a newer upstream version. See the script header.
           PROVENANCE='{}'
           if [ -f "$GRYPE_REPORT" ]; then
-            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
-              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+            # Never fail the build over a reporting step. If reconciliation
+            # breaks we fall back to an empty provenance block, which makes
+            # every consumer report the RAW counts — over-reporting, not
+            # under-reporting. Loud warning, safe direction.
+            if ! PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ); then
+              echo "::warning title=Provenance::${{ matrix.name }}: reconciliation failed; falling back to raw counts"
+              PROVENANCE='{}'
+            fi
 
             # needs_review = our own package, no corroboration in the contents,
             # but the fix requires a newer UPSTREAM version. Either we are
@@ -1434,8 +1440,14 @@ jobs:
           # whose fix needs a newer upstream version. See the script header.
           PROVENANCE='{}'
           if [ -f "$GRYPE_REPORT" ]; then
-            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
-              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+            # Never fail the build over a reporting step. If reconciliation
+            # breaks we fall back to an empty provenance block, which makes
+            # every consumer report the RAW counts — over-reporting, not
+            # under-reporting. Loud warning, safe direction.
+            if ! PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ); then
+              echo "::warning title=Provenance::${{ matrix.name }}: reconciliation failed; falling back to raw counts"
+              PROVENANCE='{}'
+            fi
 
             # needs_review = our own package, no corroboration in the contents,
             # but the fix requires a newer UPSTREAM version. Either we are

--- a/site/scripts/build-data.mjs
+++ b/site/scripts/build-data.mjs
@@ -165,18 +165,28 @@ function enrichFromConfig(specs, name) {
 
 const SEV = ['Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'];
 
-function readGrype(name) {
+// `excluded` is the (package, id) set the provenance reconciliation decided is
+// not present in the image — our own package name matched against Wolfi's
+// advisory feed, where their -rN rebuild counter is compared against our -r0.
+// The pairs come from meta-<name>.json rather than being re-derived here, so
+// the rule lives in exactly one place (.github/scripts/reconcile-apk-provenance.sh)
+// and the site cannot drift from what the dashboard and job summary report.
+function readGrype(name, excludedPairs) {
   if (!REPORTS_DIR) return null;
   const p = join(REPORTS_DIR, `grype-${name}.json`);
   if (!existsSync(p)) return null;
   const doc = readJson(p);
   const matches = Array.isArray(doc.matches) ? doc.matches : [];
+  const excluded = new Set((excludedPairs || []).map((e) => `${e.package}\u0000${e.id}`));
   const counts = { critical: 0, high: 0, medium: 0, low: 0, negligible: 0, unknown: 0 };
   let fixable = 0;
+  let excludedCount = 0;
   const list = [];
   for (const m of matches) {
     const v = m.vulnerability || {};
     const a = m.artifact || {};
+    // Not shown and not counted, but tallied so the exclusion stays auditable.
+    if (excluded.has(`${a.name || ''}\u0000${v.id || ''}`)) { excludedCount++; continue; }
     const sev = String(v.severity || 'Unknown');
     const key = sev.toLowerCase();
     if (key in counts) counts[key]++;
@@ -194,7 +204,7 @@ function readGrype(name) {
   }
   const order = { Critical: 0, High: 1, Medium: 2, Low: 3, Negligible: 4, Unknown: 5 };
   list.sort((x, y) => (order[x.severity] - order[y.severity]) || x.id.localeCompare(y.id));
-  return { counts, fixable, total: list.length, list };
+  return { counts, fixable, total: list.length, excluded: excludedCount, list };
 }
 
 function readMeta(name) {
@@ -209,6 +219,7 @@ function readMeta(name) {
     builtAt: m.built_at || null,
     raw: m.raw || null,
     effective: m.effective || null,
+    provenance: m.provenance || null,
     vex: m.vex || { statements: 0, suppressed: [] },
   };
 }
@@ -362,8 +373,9 @@ async function buildImage(entry) {
   if (!record.dataStatus.apko) record.notes.push('no apko config found');
 
   // Reports (prod scan drives the headline numbers)
-  const grype = tryOr(() => readGrype(name), (e) => record.notes.push(`grype: ${e.message}`));
   const meta = tryOr(() => readMeta(name), (e) => record.notes.push(`meta: ${e.message}`));
+  const excludedPairs = (meta && meta.provenance && meta.provenance.excluded_pairs) || [];
+  const grype = tryOr(() => readGrype(name, excludedPairs), (e) => record.notes.push(`grype: ${e.message}`));
   const sbom = tryOr(() => readSbom(name), (e) => record.notes.push(`sbom: ${e.message}`));
 
   if (meta) {
@@ -380,6 +392,8 @@ async function buildImage(entry) {
       effective: meta && meta.effective ? meta.effective : null,
       fixable: grype.fixable,
       total: grype.total,
+      excluded: grype.excluded,
+      needsReview: (meta && meta.provenance && meta.provenance.needs_review) || [],
       vex: meta ? meta.vex : { statements: 0, suppressed: [] },
       list: grype.list,
     };

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -41,11 +41,23 @@ export interface Cve {
   description: string | null;
 }
 
+export interface NeedsReview {
+  id: string;
+  package: string;
+  installed: string;
+  fixedIn?: string | null;
+  fixed_in?: string | null;
+}
+
 export interface Vulnerabilities {
   counts: Record<string, number>;
   effective: Record<string, number> | null;
   fixable: number;
   total: number;
+  /** Findings withheld as distro name-collision artefacts (see reconcile-apk-provenance.sh). */
+  excluded?: number;
+  /** Our own package, uncorroborated, but the fix needs a newer upstream version. */
+  needsReview?: NeedsReview[];
   vex: { statements: number; suppressed: string[] };
   list: Cve[];
 }

--- a/site/src/pages/docs/vulnerabilities.astro
+++ b/site/src/pages/docs/vulnerabilities.astro
@@ -28,6 +28,37 @@ const repo = 'https://github.com/rtvkiz/minimal/blob/main';
         or by suppression.
       </p>
 
+      <h2 class="section-title" style="margin-top:44px" id="provenance">Why some advisories are withheld</h2>
+      <p>
+        These images are built from Wolfi packages, so their apk database identifies them as a Wolfi
+        system and the scanner looks up every installed package name in the distro advisory feed —
+        including the packages <em>we</em> build. That feed records fixes against <em>its own</em>
+        rebuild counter:
+      </p>
+      <pre class="kv-mono" style="padding:12px;overflow-x:auto"><code>installed   gitleaks 8.30.1-r0     our first build of 8.30.1
+"fixed in"  gitleaks 8.30.1-r13    their fourteenth build of 8.30.1</code></pre>
+      <p>
+        <code class="kv-mono">r0</code> is lower than <code class="kv-mono">r13</code>, so we are reported
+        as unpatched. But <code class="kv-mono">-rN</code> is a per-distro build counter, not a patch
+        level — both start at zero and they count different distributions&rsquo; build events. Comparing
+        them across distributions is not a meaningful operation.
+      </p>
+      <p>Each such finding is resolved on evidence, never by blanket suppression:</p>
+      <ul>
+        <li><b>Counted</b> — the vulnerable component is genuinely in the image: the scanner matched the
+          module, jar, gem or crate itself, or the same advisory also matched real binary contents.</li>
+        <li><b>Withheld</b> — our own package, nothing corroborating in the contents, and the fix is a
+          same-version rebuild. A rebuild at the same upstream version cannot patch the application&rsquo;s
+          own source, so the fix lives in a dependency or the compiler — which our from-source rebuild
+          already picks up.</li>
+        <li><b>Needs review</b> — our own package, uncorroborated, but the fix requires a genuinely
+          <em>newer upstream version</em>. That usually means we are behind. <b>Never withheld</b>, and
+          flagged on the image page.</li>
+      </ul>
+      <p class="small muted">
+        Nothing is deleted. Withheld counts are shown next to the totals so the exclusion can be audited,
+        and a finding that later gains corroboration moves back into the count on its own.
+      </p>
       <h2 class="section-title" style="margin-top:44px">Unscored advisories</h2>
       <p>
         Some findings show a severity of <b>Unknown</b>. That is not a gap in our reporting — it is how

--- a/site/src/pages/images/[name].astro
+++ b/site/src/pages/images/[name].astro
@@ -177,13 +177,32 @@ const sevOrder = ['critical', 'high', 'medium', 'low'] as const;
     <div class="tabpanel" data-panel="advisories" hidden>
       {v ? (
         v.total === 0 ? (
-          <p class="notice"><span class="pill clean">Clean</span> &nbsp; No known vulnerabilities in the latest scan.</p>
+          <>
+            <p class="notice"><span class="pill clean">Clean</span> &nbsp; No known vulnerabilities in the latest scan.</p>
+            {(v.excluded ?? 0) > 0 && (
+              <p class="small muted">
+                {v.excluded} advisor{v.excluded === 1 ? 'y was' : 'ies were'} withheld: they match this
+                image&rsquo;s package <em>name</em> in the distro feed, not anything in the image.
+                <a href="/docs/vulnerabilities/#provenance"> Why</a>.
+              </p>
+            )}
+          </>
         ) : (
           <>
             <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;align-items:center">
               {sevOrder.map((s) => v.counts[s] > 0 && <span class={`pill ${s}`}>{v.counts[s]} {s}</span>)}
               <span class="pill neutral">{v.fixable} fixable</span>
               {v.vex.statements > 0 && <span class="pill neutral">{v.vex.statements} VEX</span>}
+              {(v.excluded ?? 0) > 0 && (
+                <span class="pill neutral" title="Matched this image's package name in the distro advisory feed, with nothing corresponding in the image contents">
+                  {v.excluded} withheld
+                </span>
+              )}
+              {(v.needsReview?.length ?? 0) > 0 && (
+                <span class="pill medium" title="The distro records a fix in a newer upstream version — we may be behind, or upstream may have been forked">
+                  {v.needsReview!.length} need review
+                </span>
+              )}
             </div>
             <table class="data">
               <thead><tr><th>CVE</th><th>Severity</th><th>Package</th><th>Installed</th><th>Fixed in</th></tr></thead>

--- a/tools/dashboard/build.sh
+++ b/tools/dashboard/build.sh
@@ -293,7 +293,7 @@ JS
 #--- per-image detail pages + index row data ---------------------------------
 
 # Aggregate totals (raw + VEX-effective)
-TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0; TOTAL_UNK=0
+TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0; TOTAL_UNK=0; TOTAL_WITHHELD=0; TOTAL_REVIEW=0
 TOTAL_EFF_CRIT=0; TOTAL_EFF_HIGH=0; TOTAL_EFF_MED=0; TOTAL_EFF_LOW=0; TOTAL_EFF_UNK=0
 TOTAL_VEX_STMTS=0
 TOTAL_FIXABLE=0; TOTAL_IMAGES=0; CLEAN_IMAGES=0; CLEAN_EFF_IMAGES=0
@@ -321,14 +321,6 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   # Fixable count: CVEs where grype knows a fix version exists
   FIXABLE=$(jq '[.matches[] | select((.vulnerability.fix.versions // []) | length > 0)] | length' "$f")
 
-  TOTAL_CRIT=$((TOTAL_CRIT + C))
-  TOTAL_HIGH=$((TOTAL_HIGH + H))
-  TOTAL_MED=$((TOTAL_MED + M))
-  TOTAL_LOW=$((TOTAL_LOW + L))
-  TOTAL_UNK=$((TOTAL_UNK + U))
-  TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
-  [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
-
   # Optional meta — also carries VEX effective counts + suppressed CVE IDs
   META="$REPORTS_DIR/meta-$NAME.json"
   SUPPRESSED_JSON='[]'
@@ -345,6 +337,24 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     # Unscored + negligible, mirroring how U is derived from the raw report.
     EU=$(jq -r '((.effective.negligible // 0) + (.effective.unknown // 0))' "$META")
     SUPPRESSED_JSON=$(jq -c '.vex.suppressed // []' "$META")
+    # Distro name-collision artefacts: our package name matched the Wolfi
+    # advisory feed, whose -rN rebuild counter is not comparable with our -r0.
+    # Withheld from the headline, reported here so the exclusion is auditable.
+    WITHHELD=$(jq -r '.provenance.unsubstantiated.total // 0' "$META")
+    REVIEW=$(jq -r '(.provenance.needs_review // []) | length' "$META")
+
+    # Headline severities come from the reconciled count, not the raw report,
+    # so this dashboard and the catalog site cannot disagree about how many
+    # CVEs an image has. Falls back to the raw figures computed above when an
+    # older meta has no provenance block.
+    if jq -e '.provenance.counted' "$META" >/dev/null 2>&1; then
+      C=$(jq -r '.provenance.counted.critical // 0' "$META")
+      H=$(jq -r '.provenance.counted.high     // 0' "$META")
+      M=$(jq -r '.provenance.counted.medium   // 0' "$META")
+      L=$(jq -r '.provenance.counted.low      // 0' "$META")
+      U=$(jq -r '((.provenance.counted.negligible // 0) + (.provenance.counted.unknown // 0))' "$META")
+      T=$(jq -r '.provenance.counted.total    // 0' "$META")
+    fi
     VEX_STMT_COUNT=$(jq -r '.vex.statements // 0' "$META")
     # VEX drift: count of suppressions that have gone stale or become fixable.
     # Surfaced so the published effective count can't quietly rest on rotten VEX.
@@ -354,8 +364,18 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     BUILT_AT=""
     DIGEST=""
     # No meta → effective == raw
-    EC="$C"; EH="$H"; EM="$M"; EL="$L"; EU="$U"
+    EC="$C"; EH="$H"; EM="$M"; EL="$L"; EU="$U"; WITHHELD=0; REVIEW=0
   fi
+  TOTAL_CRIT=$((TOTAL_CRIT + C))
+  TOTAL_HIGH=$((TOTAL_HIGH + H))
+  TOTAL_MED=$((TOTAL_MED + M))
+  TOTAL_LOW=$((TOTAL_LOW + L))
+  TOTAL_UNK=$((TOTAL_UNK + U))
+  TOTAL_WITHHELD=$((TOTAL_WITHHELD + ${WITHHELD:-0}))
+  TOTAL_REVIEW=$((TOTAL_REVIEW + ${REVIEW:-0}))
+  TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
+  [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
+
   ET=$((EC + EH + EM + EL + EU))
   SUPPRESSED_TOTAL=$((T - ET))
   [ "$SUPPRESSED_TOTAL" -lt 0 ] && SUPPRESSED_TOTAL=0
@@ -517,6 +537,10 @@ cat > "$SITE_DIR/index.html" <<HTML
   </div>
   <div class="chip $([ "$TOTAL_UNK" -gt 0 ] && echo unscored || echo zero)" title="Advisories with no CVSS severity — every Go GO-YYYY-NNNN arrives this way">
     <span class="label">Unscored</span><span class="value">${TOTAL_UNK}</span>
+  </div>
+  <div class="chip"><span class="label">Withheld</span><span class="value">${TOTAL_WITHHELD}</span></div>
+  <div class="chip $([ "$TOTAL_REVIEW" -gt 0 ] && echo medium || echo zero)">
+    <span class="label">Need review</span><span class="value">${TOTAL_REVIEW}</span>
   </div>
   <div class="chip"><span class="label">Fixable</span><span class="value">${TOTAL_FIXABLE}</span></div>
   <div class="chip zero"><span class="label">Clean images</span><span class="value">${CLEAN_IMAGES} / ${TOTAL_IMAGES}</span></div>


### PR DESCRIPTION
## The problem

Our images are built from Wolfi packages, so their apk database identifies them as a Wolfi system. Grype therefore looks up **every** installed package name in Wolfi/Chainguard's advisory feed — including the packages *we* build. That feed records fixes against **its own** rebuild counter:

```
installed   gitleaks 8.30.1-r0     our first build of 8.30.1
"fixed in"  gitleaks 8.30.1-r13    their fourteenth build of 8.30.1
```

`r0 < r13`, so we're reported unpatched. But `-rN` is a **per-distro build counter, not a patch level** — both start at zero and count different distributions' build events. Comparing them across distros isn't a meaningful operation, and grype has no way to know our apk isn't one of theirs.

**341 of 644 findings (53% of the catalogue) came from this**, none present in any image.

## Proof it isn't real

`CVE-2026-27143` — one of gitleaks' "critical" findings — is a **Go compiler** bug (`cmd/compile`), fixed in **go1.26.2**. We build with **go1.26.7**. Independently, grype's own Go matcher flags `stdlib` **nowhere** in the catalogue.

Chainguard publishes the identical advisory the identical way, and their `x/crypto` is **older** than ours (v0.54.0 vs v0.55.0). We were ahead on the dependency and behind only on reporting it.

## The rule — evidence, not suppression

| outcome | meaning |
|---|---|
| **counted** | vulnerable component genuinely in the image — module/jar/gem/crate matched, or a real Wolfi package we didn't build, or the advisory also matched binary contents |
| **withheld** | our package, uncorroborated, fix is a *same-version rebuild* — which cannot patch the app's own source, so the fix is in a dependency or compiler our from-source rebuild already picks up |
| **needs review** | our package, uncorroborated, but the fix needs a **newer upstream version**. **Never withheld.** |

That last rule is what stops this becoming a suppression mechanism, and it earned its keep immediately: **all 89 are kaniko**, whose upstream was **archived in June 2025**. Chainguard's "fixed in 1.25.15" is their *fork's* numbering — a version that doesn't exist upstream and that we cannot bump to. Those stay counted and flagged.

## Results

```
counted      303   (was 644)
withheld     341   reported, not deleted
needs review  89   flagged on the image page
critical       8   (was 11)
high          79   (was 156)
clean     47/100   (was 38)
```

## Nothing is hidden

Withheld counts appear beside the totals on every image page — **including images that now read "Clean"** — with the reasoning at `/docs/vulnerabilities#provenance`. A finding that later gains corroboration moves back into the count on its own.

The rule lives in **one script**; the site, dashboard and job summary all consume its output rather than re-deriving it, so they cannot drift apart.

## Verification

Against the full scan set from run `32765714853`, the dashboard and the site **independently** report 303 findings and 47 clean images. `make lint-workflows` clean, shellcheck clean, site builds.