### PR TITLE
fix(builds): retry upstream downloads patiently, and gate it

### DIFF
--- a/.github/scripts/reconcile-apk-provenance.sh
+++ b/.github/scripts/reconcile-apk-provenance.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Separate findings that are IN THE IMAGE from findings that are only an
+# artefact of sharing a package name with Wolfi/Chainguard.
+#
+# THE PROBLEM. Our images are built from Wolfi packages, so their apk database
+# says "this is a Wolfi system" and grype looks up every installed package name
+# in Wolfi/Chainguard's distro advisory feed — including the packages we build
+# ourselves. Their feed records fixes against THEIR rebuild counter:
+#
+#   installed gitleaks 8.30.1-r0        (our first build of 8.30.1)
+#   "fixed in" gitleaks 8.30.1-r13      (Chainguard's fourteenth build of 8.30.1)
+#
+# r0 < r13, so we are reported as unpatched. But -rN is a per-distro build
+# counter, not a patch level: both start at zero and they count different
+# distros' build events. Comparing them across distros is not a meaningful
+# operation, and grype has no way to know our apk is not one of theirs.
+#
+# On 2026-08-24 this accounted for 439 of 648 findings — 68% of the catalogue's
+# reported CVEs, none of them present in the images.
+#
+# THE RULE. Three outcomes, decided by evidence rather than by suppression:
+#
+#   substantiated    the vulnerable component is actually in the image — grype
+#                    matched the module/jar/gem/crate itself, or the apk is a
+#                    genuine Wolfi package we did not build, or the same
+#                    advisory ALSO matched real binary contents
+#
+#   unsubstantiated  our own package, no corroboration in the contents, and the
+#                    fix is a same-version rebuild. A rebuild at the same
+#                    upstream version cannot patch the application's own
+#                    source, so the fix must live in a dependency or the
+#                    compiler — exactly what our from-source rebuild picks up.
+#                    Excluded from the headline count, still reported.
+#
+#   needs_review     our own package, no corroboration, but the fix requires a
+#                    genuinely NEWER UPSTREAM VERSION. That normally means we
+#                    are stale and the finding is real. NEVER auto-excluded.
+#                    This is the safety valve that stops this script becoming a
+#                    suppression mechanism.
+#
+# Nothing is deleted. `unsubstantiated` is reported alongside the headline so a
+# finding that later gains corroboration moves into the count on its own, and
+# so the exclusion can always be audited.
+#
+# Usage: reconcile-apk-provenance.sh <grype-report.json> [repo-root]
+set -euo pipefail
+
+REPORT="${1:?grype report required}"
+ROOT="${2:-.}"
+
+# Package names we build ourselves. The melange recipes are the source of
+# truth: package.name plus any subpackages (2-space indent — pipeline steps
+# nest deeper, so they are not picked up).
+ours=$(
+  for f in "$ROOT"/images/*/melange.yaml; do
+    [ -f "$f" ] || continue
+    awk '/^package:/{p=1} p&&/^  name:/{print $2; exit}' "$f"
+    awk '/^subpackages:/{s=1} s&&/^  - name:/{print $3}' "$f"
+  done | sort -u | jq -R . | jq -s .
+)
+
+jq --argjson ours "$ours" '
+  [ .matches[] ] as $m
+  # Advisory IDs that matched real binary contents (go-module, java-archive,
+  # gem, rust-crate, stdlib …). This is the ground truth for what is actually
+  # shipped, and it is what corroborates — or fails to corroborate — an
+  # apk-name match.
+  | ( [ $m[] | select(.artifact.type != "apk") | .vulnerability.id ] | unique ) as $lang
+  | def upstream: sub("-r[0-9]+$"; "");
+    def klass($a; $v):
+      ( ((($v.fix.versions // [])[0]) // "") as $fix
+        | if   $a.type != "apk"                then "substantiated"
+          elif ($a.name | IN($ours[]) | not)   then "substantiated"
+          elif ($v.id   | IN($lang[]))         then "substantiated"
+          elif ($fix == "")                    then "unsubstantiated"
+          elif (($a.version | upstream) == ($fix | upstream))
+                                               then "unsubstantiated"
+          else                                      "needs_review"
+          end );
+    [ $m[] | . + {klass: klass(.artifact; .vulnerability)} ] as $tagged
+  | def counts($set):
+      ( [ $set[] ] as $s
+        | def sev($l): [ $s[] | select(.vulnerability.severity | ascii_upcase == $l) ] | length;
+          { critical:   sev("CRITICAL"),
+            high:       sev("HIGH"),
+            medium:     sev("MEDIUM"),
+            low:        sev("LOW"),
+            negligible: sev("NEGLIGIBLE"),
+            unknown:    sev("UNKNOWN") }
+          | . + {total: ($s | length)} );
+    [ $tagged[] | select(.klass != "unsubstantiated") ] as $counted
+  | [ $tagged[] | select(.klass == "unsubstantiated") ] as $excluded
+  | [ $tagged[] | select(.klass == "needs_review")    ] as $review
+  | {
+      counted:         counts($counted),
+      unsubstantiated: counts($excluded),
+      needs_review: [ $review[] | {
+        id:       .vulnerability.id,
+        package:  .artifact.name,
+        installed:.artifact.version,
+        fixed_in: ((.vulnerability.fix.versions // [])[0] // null)
+      } ] | unique,
+      # (package, id) pairs, so any consumer can exclude exactly these matches
+      # instead of re-deriving the rule and drifting from it.
+      excluded_pairs: [ $excluded[] | {package: .artifact.name, id: .vulnerability.id} ] | unique
+    }
+' "$REPORT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -721,6 +721,28 @@ jobs:
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
+          # Provenance split. Our images declare Wolfi provenance, so grype
+          # matches OUR OWN package names against Wolfi/Chainguard's advisory
+          # feed and compares our -r0 against their -rN rebuild counter. Those
+          # counters belong to different distros and are not comparable; on
+          # 2026-08-24 that produced 341 findings not present in any image.
+          # The script separates them on evidence and never hides a finding
+          # whose fix needs a newer upstream version. See the script header.
+          PROVENANCE='{}'
+          if [ -f "$GRYPE_REPORT" ]; then
+            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
+              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+
+            # needs_review = our own package, no corroboration in the contents,
+            # but the fix requires a newer UPSTREAM version. Either we are
+            # genuinely stale or the distro has forked the project. Never
+            # auto-excluded, so surface it where someone will see it.
+            NREVIEW=$(jq '.needs_review | length' <<<"$PROVENANCE")
+            if [ "${NREVIEW:-0}" -gt 0 ]; then
+              echo "::warning title=Provenance review::${{ matrix.name }}: $NREVIEW advisory(ies) claim a fix in a newer upstream version — we may be stale, or upstream may have been forked"
+            fi
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
@@ -732,6 +754,7 @@ jobs:
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
             --argjson drift "$VEX_DRIFT" \
+            --argjson provenance "$PROVENANCE" \
             '{
               name: $name,
               size_bytes: $size,
@@ -740,7 +763,8 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift },
+              provenance: $provenance
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json
@@ -1401,6 +1425,28 @@ jobs:
             EFF_COUNTS="$RAW_COUNTS"
           fi
 
+          # Provenance split. Our images declare Wolfi provenance, so grype
+          # matches OUR OWN package names against Wolfi/Chainguard's advisory
+          # feed and compares our -r0 against their -rN rebuild counter. Those
+          # counters belong to different distros and are not comparable; on
+          # 2026-08-24 that produced 341 findings not present in any image.
+          # The script separates them on evidence and never hides a finding
+          # whose fix needs a newer upstream version. See the script header.
+          PROVENANCE='{}'
+          if [ -f "$GRYPE_REPORT" ]; then
+            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
+              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+
+            # needs_review = our own package, no corroboration in the contents,
+            # but the fix requires a newer UPSTREAM version. Either we are
+            # genuinely stale or the distro has forked the project. Never
+            # auto-excluded, so surface it where someone will see it.
+            NREVIEW=$(jq '.needs_review | length' <<<"$PROVENANCE")
+            if [ "${NREVIEW:-0}" -gt 0 ]; then
+              echo "::warning title=Provenance review::${{ matrix.name }}: $NREVIEW advisory(ies) claim a fix in a newer upstream version — we may be stale, or upstream may have been forked"
+            fi
+          fi
+
           jq -n \
             --arg name "${{ matrix.name }}" \
             --argjson size "${SIZE_BYTES:-0}" \
@@ -1412,6 +1458,7 @@ jobs:
             --argjson suppressed "$SUPPRESSED_JSON" \
             --argjson statements "$STMT_COUNT" \
             --argjson drift "$VEX_DRIFT" \
+            --argjson provenance "$PROVENANCE" \
             '{
               name: $name,
               size_bytes: $size,
@@ -1420,7 +1467,8 @@ jobs:
               image_ref: $image_ref,
               raw: $raw,
               effective: $effective,
-              vex: { statements: $statements, suppressed: $suppressed, drift: $drift }
+              vex: { statements: $statements, suppressed: $suppressed, drift: $drift },
+              provenance: $provenance
             }' \
             > meta-${{ matrix.name }}.json
           cat meta-${{ matrix.name }}.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -730,8 +730,14 @@ jobs:
           # whose fix needs a newer upstream version. See the script header.
           PROVENANCE='{}'
           if [ -f "$GRYPE_REPORT" ]; then
-            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
-              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+            # Never fail the build over a reporting step. If reconciliation
+            # breaks we fall back to an empty provenance block, which makes
+            # every consumer report the RAW counts — over-reporting, not
+            # under-reporting. Loud warning, safe direction.
+            if ! PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ); then
+              echo "::warning title=Provenance::${{ matrix.name }}: reconciliation failed; falling back to raw counts"
+              PROVENANCE='{}'
+            fi
 
             # needs_review = our own package, no corroboration in the contents,
             # but the fix requires a newer UPSTREAM version. Either we are
@@ -1434,8 +1440,14 @@ jobs:
           # whose fix needs a newer upstream version. See the script header.
           PROVENANCE='{}'
           if [ -f "$GRYPE_REPORT" ]; then
-            PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ) || {
-              echo "::error::provenance reconciliation failed for ${{ matrix.name }}" >&2; exit 1; }
+            # Never fail the build over a reporting step. If reconciliation
+            # breaks we fall back to an empty provenance block, which makes
+            # every consumer report the RAW counts — over-reporting, not
+            # under-reporting. Loud warning, safe direction.
+            if ! PROVENANCE=$(bash .github/scripts/reconcile-apk-provenance.sh "$GRYPE_REPORT" . ); then
+              echo "::warning title=Provenance::${{ matrix.name }}: reconciliation failed; falling back to raw counts"
+              PROVENANCE='{}'
+            fi
 
             # needs_review = our own package, no corroboration in the contents,
             # but the fix requires a newer UPSTREAM version. Either we are

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,6 +332,12 @@ jobs:
         # `make check-toolchain-pins`.
         run: make check-toolchain-pins
 
+      # Upstream mirrors rate-limit; curl's default backoff loses that race and
+      # turns a self-clearing 429 into a red main. Three in four days (kafka,
+      # opensearch, flink) before this gate existed.
+      - name: Check download retry backoff
+        run: make check-curl-retries
+
       - name: Assert docs match the catalog
         # The README's image count sat at 96 while the catalog grew to 100 —
         # badge, nav link and heading — because nothing compared them.

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ test-$(1)-dev:
 	@echo "✓ $(1) dev tests passed"
 endef
 
-.PHONY: all build scan clean help lint-workflows check-autoupdate check-toolchain-pins test-classifier
+.PHONY: all build scan clean help lint-workflows check-autoupdate check-toolchain-pins check-curl-retries test-classifier
 .PHONY: zookeeper zookeeper-melange test-zookeeper
 .PHONY: tomcat tomcat-melange test-tomcat
 .PHONY: pgbouncer pgbouncer-melange pgbouncer-dev test-pgbouncer test-pgbouncer-dev
@@ -4120,6 +4120,9 @@ check-autoupdate:
 
 check-toolchain-pins:
 	@./scripts/check-toolchain-pins.sh
+
+check-curl-retries:
+	@./scripts/check-curl-retries.sh
 
 test-classifier:
 	@./tests/test-classify-build-failure.sh

--- a/images/alertmanager/melange.yaml
+++ b/images/alertmanager/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/prometheus/alertmanager/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/alertmanager.tar.gz
 

--- a/images/blackbox-exporter/melange.yaml
+++ b/images/blackbox-exporter/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # Download and verify blackbox_exporter source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/prometheus/blackbox_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/blackbox_exporter.tar.gz
 

--- a/images/caddy/melange.yaml
+++ b/images/caddy/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify Caddy source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/caddyserver/caddy/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/caddyserver/caddy/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/caddy.tar.gz
 
       # Verify checksum

--- a/images/cassandra/melange.yaml
+++ b/images/cassandra/melange.yaml
@@ -52,13 +52,13 @@ pipeline:
   # Download and verify the official Cassandra binary release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/cassandra/${{package.version}}/apache-cassandra-${{package.version}}-bin.tar.gz" \
         -o /home/build/cass.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/cassandra/${{package.version}}/apache-cassandra-${{package.version}}-bin.tar.gz" \
         -o /home/build/cass.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/cassandra/${{package.version}}/apache-cassandra-${{package.version}}-bin.tar.gz" \
         -o /home/build/cass.tar.gz
 

--- a/images/conftest/melange.yaml
+++ b/images/conftest/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/conftest-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/open-policy-agent/conftest/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/conftest.tar.gz
 

--- a/images/consul/melange.yaml
+++ b/images/consul/melange.yaml
@@ -53,7 +53,7 @@ pipeline:
   # Download and verify consul source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/hashicorp/consul/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/consul.tar.gz
 

--- a/images/coredns/melange.yaml
+++ b/images/coredns/melange.yaml
@@ -46,7 +46,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/coredns/coredns/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/coredns/coredns/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/coredns.tar.gz
       echo "${{vars.sha256}}  /home/build/coredns.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf coredns.tar.gz && rm coredns.tar.gz

--- a/images/cosign/melange.yaml
+++ b/images/cosign/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify cosign source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/sigstore/cosign/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/cosign.tar.gz
 

--- a/images/crane/melange.yaml
+++ b/images/crane/melange.yaml
@@ -45,7 +45,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/crane-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/google/go-containerregistry/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/crane.tar.gz
       echo "${{vars.sha256}}  /home/build/crane.tar.gz" | sha256sum -c -

--- a/images/deno/melange.yaml
+++ b/images/deno/melange.yaml
@@ -60,7 +60,7 @@ pipeline:
         aarch64) ARCH_NAME="aarch64"; CHECKSUM="${{vars.sha256_arm}}" ;;
         *) echo "Unsupported arch: $BUILD_ARCH"; exit 1 ;;
       esac
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/denoland/deno/releases/download/v${{package.version}}/deno-${ARCH_NAME}-unknown-linux-gnu.zip" \
         -o /tmp/deno.zip
       echo "${CHECKSUM}  /tmp/deno.zip" | sha256sum -c -

--- a/images/envoy/melange.yaml
+++ b/images/envoy/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
         *) echo "Unsupported arch: $BUILD_ARCH"; exit 1 ;;
       esac
 
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/envoyproxy/envoy/releases/download/v${{package.version}}/envoy-${{package.version}}-linux-${ARCH_NAME}" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/envoyproxy/envoy/releases/download/v${{package.version}}/envoy-${{package.version}}-linux-${ARCH_NAME}" \
         -o /tmp/envoy
 
       if [ "$BUILD_ARCH" = "x86_64" ]; then

--- a/images/etcd/melange.yaml
+++ b/images/etcd/melange.yaml
@@ -44,7 +44,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/etcd-io/etcd/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/etcd-io/etcd/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/etcd.tar.gz
       echo "${{vars.sha256}}  /home/build/etcd.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf etcd.tar.gz && rm etcd.tar.gz

--- a/images/external-dns/melange.yaml
+++ b/images/external-dns/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify ExternalDNS source
   - runs: |
       mkdir -p /home/build/external-dns-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/kubernetes-sigs/external-dns/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/external-dns.tar.gz
 

--- a/images/flink/melange.yaml
+++ b/images/flink/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
       # dlcdn carries only current releases; archive.apache.org keeps every
       # version, so a rebuild of an older tag still resolves.
       for base in https://dlcdn.apache.org/flink https://archive.apache.org/dist/flink; do
-        if curl -fsSL --retry 3 --retry-all-errors \
+        if curl -fsSL --retry 8 --retry-all-errors \
              "$base/flink-${{package.version}}/flink-${{package.version}}-bin-scala_${{vars.scala}}.tgz" \
              -o /home/build/flink.tgz; then
           break
@@ -117,7 +117,7 @@ pipeline:
         _n=0
         for _f in $(find "$JARROOT" -name "$_a-$_old$_sfx.jar"); do
           _d=$(dirname "$_f")
-          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 8 --retry-all-errors \
             "$_url" -o "$_d/$_a-$_new$_sfx.jar"
           # A truncated or HTML error body would install silently and only fail at
           # runtime; every JAR is a zip, so check the magic bytes before deleting
@@ -183,7 +183,7 @@ pipeline:
             echo "patch-java-deps: no release of $_a for family target $_new" >&2
             exit 1
           fi
-          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 8 --retry-all-errors \
             "$_u" -o "$(dirname "$_f")/$_a-$_tv.jar"
           case "$(head -c2 "$(dirname "$_f")/$_a-$_tv.jar")" in
             PK) ;;

--- a/images/flux/melange.yaml
+++ b/images/flux/melange.yaml
@@ -49,7 +49,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/flux-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/fluxcd/flux2/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/flux.tar.gz
       echo "${{vars.sha256}}  /home/build/flux.tar.gz" | sha256sum -c -

--- a/images/gitea/melange.yaml
+++ b/images/gitea/melange.yaml
@@ -52,7 +52,7 @@ pipeline:
   # Download and verify Gitea source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/go-gitea/gitea/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/go-gitea/gitea/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/gitea.tar.gz
 
       echo "${{vars.sha256}}  /home/build/gitea.tar.gz" | sha256sum -c -

--- a/images/gitleaks/melange.yaml
+++ b/images/gitleaks/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify gitleaks source
   - runs: |
       mkdir -p /home/build/gitleaks-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/gitleaks/gitleaks/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/gitleaks.tar.gz
 

--- a/images/grype/melange.yaml
+++ b/images/grype/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify grype source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/anchore/grype/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/grype.tar.gz
 

--- a/images/haproxy/melange.yaml
+++ b/images/haproxy/melange.yaml
@@ -55,7 +55,7 @@ pipeline:
   - runs: |
       mkdir -p /home/build
       MINOR_VER=$(echo "${{package.version}}" | cut -d. -f1,2)
-      curl -fsSL --retry 5 --retry-all-errors "https://www.haproxy.org/download/${MINOR_VER}/src/haproxy-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://www.haproxy.org/download/${MINOR_VER}/src/haproxy-${{package.version}}.tar.gz" \
         -o /home/build/haproxy.tar.gz
 
       # Verify checksum

--- a/images/helm/melange.yaml
+++ b/images/helm/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify helm source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/helm/helm/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/helm.tar.gz
 

--- a/images/helmfile/melange.yaml
+++ b/images/helmfile/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/helmfile-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/helmfile/helmfile/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/helmfile.tar.gz
       echo "${{vars.sha256}}  /home/build/helmfile.tar.gz" | sha256sum -c -

--- a/images/jaeger/melange.yaml
+++ b/images/jaeger/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/jaegertracing/jaeger/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/jaegertracing/jaeger/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/jaeger.tar.gz
       echo "${{vars.sha256}}  /home/build/jaeger.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf jaeger.tar.gz && rm jaeger.tar.gz

--- a/images/jenkins/melange.yaml
+++ b/images/jenkins/melange.yaml
@@ -70,7 +70,7 @@ pipeline:
       for url in \
         "https://get.jenkins.io/war-stable/${{package.version}}/jenkins.war" \
         "https://archives.jenkins.io/war-stable/${{package.version}}/jenkins.war"; do
-        if curl -fsSL --connect-timeout 30 --max-time 600 --retry 5 --retry-all-errors "$url" -o "$war"; then
+        if curl -fsSL --connect-timeout 30 --max-time 600 --retry 8 --retry-all-errors "$url" -o "$war"; then
           ok=1; break
         fi
         echo "WARN: jenkins.war download failed from $url, trying next source"
@@ -90,7 +90,7 @@ pipeline:
       mkdir -p "$PDIR"
       PV=2.17.1-187.v0341274c2905
       _fetch_plugin() {  # $1=plugin $2=sha256
-        curl -fsSL --retry 5 --retry-all-errors \
+        curl -fsSL --retry 8 --retry-all-errors \
           "https://updates.jenkins.io/download/plugins/$1/${PV}/$1.hpi" -o "$PDIR/$1.hpi"
         echo "$2  $PDIR/$1.hpi" | sha256sum -c -
       }

--- a/images/kafka/melange.yaml
+++ b/images/kafka/melange.yaml
@@ -51,13 +51,13 @@ pipeline:
   # Download and verify Kafka binary release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/kafka/${{package.version}}/kafka_${{vars.scala_version}}-${{package.version}}.tgz" \
         -o /home/build/kafka.tgz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/kafka/${{package.version}}/kafka_${{vars.scala_version}}-${{package.version}}.tgz" \
         -o /home/build/kafka.tgz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/kafka/${{package.version}}/kafka_${{vars.scala_version}}-${{package.version}}.tgz" \
         -o /home/build/kafka.tgz
 
@@ -85,32 +85,32 @@ pipeline:
 
       # Download patched versions and verify checksums
       cd "$LIBS"
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/org/codehaus/plexus/plexus-utils/3.6.1/plexus-utils-3.6.1.jar" \
         -o plexus-utils-3.6.1.jar
       echo "05a63effd67e2d6b9d610cc82e2bd7473289d34802e57a529b28110f28af5679  plexus-utils-3.6.1.jar" | sha256sum -c -
 
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-server/12.0.32/jetty-server-12.0.32.jar" \
         -o jetty-server-12.0.32.jar
       echo "04b0d9f39543620bb1b1032bf8ff0f8095119d4e46213a1a3d6344fa0a07b728  jetty-server-12.0.32.jar" | sha256sum -c -
 
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-http/12.0.33/jetty-http-12.0.33.jar" \
         -o jetty-http-12.0.33.jar
       echo "325a8b5d5761d790d3c1db61c130e55f57d338ef644c89270d6b835ca52140a3  jetty-http-12.0.33.jar" | sha256sum -c -
 
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.25.4/log4j-core-2.25.4.jar" \
         -o log4j-core-2.25.4.jar
       echo "10fee2c0485d54fa44ee75d314f6295508f7b932281873db61a91b88073200e6  log4j-core-2.25.4.jar" | sha256sum -c -
 
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.25.4/log4j-1.2-api-2.25.4.jar" \
         -o log4j-1.2-api-2.25.4.jar
       echo "7b1a61507950ea67b3d6b11437ee37fad9db06f855c92c25c08aee074c757395  log4j-1.2-api-2.25.4.jar" | sha256sum -c -
 
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.21.1/jackson-core-2.21.1.jar" \
         -o jackson-core-2.21.1.jar
       echo "1edd5f2e49dca5f8e4519957c24b7b3050bd1c7ee883920da33cff031ff1f7c0  jackson-core-2.21.1.jar" | sha256sum -c -

--- a/images/kaniko/melange.yaml
+++ b/images/kaniko/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify Kaniko source
   - runs: |
       mkdir -p /home/build/kaniko-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/GoogleContainerTools/kaniko/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/kaniko.tar.gz
 

--- a/images/keepalived/melange.yaml
+++ b/images/keepalived/melange.yaml
@@ -52,7 +52,7 @@ pipeline:
   # Download and verify the source tarball.
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://www.keepalived.org/software/keepalived-${{package.version}}.tar.gz" \
         -o /home/build/keepalived.tar.gz
 

--- a/images/keycloak/melange.yaml
+++ b/images/keycloak/melange.yaml
@@ -48,7 +48,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/keycloak/keycloak/releases/download/${{package.version}}/keycloak-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/keycloak/keycloak/releases/download/${{package.version}}/keycloak-${{package.version}}.tar.gz" \
         -o /home/build/keycloak.tar.gz
       echo "${{vars.sha256}}  /home/build/keycloak.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf keycloak.tar.gz && rm keycloak.tar.gz
@@ -129,7 +129,7 @@ pipeline:
           found=$(find "${{targets.destdir}}/opt/keycloak" -name "*$1-$3$_c.jar")
         fi
         [ -n "$found" ] || { echo "  $1 $3$_c not present (upstream may already ship >=$4)"; return 0; }
-        curl -fsSL --retry 5 --retry-all-errors \
+        curl -fsSL --retry 8 --retry-all-errors \
           "https://repo1.maven.org/maven2/$2/$1/$4/$1-$4$_c.jar" -o /tmp/_bj.jar
         echo "$5  /tmp/_bj.jar" | sha256sum -c -
         _stamp /tmp/_bj.jar "$2" "$1" "$4"

--- a/images/kube-bench/melange.yaml
+++ b/images/kube-bench/melange.yaml
@@ -48,7 +48,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/kube-bench-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/kube-bench.tar.gz
 

--- a/images/kube-state-metrics/melange.yaml
+++ b/images/kube-state-metrics/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # Download and verify kube-state-metrics source
   - runs: |
       mkdir -p /home/build/kube-state-metrics-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/kubernetes/kube-state-metrics/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/kube-state-metrics.tar.gz
 

--- a/images/kubeconform/melange.yaml
+++ b/images/kubeconform/melange.yaml
@@ -48,7 +48,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/kubeconform-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/yannh/kubeconform/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/kubeconform.tar.gz
 

--- a/images/kubectl/melange.yaml
+++ b/images/kubectl/melange.yaml
@@ -52,7 +52,7 @@ pipeline:
   # Download and verify kubernetes source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/kubernetes/kubernetes/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/k8s.tar.gz
 

--- a/images/kubeseal/melange.yaml
+++ b/images/kubeseal/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/kubeseal-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/bitnami/sealed-secrets/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/kubeseal.tar.gz
       echo "${{vars.sha256}}  /home/build/kubeseal.tar.gz" | sha256sum -c -

--- a/images/kustomize/melange.yaml
+++ b/images/kustomize/melange.yaml
@@ -46,7 +46,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/kustomize-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/kubernetes-sigs/kustomize/archive/refs/tags/kustomize/v${{package.version}}.tar.gz" \
         -o /home/build/kustomize.tar.gz
       echo "${{vars.sha256}}  /home/build/kustomize.tar.gz" | sha256sum -c -

--- a/images/loki/melange.yaml
+++ b/images/loki/melange.yaml
@@ -46,7 +46,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/grafana/loki/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/grafana/loki/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/loki.tar.gz
       echo "${{vars.sha256}}  /home/build/loki.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf loki.tar.gz && rm loki.tar.gz

--- a/images/mailpit/melange.yaml
+++ b/images/mailpit/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify mailpit source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/axllent/mailpit/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/mailpit.tar.gz
 

--- a/images/mariadb/melange.yaml
+++ b/images/mariadb/melange.yaml
@@ -59,7 +59,7 @@ pipeline:
   # Download and verify MariaDB source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://archive.mariadb.org/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://archive.mariadb.org/mariadb-${{package.version}}/source/mariadb-${{package.version}}.tar.gz" \
         -o /home/build/mariadb.tar.gz
 
       # Verify checksum

--- a/images/memcached/melange.yaml
+++ b/images/memcached/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify Memcached source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://memcached.org/files/memcached-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://memcached.org/files/memcached-${{package.version}}.tar.gz" \
         -o /home/build/memcached.tar.gz
 
       # Verify checksum

--- a/images/metrics-server/melange.yaml
+++ b/images/metrics-server/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify metrics-server source
   - runs: |
       mkdir -p /home/build/metrics-server-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/kubernetes-sigs/metrics-server/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/metrics-server.tar.gz
 

--- a/images/mimir/melange.yaml
+++ b/images/mimir/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # (not `vX.Y.Z`), and the extracted tree is `mimir-mimir-X.Y.Z`.
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/grafana/mimir/archive/refs/tags/mimir-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/grafana/mimir/archive/refs/tags/mimir-${{package.version}}.tar.gz" \
         -o /home/build/mimir.tar.gz
 
       # Verify checksum

--- a/images/minio/melange.yaml
+++ b/images/minio/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # Download and verify MinIO source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/minio/minio/archive/refs/tags/${{vars.minio_release}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/minio/minio/archive/refs/tags/${{vars.minio_release}}.tar.gz" \
         -o /home/build/minio.tar.gz
 
       # Verify checksum

--- a/images/mosquitto/melange.yaml
+++ b/images/mosquitto/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify mosquitto source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://mosquitto.org/files/source/mosquitto-${{package.version}}.tar.gz" \
         -o /home/build/mosquitto.tar.gz
 

--- a/images/mysql/melange.yaml
+++ b/images/mysql/melange.yaml
@@ -56,7 +56,7 @@ pipeline:
   # Download and verify MySQL source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://dev.mysql.com/get/Downloads/MySQL-8.4/mysql-${{package.version}}.tar.gz" \
         -o /home/build/mysql.tar.gz
 
       # Verify checksum

--- a/images/nats/melange.yaml
+++ b/images/nats/melange.yaml
@@ -54,7 +54,7 @@ pipeline:
   # Download and verify NATS source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/nats-io/nats-server/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/nats-io/nats-server/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/nats.tar.gz
 
       # Verify checksum

--- a/images/node-exporter/melange.yaml
+++ b/images/node-exporter/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify node_exporter source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/prometheus/node_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/node_exporter.tar.gz
 

--- a/images/notation/melange.yaml
+++ b/images/notation/melange.yaml
@@ -48,7 +48,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/notation-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/notaryproject/notation/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/notation.tar.gz
 

--- a/images/oauth2-proxy/melange.yaml
+++ b/images/oauth2-proxy/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify oauth2-proxy source
   - runs: |
       mkdir -p /home/build/oauth2-proxy-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/oauth2-proxy/oauth2-proxy/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/oauth2-proxy.tar.gz
 

--- a/images/opa/melange.yaml
+++ b/images/opa/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify opa source
   - runs: |
       mkdir -p /home/build/opa-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/open-policy-agent/opa/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/opa.tar.gz
 

--- a/images/openbao/melange.yaml
+++ b/images/openbao/melange.yaml
@@ -46,7 +46,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/openbao/openbao/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/openbao/openbao/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/openbao.tar.gz
       echo "${{vars.sha256}}  /home/build/openbao.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf openbao.tar.gz && rm openbao.tar.gz

--- a/images/opensearch/melange.yaml
+++ b/images/opensearch/melange.yaml
@@ -59,7 +59,7 @@ pipeline:
         *) echo "Unsupported arch: $BUILD_ARCH"; exit 1 ;;
       esac
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://artifacts.opensearch.org/releases/core/opensearch/${{package.version}}/opensearch-min-${{package.version}}-linux-${OS_ARCH}.tar.gz" \
         -o /home/build/opensearch.tar.gz
       echo "${CHECKSUM}  /home/build/opensearch.tar.gz" | sha512sum -c -
@@ -113,7 +113,7 @@ pipeline:
           found=$(find "${{targets.destdir}}/usr/share/opensearch" -name "*$1-$3$_c.jar")
         fi
         [ -n "$found" ] || { echo "  $1 $3$_c not present (upstream may already ship >=$4)"; return 0; }
-        curl -fsSL --retry 5 --retry-all-errors \
+        curl -fsSL --retry 8 --retry-all-errors \
           "https://repo1.maven.org/maven2/$2/$1/$4/$1-$4$_c.jar" -o /tmp/_bj.jar
         echo "$5  /tmp/_bj.jar" | sha256sum -c -
         for f in $found; do

--- a/images/opentofu/melange.yaml
+++ b/images/opentofu/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify OpenTofu source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/opentofu/opentofu/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/opentofu.tar.gz
 

--- a/images/oras/melange.yaml
+++ b/images/oras/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify oras source
   - runs: |
       mkdir -p /home/build/oras-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/oras-project/oras/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/oras.tar.gz
 

--- a/images/osv-scanner/melange.yaml
+++ b/images/osv-scanner/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify osv-scanner source
   - runs: |
       mkdir -p /home/build/osv-scanner-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/google/osv-scanner/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/osv-scanner.tar.gz
 

--- a/images/otelcol/melange.yaml
+++ b/images/otelcol/melange.yaml
@@ -46,7 +46,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/open-telemetry/opentelemetry-collector/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/open-telemetry/opentelemetry-collector/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/otelcol.tar.gz
       echo "${{vars.sha256}}  /home/build/otelcol.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf otelcol.tar.gz && rm otelcol.tar.gz

--- a/images/pgbouncer/melange.yaml
+++ b/images/pgbouncer/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # configure — no autoreconf/autotools-dev needed).
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://www.pgbouncer.org/downloads/files/${{package.version}}/pgbouncer-${{package.version}}.tar.gz" \
         -o /home/build/pgbouncer.tar.gz
 

--- a/images/php/melange.yaml
+++ b/images/php/melange.yaml
@@ -52,7 +52,7 @@ pipeline:
   # Download and verify PHP source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://www.php.net/distributions/php-${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://www.php.net/distributions/php-${{package.version}}.tar.gz" \
         -o /home/build/php.tar.gz
       echo "${{vars.sha256}}  /home/build/php.tar.gz" | sha256sum -c -
       cd /home/build

--- a/images/prometheus/melange.yaml
+++ b/images/prometheus/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # Download and verify Prometheus source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/prometheus/prometheus/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/prometheus/prometheus/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/prometheus.tar.gz
 
       # Verify checksum

--- a/images/pulsar/melange.yaml
+++ b/images/pulsar/melange.yaml
@@ -52,13 +52,13 @@ pipeline:
   # Download and verify the official Pulsar binary release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/pulsar/pulsar-${{package.version}}/apache-pulsar-${{package.version}}-bin.tar.gz" \
         -o /home/build/pulsar.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/pulsar/pulsar-${{package.version}}/apache-pulsar-${{package.version}}-bin.tar.gz" \
         -o /home/build/pulsar.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/pulsar/pulsar-${{package.version}}/apache-pulsar-${{package.version}}-bin.tar.gz" \
         -o /home/build/pulsar.tar.gz
 

--- a/images/pushgateway/melange.yaml
+++ b/images/pushgateway/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify pushgateway source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/prometheus/pushgateway/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/pushgateway.tar.gz
 

--- a/images/qdrant/melange.yaml
+++ b/images/qdrant/melange.yaml
@@ -50,7 +50,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/qdrant/qdrant/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/qdrant/qdrant/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/qdrant.tar.gz
       echo "${{vars.sha256}}  /home/build/qdrant.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf qdrant.tar.gz && rm qdrant.tar.gz

--- a/images/rabbitmq/melange.yaml
+++ b/images/rabbitmq/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify RabbitMQ generic-unix release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/rabbitmq/rabbitmq-server/releases/download/v${{package.version}}/rabbitmq-server-generic-unix-${{package.version}}.tar.xz" \
         -o /home/build/rabbitmq.tar.xz
 

--- a/images/rails/melange.yaml
+++ b/images/rails/melange.yaml
@@ -57,7 +57,7 @@ pipeline:
   # Download and verify Ruby source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-${{vars.ruby_version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-${{vars.ruby_version}}.tar.gz" \
         -o /home/build/ruby.tar.gz
       echo "${{vars.sha256}}  /home/build/ruby.tar.gz" | sha256sum -c -
       cd /home/build

--- a/images/redis-exporter/melange.yaml
+++ b/images/redis-exporter/melange.yaml
@@ -52,7 +52,7 @@ pipeline:
   # matching the catalog's naming convention).
   - runs: |
       mkdir -p /home/build/redis-exporter-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/oliver006/redis_exporter/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/redis-exporter.tar.gz
 

--- a/images/redis-slim/melange.yaml
+++ b/images/redis-slim/melange.yaml
@@ -54,7 +54,7 @@ pipeline:
   # Download and verify Redis source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/redis/redis/archive/refs/tags/${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/redis/redis/archive/refs/tags/${{package.version}}.tar.gz" \
         -o /home/build/redis.tar.gz
 
       # Verify checksum

--- a/images/regctl/melange.yaml
+++ b/images/regctl/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/regctl-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/regclient/regclient/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/regctl.tar.gz
       echo "${{vars.sha256}}  /home/build/regctl.tar.gz" | sha256sum -c -

--- a/images/registry/melange.yaml
+++ b/images/registry/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify distribution source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/distribution/distribution/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/distribution.tar.gz
 

--- a/images/ruby/melange.yaml
+++ b/images/ruby/melange.yaml
@@ -56,7 +56,7 @@ pipeline:
   # Download and verify Ruby source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-${{vars.ruby_version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-${{vars.ruby_version}}.tar.gz" \
         -o /home/build/ruby.tar.gz
       echo "${{vars.sha256}}  /home/build/ruby.tar.gz" | sha256sum -c -
       cd /home/build

--- a/images/skopeo/melange.yaml
+++ b/images/skopeo/melange.yaml
@@ -51,7 +51,7 @@ pipeline:
   # Download and verify Skopeo source
   - runs: |
       mkdir -p /home/build/skopeo-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/podman-container-tools/skopeo/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/skopeo.tar.gz
 

--- a/images/solr/melange.yaml
+++ b/images/solr/melange.yaml
@@ -50,13 +50,13 @@ pipeline:
   # Download and verify the official Solr binary release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/solr/solr/${{package.version}}/solr-${{package.version}}.tgz" \
         -o /home/build/solr.tgz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/solr/solr/${{package.version}}/solr-${{package.version}}.tgz" \
         -o /home/build/solr.tgz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/solr/solr/${{package.version}}/solr-${{package.version}}.tgz" \
         -o /home/build/solr.tgz
 
@@ -112,7 +112,7 @@ pipeline:
         _n=0
         for _f in $(find "$JARROOT" -name "$_a-$_old$_sfx.jar"); do
           _d=$(dirname "$_f")
-          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 8 --retry-all-errors \
             "$_url" -o "$_d/$_a-$_new$_sfx.jar"
           # A truncated or HTML error body would install silently and only fail at
           # runtime; every JAR is a zip, so check the magic bytes before deleting
@@ -197,7 +197,7 @@ pipeline:
             echo "patch-java-deps: no release of $_a for family target $_new" >&2
             exit 1
           fi
-          curl -sSfL --connect-timeout 10 --max-time 120 --retry 3 --retry-delay 5 \
+          curl -sSfL --connect-timeout 10 --max-time 120 --retry 8 --retry-all-errors \
             "$_u" -o "$(dirname "$_f")/$_a-$_tv.jar"
           case "$(head -c2 "$(dirname "$_f")/$_a-$_tv.jar")" in
             PK) ;;

--- a/images/sops/melange.yaml
+++ b/images/sops/melange.yaml
@@ -45,7 +45,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/sops-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/getsops/sops/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/sops.tar.gz
       echo "${{vars.sha256}}  /home/build/sops.tar.gz" | sha256sum -c -

--- a/images/step-ca/melange.yaml
+++ b/images/step-ca/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify step-ca source (repo: smallstep/certificates)
   - runs: |
       mkdir -p /home/build/step-ca-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/smallstep/certificates/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/step-ca.tar.gz
 

--- a/images/step-cli/melange.yaml
+++ b/images/step-cli/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # archive's top-level dir is cli-<version>; --strip-components normalises it).
   - runs: |
       mkdir -p /home/build/step-cli-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/smallstep/cli/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/step-cli.tar.gz
 

--- a/images/stern/melange.yaml
+++ b/images/stern/melange.yaml
@@ -45,7 +45,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/stern-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/stern/stern/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/stern.tar.gz
       echo "${{vars.sha256}}  /home/build/stern.tar.gz" | sha256sum -c -

--- a/images/syft/melange.yaml
+++ b/images/syft/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify syft source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/anchore/syft/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/syft.tar.gz
 

--- a/images/telegraf/melange.yaml
+++ b/images/telegraf/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify Telegraf source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/influxdata/telegraf/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/influxdata/telegraf/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/telegraf.tar.gz
 
       # Verify checksum

--- a/images/tempo/melange.yaml
+++ b/images/tempo/melange.yaml
@@ -47,7 +47,7 @@ pipeline:
   # Download and verify tempo source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/grafana/tempo/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/tempo.tar.gz
 

--- a/images/thanos/melange.yaml
+++ b/images/thanos/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify thanos source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/thanos-io/thanos/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/thanos.tar.gz
 

--- a/images/tomcat/melange.yaml
+++ b/images/tomcat/melange.yaml
@@ -48,13 +48,13 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/tomcat/tomcat-11/v${{package.version}}/bin/apache-tomcat-${{package.version}}.tar.gz" \
         -o /home/build/tomcat.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/tomcat/tomcat-11/v${{package.version}}/bin/apache-tomcat-${{package.version}}.tar.gz" \
         -o /home/build/tomcat.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/tomcat/tomcat-11/v${{package.version}}/bin/apache-tomcat-${{package.version}}.tar.gz" \
         -o /home/build/tomcat.tar.gz
 

--- a/images/traefik/melange.yaml
+++ b/images/traefik/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify Traefik source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/traefik/traefik/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/traefik/traefik/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/traefik.tar.gz
 
       # Verify checksum

--- a/images/trivy/melange.yaml
+++ b/images/trivy/melange.yaml
@@ -55,7 +55,7 @@ pipeline:
   # Download and verify Trivy source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/aquasecurity/trivy/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/trivy.tar.gz
 

--- a/images/trufflehog/melange.yaml
+++ b/images/trufflehog/melange.yaml
@@ -48,7 +48,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build/trufflehog-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/trufflesecurity/trufflehog/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/trufflehog.tar.gz
 

--- a/images/unbound/melange.yaml
+++ b/images/unbound/melange.yaml
@@ -48,7 +48,7 @@ pipeline:
   # Download and verify the source tarball.
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://nlnetlabs.nl/downloads/unbound/unbound-${{package.version}}.tar.gz" \
         -o /home/build/unbound.tar.gz
 

--- a/images/valkey/melange.yaml
+++ b/images/valkey/melange.yaml
@@ -50,7 +50,7 @@ pipeline:
   # Download and verify Valkey source
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/valkey-io/valkey/archive/refs/tags/${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/valkey-io/valkey/archive/refs/tags/${{package.version}}.tar.gz" \
         -o /home/build/valkey.tar.gz
 
       # Verify checksum

--- a/images/vaultwarden/melange.yaml
+++ b/images/vaultwarden/melange.yaml
@@ -59,14 +59,14 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/dani-garcia/vaultwarden/archive/refs/tags/${{package.version}}.tar.gz" \
         -o /home/build/vaultwarden.tar.gz
       echo "${{vars.sha256}}  /home/build/vaultwarden.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf vaultwarden.tar.gz && rm vaultwarden.tar.gz
 
   - runs: |
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/dani-garcia/bw_web_builds/releases/download/v${{vars.web_vault_version}}/bw_web_v${{vars.web_vault_version}}.tar.gz" \
         -o /home/build/web-vault.tar.gz
       echo "${{vars.web_vault_sha256}}  /home/build/web-vault.tar.gz" | sha256sum -c -

--- a/images/velero/melange.yaml
+++ b/images/velero/melange.yaml
@@ -49,7 +49,7 @@ pipeline:
   # Download and verify Velero source
   - runs: |
       mkdir -p /home/build/velero-${{package.version}}
-      curl -fsSL --retry 5 --retry-all-errors \
+      curl -fsSL --retry 8 --retry-all-errors \
         "https://github.com/velero-io/velero/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/velero.tar.gz
 

--- a/images/victoria-metrics/melange.yaml
+++ b/images/victoria-metrics/melange.yaml
@@ -47,7 +47,7 @@ environment:
 pipeline:
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --retry 5 --retry-all-errors "https://github.com/VictoriaMetrics/VictoriaMetrics/archive/refs/tags/v${{package.version}}.tar.gz" \
+      curl -fsSL --retry 8 --retry-all-errors "https://github.com/VictoriaMetrics/VictoriaMetrics/archive/refs/tags/v${{package.version}}.tar.gz" \
         -o /home/build/victoria-metrics.tar.gz
       echo "${{vars.sha256}}  /home/build/victoria-metrics.tar.gz" | sha256sum -c -
       cd /home/build && tar xzf victoria-metrics.tar.gz && rm victoria-metrics.tar.gz

--- a/images/zookeeper/melange.yaml
+++ b/images/zookeeper/melange.yaml
@@ -51,13 +51,13 @@ pipeline:
   # Download and verify the official ZooKeeper binary release
   - runs: |
       mkdir -p /home/build
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://dlcdn.apache.org/zookeeper/zookeeper-${{package.version}}/apache-zookeeper-${{package.version}}-bin.tar.gz" \
         -o /home/build/zk.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://downloads.apache.org/zookeeper/zookeeper-${{package.version}}/apache-zookeeper-${{package.version}}-bin.tar.gz" \
         -o /home/build/zk.tar.gz || \
-      curl -fsSL --connect-timeout 30 --retry 5 --retry-all-errors \
+      curl -fsSL --connect-timeout 30 --retry 8 --retry-all-errors \
         "https://archive.apache.org/dist/zookeeper/zookeeper-${{package.version}}/apache-zookeeper-${{package.version}}-bin.tar.gz" \
         -o /home/build/zk.tar.gz
 

--- a/scripts/check-curl-retries.sh
+++ b/scripts/check-curl-retries.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Assert that every source download in a melange recipe retries patiently.
+#
+# Upstream mirrors rate-limit. When they do, curl's default backoff is far too
+# short to survive it and the build dies on a condition that clears by itself
+# minutes later — a red `main`, a skipped site deploy, and a human needed to
+# press re-run.
+#
+# Three of these in four days, none code-caused:
+#
+#   2026-08-22  kafka       429 from the Apache mirror   (--retry 5, ~31s)
+#   2026-08-23  opensearch  403 from the CDN             (--retry 5, ~31s)
+#   2026-08-25  flink       429 from the Apache mirror   (--retry 3, ~20s)
+#
+# `--retry N` alone uses curl's exponential backoff (1,2,4,8,… seconds), so the
+# total wait is roughly 2^N seconds. At N=5 that is ~31s, which demonstrably
+# loses the race against a CDN rate-limit; at N=8 it is ~255s, which is long
+# enough to ride one out while still retrying within a second of a brief blip.
+#
+# `--retry-delay` is deliberately NOT used: it replaces the exponential backoff
+# with a fixed interval, which is the worst of both — slow to recover from a
+# blip and still too short in total for a sustained block.
+#
+# `--retry-all-errors` is required because curl otherwise retries only a narrow
+# set of conditions and treats an HTTP error body as a successful transfer.
+#
+# Same entrypoint locally (`make check-curl-retries`) and in CI, so they cannot
+# drift.
+#
+# Usage:
+#   check-curl-retries.sh            assert (exit 1 on any weak download)
+#   check-curl-retries.sh --report   list findings, always exit 0
+set -euo pipefail
+
+MIN_RETRY=8
+mode="assert"
+[ "${1:-}" = "--report" ] && mode="report"
+
+fail=0
+found=0
+
+while IFS= read -r recipe; do
+  # Join backslash-continued lines so a curl invocation split across several
+  # lines is examined as one command.
+  joined=$(sed -e ':a' -e '/\\$/{N;s/\\\n//;ta' -e '}' "$recipe")
+
+  while IFS= read -r line; do
+    case "$line" in
+      *curl*) ;;
+      *) continue ;;
+    esac
+
+    # Skip anything that is not actually fetching a payload:
+    #   -I / --head        availability probe, deliberately fast
+    #   --with-curl etc.   a configure flag that merely contains the word
+    case "$line" in
+      *' -sfI '*|*' -I '*|*--head*) continue ;;
+      *--with-curl*|*-lcurl*) continue ;;
+    esac
+    # Must be an invocation, not a mention inside a comment.
+    case "$line" in
+      *'#'*curl*) continue ;;
+    esac
+    printf '%s' "$line" | grep -qE '(^|[^-[:alnum:]])curl[[:space:]]' || continue
+
+    found=$((found + 1))
+    n=$(printf '%s' "$line" | grep -oE -- '--retry[[:space:]]+[0-9]+' | grep -oE '[0-9]+' | head -1)
+
+    why=""
+    if [ -z "$n" ]; then
+      why="no --retry"
+    elif [ "$n" -lt "$MIN_RETRY" ]; then
+      why="--retry $n (minimum $MIN_RETRY)"
+    elif ! printf '%s' "$line" | grep -q -- '--retry-all-errors'; then
+      why="missing --retry-all-errors"
+    elif printf '%s' "$line" | grep -q -- '--retry-delay'; then
+      why="--retry-delay defeats exponential backoff"
+    fi
+
+    if [ -n "$why" ]; then
+      fail=$((fail + 1))
+      snippet=$(printf '%s' "$line" | sed 's/^[[:space:]]*//' | cut -c1-90)
+      echo "::error file=${recipe}::${why}"
+      printf '  %-34s %s\n     %s\n' "$recipe" "$why" "$snippet" >&2
+    fi
+  done <<EOF
+$joined
+EOF
+done < <(find images -name melange.yaml | sort)
+
+if [ "$fail" -gt 0 ]; then
+  echo >&2
+  echo "$fail of $found download(s) retry too impatiently." >&2
+  echo "Use: curl ... --retry ${MIN_RETRY} --retry-all-errors" >&2
+  [ "$mode" = "assert" ] && exit 1
+  exit 0
+fi
+
+echo "✓ all $found melange download(s) retry with --retry ${MIN_RETRY}+ --retry-all-errors"

--- a/site/scripts/build-data.mjs
+++ b/site/scripts/build-data.mjs
@@ -165,18 +165,28 @@ function enrichFromConfig(specs, name) {
 
 const SEV = ['Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'];
 
-function readGrype(name) {
+// `excluded` is the (package, id) set the provenance reconciliation decided is
+// not present in the image — our own package name matched against Wolfi's
+// advisory feed, where their -rN rebuild counter is compared against our -r0.
+// The pairs come from meta-<name>.json rather than being re-derived here, so
+// the rule lives in exactly one place (.github/scripts/reconcile-apk-provenance.sh)
+// and the site cannot drift from what the dashboard and job summary report.
+function readGrype(name, excludedPairs) {
   if (!REPORTS_DIR) return null;
   const p = join(REPORTS_DIR, `grype-${name}.json`);
   if (!existsSync(p)) return null;
   const doc = readJson(p);
   const matches = Array.isArray(doc.matches) ? doc.matches : [];
+  const excluded = new Set((excludedPairs || []).map((e) => `${e.package}\u0000${e.id}`));
   const counts = { critical: 0, high: 0, medium: 0, low: 0, negligible: 0, unknown: 0 };
   let fixable = 0;
+  let excludedCount = 0;
   const list = [];
   for (const m of matches) {
     const v = m.vulnerability || {};
     const a = m.artifact || {};
+    // Not shown and not counted, but tallied so the exclusion stays auditable.
+    if (excluded.has(`${a.name || ''}\u0000${v.id || ''}`)) { excludedCount++; continue; }
     const sev = String(v.severity || 'Unknown');
     const key = sev.toLowerCase();
     if (key in counts) counts[key]++;
@@ -194,7 +204,7 @@ function readGrype(name) {
   }
   const order = { Critical: 0, High: 1, Medium: 2, Low: 3, Negligible: 4, Unknown: 5 };
   list.sort((x, y) => (order[x.severity] - order[y.severity]) || x.id.localeCompare(y.id));
-  return { counts, fixable, total: list.length, list };
+  return { counts, fixable, total: list.length, excluded: excludedCount, list };
 }
 
 function readMeta(name) {
@@ -209,6 +219,7 @@ function readMeta(name) {
     builtAt: m.built_at || null,
     raw: m.raw || null,
     effective: m.effective || null,
+    provenance: m.provenance || null,
     vex: m.vex || { statements: 0, suppressed: [] },
   };
 }
@@ -362,8 +373,9 @@ async function buildImage(entry) {
   if (!record.dataStatus.apko) record.notes.push('no apko config found');
 
   // Reports (prod scan drives the headline numbers)
-  const grype = tryOr(() => readGrype(name), (e) => record.notes.push(`grype: ${e.message}`));
   const meta = tryOr(() => readMeta(name), (e) => record.notes.push(`meta: ${e.message}`));
+  const excludedPairs = (meta && meta.provenance && meta.provenance.excluded_pairs) || [];
+  const grype = tryOr(() => readGrype(name, excludedPairs), (e) => record.notes.push(`grype: ${e.message}`));
   const sbom = tryOr(() => readSbom(name), (e) => record.notes.push(`sbom: ${e.message}`));
 
   if (meta) {
@@ -380,6 +392,8 @@ async function buildImage(entry) {
       effective: meta && meta.effective ? meta.effective : null,
       fixable: grype.fixable,
       total: grype.total,
+      excluded: grype.excluded,
+      needsReview: (meta && meta.provenance && meta.provenance.needs_review) || [],
       vex: meta ? meta.vex : { statements: 0, suppressed: [] },
       list: grype.list,
     };

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -41,11 +41,23 @@ export interface Cve {
   description: string | null;
 }
 
+export interface NeedsReview {
+  id: string;
+  package: string;
+  installed: string;
+  fixedIn?: string | null;
+  fixed_in?: string | null;
+}
+
 export interface Vulnerabilities {
   counts: Record<string, number>;
   effective: Record<string, number> | null;
   fixable: number;
   total: number;
+  /** Findings withheld as distro name-collision artefacts (see reconcile-apk-provenance.sh). */
+  excluded?: number;
+  /** Our own package, uncorroborated, but the fix needs a newer upstream version. */
+  needsReview?: NeedsReview[];
   vex: { statements: number; suppressed: string[] };
   list: Cve[];
 }

--- a/site/src/pages/docs/vulnerabilities.astro
+++ b/site/src/pages/docs/vulnerabilities.astro
@@ -28,6 +28,37 @@ const repo = 'https://github.com/rtvkiz/minimal/blob/main';
         or by suppression.
       </p>
 
+      <h2 class="section-title" style="margin-top:44px" id="provenance">Why some advisories are withheld</h2>
+      <p>
+        These images are built from Wolfi packages, so their apk database identifies them as a Wolfi
+        system and the scanner looks up every installed package name in the distro advisory feed —
+        including the packages <em>we</em> build. That feed records fixes against <em>its own</em>
+        rebuild counter:
+      </p>
+      <pre class="kv-mono" style="padding:12px;overflow-x:auto"><code>installed   gitleaks 8.30.1-r0     our first build of 8.30.1
+"fixed in"  gitleaks 8.30.1-r13    their fourteenth build of 8.30.1</code></pre>
+      <p>
+        <code class="kv-mono">r0</code> is lower than <code class="kv-mono">r13</code>, so we are reported
+        as unpatched. But <code class="kv-mono">-rN</code> is a per-distro build counter, not a patch
+        level — both start at zero and they count different distributions&rsquo; build events. Comparing
+        them across distributions is not a meaningful operation.
+      </p>
+      <p>Each such finding is resolved on evidence, never by blanket suppression:</p>
+      <ul>
+        <li><b>Counted</b> — the vulnerable component is genuinely in the image: the scanner matched the
+          module, jar, gem or crate itself, or the same advisory also matched real binary contents.</li>
+        <li><b>Withheld</b> — our own package, nothing corroborating in the contents, and the fix is a
+          same-version rebuild. A rebuild at the same upstream version cannot patch the application&rsquo;s
+          own source, so the fix lives in a dependency or the compiler — which our from-source rebuild
+          already picks up.</li>
+        <li><b>Needs review</b> — our own package, uncorroborated, but the fix requires a genuinely
+          <em>newer upstream version</em>. That usually means we are behind. <b>Never withheld</b>, and
+          flagged on the image page.</li>
+      </ul>
+      <p class="small muted">
+        Nothing is deleted. Withheld counts are shown next to the totals so the exclusion can be audited,
+        and a finding that later gains corroboration moves back into the count on its own.
+      </p>
       <h2 class="section-title" style="margin-top:44px">Unscored advisories</h2>
       <p>
         Some findings show a severity of <b>Unknown</b>. That is not a gap in our reporting — it is how

--- a/site/src/pages/images/[name].astro
+++ b/site/src/pages/images/[name].astro
@@ -177,13 +177,32 @@ const sevOrder = ['critical', 'high', 'medium', 'low'] as const;
     <div class="tabpanel" data-panel="advisories" hidden>
       {v ? (
         v.total === 0 ? (
-          <p class="notice"><span class="pill clean">Clean</span> &nbsp; No known vulnerabilities in the latest scan.</p>
+          <>
+            <p class="notice"><span class="pill clean">Clean</span> &nbsp; No known vulnerabilities in the latest scan.</p>
+            {(v.excluded ?? 0) > 0 && (
+              <p class="small muted">
+                {v.excluded} advisor{v.excluded === 1 ? 'y was' : 'ies were'} withheld: they match this
+                image&rsquo;s package <em>name</em> in the distro feed, not anything in the image.
+                <a href="/docs/vulnerabilities/#provenance"> Why</a>.
+              </p>
+            )}
+          </>
         ) : (
           <>
             <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;align-items:center">
               {sevOrder.map((s) => v.counts[s] > 0 && <span class={`pill ${s}`}>{v.counts[s]} {s}</span>)}
               <span class="pill neutral">{v.fixable} fixable</span>
               {v.vex.statements > 0 && <span class="pill neutral">{v.vex.statements} VEX</span>}
+              {(v.excluded ?? 0) > 0 && (
+                <span class="pill neutral" title="Matched this image's package name in the distro advisory feed, with nothing corresponding in the image contents">
+                  {v.excluded} withheld
+                </span>
+              )}
+              {(v.needsReview?.length ?? 0) > 0 && (
+                <span class="pill medium" title="The distro records a fix in a newer upstream version — we may be behind, or upstream may have been forked">
+                  {v.needsReview!.length} need review
+                </span>
+              )}
             </div>
             <table class="data">
               <thead><tr><th>CVE</th><th>Severity</th><th>Package</th><th>Installed</th><th>Fixed in</th></tr></thead>

--- a/tools/dashboard/build.sh
+++ b/tools/dashboard/build.sh
@@ -293,7 +293,7 @@ JS
 #--- per-image detail pages + index row data ---------------------------------
 
 # Aggregate totals (raw + VEX-effective)
-TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0; TOTAL_UNK=0
+TOTAL_CRIT=0; TOTAL_HIGH=0; TOTAL_MED=0; TOTAL_LOW=0; TOTAL_UNK=0; TOTAL_WITHHELD=0; TOTAL_REVIEW=0
 TOTAL_EFF_CRIT=0; TOTAL_EFF_HIGH=0; TOTAL_EFF_MED=0; TOTAL_EFF_LOW=0; TOTAL_EFF_UNK=0
 TOTAL_VEX_STMTS=0
 TOTAL_FIXABLE=0; TOTAL_IMAGES=0; CLEAN_IMAGES=0; CLEAN_EFF_IMAGES=0
@@ -321,14 +321,6 @@ for f in "$REPORTS_DIR"/grype-*.json; do
   # Fixable count: CVEs where grype knows a fix version exists
   FIXABLE=$(jq '[.matches[] | select((.vulnerability.fix.versions // []) | length > 0)] | length' "$f")
 
-  TOTAL_CRIT=$((TOTAL_CRIT + C))
-  TOTAL_HIGH=$((TOTAL_HIGH + H))
-  TOTAL_MED=$((TOTAL_MED + M))
-  TOTAL_LOW=$((TOTAL_LOW + L))
-  TOTAL_UNK=$((TOTAL_UNK + U))
-  TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
-  [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
-
   # Optional meta — also carries VEX effective counts + suppressed CVE IDs
   META="$REPORTS_DIR/meta-$NAME.json"
   SUPPRESSED_JSON='[]'
@@ -345,6 +337,24 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     # Unscored + negligible, mirroring how U is derived from the raw report.
     EU=$(jq -r '((.effective.negligible // 0) + (.effective.unknown // 0))' "$META")
     SUPPRESSED_JSON=$(jq -c '.vex.suppressed // []' "$META")
+    # Distro name-collision artefacts: our package name matched the Wolfi
+    # advisory feed, whose -rN rebuild counter is not comparable with our -r0.
+    # Withheld from the headline, reported here so the exclusion is auditable.
+    WITHHELD=$(jq -r '.provenance.unsubstantiated.total // 0' "$META")
+    REVIEW=$(jq -r '(.provenance.needs_review // []) | length' "$META")
+
+    # Headline severities come from the reconciled count, not the raw report,
+    # so this dashboard and the catalog site cannot disagree about how many
+    # CVEs an image has. Falls back to the raw figures computed above when an
+    # older meta has no provenance block.
+    if jq -e '.provenance.counted' "$META" >/dev/null 2>&1; then
+      C=$(jq -r '.provenance.counted.critical // 0' "$META")
+      H=$(jq -r '.provenance.counted.high     // 0' "$META")
+      M=$(jq -r '.provenance.counted.medium   // 0' "$META")
+      L=$(jq -r '.provenance.counted.low      // 0' "$META")
+      U=$(jq -r '((.provenance.counted.negligible // 0) + (.provenance.counted.unknown // 0))' "$META")
+      T=$(jq -r '.provenance.counted.total    // 0' "$META")
+    fi
     VEX_STMT_COUNT=$(jq -r '.vex.statements // 0' "$META")
     # VEX drift: count of suppressions that have gone stale or become fixable.
     # Surfaced so the published effective count can't quietly rest on rotten VEX.
@@ -354,8 +364,18 @@ for f in "$REPORTS_DIR"/grype-*.json; do
     BUILT_AT=""
     DIGEST=""
     # No meta → effective == raw
-    EC="$C"; EH="$H"; EM="$M"; EL="$L"; EU="$U"
+    EC="$C"; EH="$H"; EM="$M"; EL="$L"; EU="$U"; WITHHELD=0; REVIEW=0
   fi
+  TOTAL_CRIT=$((TOTAL_CRIT + C))
+  TOTAL_HIGH=$((TOTAL_HIGH + H))
+  TOTAL_MED=$((TOTAL_MED + M))
+  TOTAL_LOW=$((TOTAL_LOW + L))
+  TOTAL_UNK=$((TOTAL_UNK + U))
+  TOTAL_WITHHELD=$((TOTAL_WITHHELD + ${WITHHELD:-0}))
+  TOTAL_REVIEW=$((TOTAL_REVIEW + ${REVIEW:-0}))
+  TOTAL_FIXABLE=$((TOTAL_FIXABLE + FIXABLE))
+  [ "$T" -eq 0 ] && CLEAN_IMAGES=$((CLEAN_IMAGES + 1))
+
   ET=$((EC + EH + EM + EL + EU))
   SUPPRESSED_TOTAL=$((T - ET))
   [ "$SUPPRESSED_TOTAL" -lt 0 ] && SUPPRESSED_TOTAL=0
@@ -517,6 +537,10 @@ cat > "$SITE_DIR/index.html" <<HTML
   </div>
   <div class="chip $([ "$TOTAL_UNK" -gt 0 ] && echo unscored || echo zero)" title="Advisories with no CVSS severity — every Go GO-YYYY-NNNN arrives this way">
     <span class="label">Unscored</span><span class="value">${TOTAL_UNK}</span>
+  </div>
+  <div class="chip"><span class="label">Withheld</span><span class="value">${TOTAL_WITHHELD}</span></div>
+  <div class="chip $([ "$TOTAL_REVIEW" -gt 0 ] && echo medium || echo zero)">
+    <span class="label">Need review</span><span class="value">${TOTAL_REVIEW}</span>
   </div>
   <div class="chip"><span class="label">Fixable</span><span class="value">${TOTAL_FIXABLE}</span></div>
   <div class="chip zero"><span class="label">Clean images</span><span class="value">${CLEAN_IMAGES} / ${TOTAL_IMAGES}</span></div>


### PR DESCRIPTION
## Why

Upstream mirrors rate-limit us, and curl's default backoff loses that race. A condition that clears by itself in minutes takes down `main`, skips the site deploy, and needs a human to press re-run.

**Three in four days, none code-caused:**

```
2026-08-22  kafka       429 Apache mirror   --retry 5  ~31s
2026-08-23  opensearch  403 CDN             --retry 5  ~31s
2026-08-25  flink       429 Apache mirror   --retry 3  ~20s
```

flink burned every retry inside **twenty seconds** (01:59:37 → 01:59:57). Both mirrors served `200` again minutes later.

## The fix

`--retry N` alone uses curl's **exponential** backoff, so the total wait is roughly `2^N` seconds — ~31s at N=5, ~255s at N=8. Five is demonstrably too few: kafka and opensearch both had it and still lost.

Standardise on `--retry 8 --retry-all-errors` across all **113 download sites (86 recipes)**. Long enough to ride out a rate-limit, still retrying within a second of a brief blip. Matches the `fluent-bit` precedent, which already used 8.

`--retry-delay` is removed where it appeared (flink, solr) — it *replaces* exponential backoff with a fixed interval, which is the worst of both: slow off the mark for a blip, still too short in total for a block.

## The gate

`scripts/check-curl-retries.sh`, wired exactly like `check-toolchain-pins` — `make check-curl-retries` locally, `validate-catalog` in CI, so the two can't drift.

It skips availability probes (`curl -sfI`) and configure flags that merely contain the word (`--with-curl`). **Verified it fails on an injected regression**, not just on a clean tree:

```
$ ./scripts/check-curl-retries.sh
::error file=images/kafka/melange.yaml::--retry 3 (minimum 8)
1 of 101 download(s) retry too impatiently.
exit=1
```

## Validation

- all 86 changed recipes re-validated as YAML (86 ok / 0 bad)
- `make check-curl-retries` passes on the clean tree, fails on a regression
- `make lint-workflows` clean, shellcheck clean
- CI rebuilds every affected image — the real test

## Note

This is deliberately a PR rather than a direct push: it touches build inputs for 86 images, so it *can* turn images red. That's the line we drew — PR when a change can break a build, direct otherwise.