### PR TITLE
feat: onboard tailscale and descheduler

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -277,6 +277,24 @@
     releases: "https://github.com/dexidp/dex/releases"
     notes: "https://github.com/dexidp/dex/releases/tag/v{version}"
 
+- name: tailscale
+  cron-enabled: true   # validated 2026-08-27 (see PR)
+  files: [images/tailscale/melange.yaml]
+  source: { type: github-releases-latest, repo: tailscale/tailscale, strip-v: true }
+  tarball: { url: "https://github.com/tailscale/tailscale/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  links:
+    releases: "https://github.com/tailscale/tailscale/releases"
+    notes: "https://github.com/tailscale/tailscale/releases/tag/v{version}"
+
+- name: descheduler
+  cron-enabled: true   # validated 2026-08-27 (see PR)
+  files: [images/descheduler/melange.yaml]
+  source: { type: github-releases-latest, repo: kubernetes-sigs/descheduler, strip-v: true }
+  tarball: { url: "https://github.com/kubernetes-sigs/descheduler/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  links:
+    releases: "https://github.com/kubernetes-sigs/descheduler/releases"
+    notes: "https://github.com/kubernetes-sigs/descheduler/releases/tag/v{version}"
+
 - name: rclone
   cron-enabled: true   # validated 2026-08-26 (see PR)
   files: [images/rclone/melange.yaml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,8 @@ jobs:
             {"name":"kube-bench","variants":["prod","dev"]},
             {"name":"trufflehog","variants":["prod","dev"]},
             {"name":"dex","variants":["prod","dev"]},
+            {"name":"tailscale","variants":["prod","dev"]},
+            {"name":"descheduler","variants":["prod","dev"]},
             {"name":"rclone","variants":["prod","dev"]},
             {"name":"restic","variants":["prod","dev"]},
             {"name":"seaweedfs","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -137,6 +137,8 @@ jobs:
             [kube-bench]="/home/build/kube-bench-${D}{{package.version}}"
             [trufflehog]="/home/build/trufflehog-${D}{{package.version}}"
             [dex]="/home/build/dex-${D}{{package.version}}"
+            [tailscale]="/home/build/tailscale-${D}{{package.version}}"
+            [descheduler]="/home/build/descheduler-${D}{{package.version}}"
             [rclone]="/home/build/rclone-${D}{{package.version}}"
             [restic]="/home/build/restic-${D}{{package.version}}"
             [seaweedfs]="/home/build/seaweedfs-${D}{{package.version}}"
@@ -208,6 +210,8 @@ jobs:
             [kube-bench]="github.com/aquasecurity/kube-bench"
             [trufflehog]="github.com/trufflesecurity/trufflehog/v3"
             [dex]="github.com/dexidp/dex"
+            [tailscale]="tailscale.com"
+            [descheduler]="sigs.k8s.io/descheduler"
             [rclone]="github.com/rclone/rclone"
             [restic]="github.com/restic/restic"
             [seaweedfs]="github.com/seaweedfs/seaweedfs"
@@ -278,6 +282,8 @@ jobs:
             [kube-bench]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [trufflehog]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [dex]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [tailscale]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [descheduler]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [rclone]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [restic]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [seaweedfs]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ DEX_VERSION ?= $(call melange_version,images/dex/melange.yaml)
 SEAWEEDFS_VERSION ?= $(call melange_version,images/seaweedfs/melange.yaml)
 RCLONE_VERSION ?= $(call melange_version,images/rclone/melange.yaml)
 RESTIC_VERSION ?= $(call melange_version,images/restic/melange.yaml)
+TAILSCALE_VERSION ?= $(call melange_version,images/tailscale/melange.yaml)
+DESCHEDULER_VERSION ?= $(call melange_version,images/descheduler/melange.yaml)
 OAUTH2_PROXY_VERSION ?= $(call melange_version,images/oauth2-proxy/melange.yaml)
 FLUX_VERSION ?= $(call melange_version,images/flux/melange.yaml)
 KUSTOMIZE_VERSION ?= $(call melange_version,images/kustomize/melange.yaml)
@@ -216,6 +218,8 @@ endef
 .PHONY: seaweedfs seaweedfs-melange test-seaweedfs
 .PHONY: rclone rclone-melange test-rclone
 .PHONY: restic restic-melange test-restic
+.PHONY: tailscale tailscale-melange test-tailscale
+.PHONY: descheduler descheduler-melange test-descheduler
 .PHONY: oauth2-proxy oauth2-proxy-melange test-oauth2-proxy
 .PHONY: flux flux-melange test-flux
 .PHONY: kustomize kustomize-melange test-kustomize
@@ -2032,6 +2036,52 @@ rclone: rclone-melange
 	@rm -f rclone.tar sbom-*.spdx.json
 	@echo "✓ minimal-rclone built (source build)"
 
+tailscale-melange: keygen
+	@echo "Building Tailscale $(TAILSCALE_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/tailscale/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Tailscale package built from source"
+
+tailscale: tailscale-melange
+	@echo "Assembling minimal-tailscale image with apko..."
+	apko build images/tailscale/apko/tailscale.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-tailscale:$(VERSION) \
+		tailscale.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < tailscale.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-tailscale:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-tailscale:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-tailscale:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-tailscale:latest
+	@rm -f tailscale.tar sbom-*.spdx.json
+	@echo "✓ minimal-tailscale built (source build)"
+
+descheduler-melange: keygen
+	@echo "Building descheduler $(DESCHEDULER_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/descheduler/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ descheduler package built from source"
+
+descheduler: descheduler-melange
+	@echo "Assembling minimal-descheduler image with apko..."
+	apko build images/descheduler/apko/descheduler.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-descheduler:$(VERSION) \
+		descheduler.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < descheduler.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-descheduler:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-descheduler:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-descheduler:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-descheduler:latest
+	@rm -f descheduler.tar sbom-*.spdx.json
+	@echo "✓ minimal-descheduler built (source build)"
+
 restic-melange: keygen
 	@echo "Building restic $(RESTIC_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
 	melange build images/restic/melange.yaml \
@@ -3744,6 +3794,18 @@ test-rclone:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-rclone:latest" && \
 		images/rclone/test.sh
 	@echo "✓ rclone tests passed"
+
+test-tailscale:
+	@echo "Testing tailscale image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-tailscale:latest" && \
+		images/tailscale/test.sh
+	@echo "✓ tailscale tests passed"
+
+test-descheduler:
+	@echo "Testing descheduler image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-descheduler:latest" && \
+		images/descheduler/test.sh
+	@echo "✓ descheduler tests passed"
 
 test-restic:
 	@echo "Testing restic image..."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>104 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
+  <strong>106 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
 </p>
 
 <p align="center">
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/rtvkiz/minimal/actions/workflows/build.yml"><img src="https://github.com/rtvkiz/minimal/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
-  <img src="https://img.shields.io/badge/Images-104-0d9488" alt="Images: 104">
+  <img src="https://img.shields.io/badge/Images-106-0d9488" alt="Images: 106">
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures: amd64 and arm64">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
@@ -34,7 +34,7 @@ docker run --rm -p 8080:80 ghcr.io/rtvkiz/minimal-nginx:latest
 docker run --rm -p 6379:6379 ghcr.io/rtvkiz/minimal-redis-slim:latest
 ```
 
-**[Find an image →](https://minimalcontainers.com/images)** — all 104, with live
+**[Find an image →](https://minimalcontainers.com/images)** — all 106, with live
 sizes and CVE counts.
 
 ## Verify what you pulled

--- a/catalog.json
+++ b/catalog.json
@@ -531,6 +531,28 @@
       "summary": "Shell-less restic deduplicating, encrypted backup program, built from source via melange."
     },
     {
+      "name": "tailscale",
+      "category": "Infrastructure",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "tailscale",
+      "upstream_url": "https://tailscale.com/",
+      "summary": "Shell-less Tailscale WireGuard mesh VPN (tailscaled daemon + CLI), built from source via melange."
+    },
+    {
+      "name": "descheduler",
+      "category": "Kubernetes, CI & IaC",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "descheduler",
+      "upstream_url": "https://github.com/kubernetes-sigs/descheduler",
+      "summary": "Shell-less Kubernetes descheduler, built from source via melange."
+    },
+    {
       "name": "oauth2-proxy",
       "category": "Web Servers & Proxies",
       "variants": [

--- a/images/descheduler/apko/descheduler-dev.yaml
+++ b/images/descheduler/apko/descheduler-dev.yaml
@@ -1,0 +1,55 @@
+# Development variant of minimal-descheduler.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - descheduler
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Runs in-cluster against the API server; configuration comes from a policy
+# ConfigMap mounted by the operator/Deployment, e.g.
+# `--policy-config-file=/policy-dir/policy.yaml`.
+
+entrypoint:
+  command: /usr/bin/descheduler
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-descheduler-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-descheduler: same binaries + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/descheduler"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/descheduler/apko/descheduler.yaml
+++ b/images/descheduler/apko/descheduler.yaml
@@ -1,0 +1,45 @@
+# Minimal descheduler image - Kubernetes descheduler, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - descheduler
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Runs in-cluster against the API server; configuration comes from a policy
+# ConfigMap mounted by the operator/Deployment, e.g.
+# `--policy-config-file=/policy-dir/policy.yaml`.
+
+entrypoint:
+  command: /usr/bin/descheduler
+
+environment:
+  PATH: /usr/bin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-descheduler"
+  org.opencontainers.image.description: "Hardened shell-less Kubernetes descheduler built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/descheduler"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/descheduler/melange.yaml
+++ b/images/descheduler/melange.yaml
@@ -1,0 +1,89 @@
+# Melange build configuration for minimal descheduler
+# Pure Go from source. Single static `descheduler` binary — the Kubernetes SIG
+# component that evicts pods so the scheduler can place them better (rebalances
+# after node additions, taints, or drifted affinity).
+# License: Apache-2.0 (The Kubernetes Authors).
+
+package:
+  # Named `descheduler` (not `descheduler-minimal`) so vulnerability scanners
+  # can identify it. Syft derives a package's CPE from its apk name, and every
+  # CPE it generated kept -minimal in the product field
+  # (cpe:2.3:a:descheduler:descheduler-minimal:*, ...). NVD indexes this
+  # product bare, so none of them matched.
+  name: descheduler
+  version: 0.36.0
+  epoch: 0
+  description: "Minimal Kubernetes descheduler built from source"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    # apko resolves a top-level package name across ALL repositories and picks
+    # the highest version — it does not prefer our local repo (apko v1.1.6
+    # pkg/apk/apk/repo.go, comparePackages: `compare` is nil for a top-level
+    # request, so the repository-matching tiebreak never runs). Wolfi ships a
+    # bare `descheduler`, so without this apk could install Wolfi's build
+    # instead of this source-built one. provider-priority is evaluated BEFORE
+    # version in that comparator, so this pins resolution permanently.
+    provider-priority: 100
+
+vars:
+  # SHA256 of descheduler source tarball - updated by update-versions.yml workflow
+  sha256: 9b7fc9a457642f80c8683b96fafecc58e2229097399b300826bbb07d5de8effe
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      # go-1.26, not 1.27. descheduler vendors k8s.io/kube-openapi, which carries
+      # a copy of go-json-experiment and calls json.SkipFunc /
+      # json.DiscardUnknownMembers — both removed from encoding/json/v2 in
+      # go1.27, so the build fails with "undefined: json.SkipFunc". Same break
+      # that took trivy out on 2026-08-19; trivy is pinned here for the same
+      # reason. update-wolfi-packages retries the bump on each toolchain
+      # release and the repair loop holds this image back until upstream
+      # adapts, so the pin clears itself.
+      - go-1.26
+      - git
+
+pipeline:
+  # Download and verify descheduler source
+  - runs: |
+      mkdir -p /home/build/descheduler-${{package.version}}
+      curl -fsSL --retry 8 --retry-all-errors \
+        "https://github.com/kubernetes-sigs/descheduler/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/descheduler.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/descheduler.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/descheduler.tar.gz -C /home/build/descheduler-${{package.version}} --strip-components=1
+      rm /home/build/descheduler.tar.gz
+
+  # Version is reported via pkg/version (see upstream Makefile LDFLAG_LOCATION).
+  # Upstream prefixes the tag with `v`; keep that so `--version` matches what
+  # they publish. CGO_ENABLED=0 gives a static binary.
+  - runs: |
+      cd /home/build/descheduler-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= \
+          -X sigs.k8s.io/descheduler/pkg/version.version=v${{package.version}}" \
+        -o /home/build/descheduler-bin \
+        ./cmd/descheduler
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/descheduler-bin "${{targets.destdir}}/usr/bin/descheduler"
+      chmod 0755 "${{targets.destdir}}/usr/bin/descheduler"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying descheduler binary..."
+      "${{targets.destdir}}/usr/bin/descheduler" version

--- a/images/descheduler/test-dev.sh
+++ b/images/descheduler/test-dev.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Smoke test for minimal-descheduler-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing descheduler binary (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/descheduler "$IMAGE" version 2>&1 | grep -qE '[0-9]+\.[0-9]+'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "All descheduler-dev tests passed!"

--- a/images/descheduler/test.sh
+++ b/images/descheduler/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing descheduler version..."
+# `version` is a subcommand, not a flag — descheduler is a cobra command and
+# rejects --version outright.
+docker run --rm "$IMAGE" version 2>&1 | grep -qE 'v?0\.[0-9]+'
+
+echo "Testing descheduler flags load (cobra command tree intact)..."
+docker run --rm "$IMAGE" --help 2>&1 | grep -qiE 'policy-config-file|descheduling-interval|dry-run'
+
+echo "Testing descheduler fails cleanly without a cluster..."
+# No kubeconfig and no in-cluster service account: it must report that clearly
+# and exit, not hang or panic. Exercises client construction and the config
+# path — the parts a dependency bump would break.
+out=$(docker run --rm "$IMAGE" --policy-config-file=/nonexistent.yaml 2>&1 || true)
+case "$out" in
+  *"unable to load in-cluster configuration"*|*KUBERNETES_SERVICE_HOST*|*"no such file"*|*"failed to"*) ;;
+  *) echo "FAIL: unexpected output without a cluster: $out"; exit 1 ;;
+esac
+echo "✓ descheduler reported a clean startup error"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All descheduler tests passed!"

--- a/images/tailscale/apko/tailscale-dev.yaml
+++ b/images/tailscale/apko/tailscale-dev.yaml
@@ -1,0 +1,68 @@
+# Development variant of minimal-tailscale.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - tailscale
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Entrypoint is the DAEMON; the `tailscale` CLI is also on PATH for
+# `docker exec`-style use and for `tailscale up` inside the same container.
+#
+# A real mesh needs /dev/net/tun plus NET_ADMIN, which a distroless image
+# cannot grant itself — run with `--device /dev/net/tun --cap-add NET_ADMIN`,
+# or use userspace networking (`--tun=userspace-networking`) which needs
+# neither and is the usual choice in Kubernetes.
+
+entrypoint:
+  command: /usr/bin/tailscaled
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+# tailscaled persists node state here. A nonroot process cannot create it at
+# runtime, so apko must author it owned by the run-as user.
+paths:
+  - path: /var/lib/tailscale
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+
+annotations:
+  org.opencontainers.image.title: "minimal-tailscale-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-tailscale: same binaries + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/tailscale"
+  org.opencontainers.image.licenses: "BSD-3-Clause"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/tailscale/apko/tailscale.yaml
+++ b/images/tailscale/apko/tailscale.yaml
@@ -1,0 +1,58 @@
+# Minimal tailscale image - Tailscale WireGuard mesh VPN (tailscaled daemon + CLI), built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - tailscale
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Entrypoint is the DAEMON; the `tailscale` CLI is also on PATH for
+# `docker exec`-style use and for `tailscale up` inside the same container.
+#
+# A real mesh needs /dev/net/tun plus NET_ADMIN, which a distroless image
+# cannot grant itself — run with `--device /dev/net/tun --cap-add NET_ADMIN`,
+# or use userspace networking (`--tun=userspace-networking`) which needs
+# neither and is the usual choice in Kubernetes.
+
+entrypoint:
+  command: /usr/bin/tailscaled
+
+environment:
+  PATH: /usr/bin:/bin
+
+# tailscaled persists node state here. A nonroot process cannot create it at
+# runtime, so apko must author it owned by the run-as user.
+paths:
+  - path: /var/lib/tailscale
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+
+annotations:
+  org.opencontainers.image.title: "minimal-tailscale"
+  org.opencontainers.image.description: "Hardened shell-less Tailscale WireGuard mesh VPN (tailscaled daemon + CLI) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/tailscale"
+  org.opencontainers.image.licenses: "BSD-3-Clause"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/tailscale/melange.yaml
+++ b/images/tailscale/melange.yaml
@@ -1,0 +1,92 @@
+# Melange build configuration for minimal Tailscale
+# Pure Go from source. Ships BOTH binaries the product needs: `tailscaled`
+# (the daemon that maintains the WireGuard mesh) and `tailscale` (the CLI that
+# talks to it over a local socket). They are one release and one module, so one
+# package carries both.
+# License: BSD-3-Clause (Tailscale Inc.).
+#
+# Built from source rather than Wolfi's package so the catalog tracks upstream
+# latest — Tailscale releases often, and a mesh VPN is a poor thing to be
+# behind on.
+
+package:
+  # Named `tailscale` (not `tailscale-minimal`) so vulnerability scanners can
+  # identify it. Syft derives a package's CPE from its apk name, and every CPE
+  # it generated kept -minimal in the product field
+  # (cpe:2.3:a:tailscale:tailscale-minimal:*, ...). NVD indexes this product
+  # bare, as cpe:2.3:a:tailscale:tailscale:*, so none of them matched.
+  name: tailscale
+  version: 1.102.3
+  epoch: 0
+  description: "Minimal Tailscale WireGuard mesh VPN (tailscaled + CLI) built from source"
+  copyright:
+    - license: BSD-3-Clause
+  dependencies:
+    # apko resolves a top-level package name across ALL repositories and picks
+    # the highest version — it does not prefer our local repo (apko v1.1.6
+    # pkg/apk/apk/repo.go, comparePackages: `compare` is nil for a top-level
+    # request, so the repository-matching tiebreak never runs). Wolfi ships a
+    # bare `tailscale`, so without this apk could install Wolfi's build instead
+    # of this source-built one. provider-priority is evaluated BEFORE version
+    # in that comparator, so this pins resolution to our package permanently.
+    provider-priority: 100
+
+vars:
+  # SHA256 of tailscale source tarball - updated by update-versions.yml workflow
+  sha256: 0e94d961c31ce7d33e8b7ce4ac6fdbec83ee5658784eed69eb7fce300729d717
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go-1.27
+      - git
+
+pipeline:
+  # Download and verify Tailscale source
+  - runs: |
+      mkdir -p /home/build/tailscale-${{package.version}}
+      curl -fsSL --retry 8 --retry-all-errors \
+        "https://github.com/tailscale/tailscale/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/tailscale.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/tailscale.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/tailscale.tar.gz -C /home/build/tailscale-${{package.version}} --strip-components=1
+      rm /home/build/tailscale.tar.gz
+
+  # Version is reported via tailscale.com/version.{long,short}Stamp — see
+  # upstream build_dist.sh. Both must be set or `tailscale version` prints a
+  # bare "date" placeholder. CGO_ENABLED=0 gives static binaries.
+  - runs: |
+      cd /home/build/tailscale-${{package.version}}
+      for _c in tailscale tailscaled; do
+        GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+          -trimpath \
+          -ldflags="-s -w -buildid= \
+            -X tailscale.com/version.longStamp=${{package.version}} \
+            -X tailscale.com/version.shortStamp=${{package.version}}" \
+          -o "/home/build/${_c}-bin" \
+          "./cmd/${_c}"
+      done
+
+  # Install binaries
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      for _c in tailscale tailscaled; do
+        cp "/home/build/${_c}-bin" "${{targets.destdir}}/usr/bin/${_c}"
+        chmod 0755 "${{targets.destdir}}/usr/bin/${_c}"
+      done
+
+  # Verify the build
+  - runs: |
+      echo "Verifying tailscale binaries..."
+      "${{targets.destdir}}/usr/bin/tailscale" version
+      "${{targets.destdir}}/usr/bin/tailscaled" --version

--- a/images/tailscale/test-dev.sh
+++ b/images/tailscale/test-dev.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Smoke test for minimal-tailscale-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing tailscale binary (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/tailscale "$IMAGE" --version 2>&1 | grep -qE '[0-9]+\.[0-9]+'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "All tailscale-dev tests passed!"

--- a/images/tailscale/test.sh
+++ b/images/tailscale/test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing tailscale CLI version..."
+docker run --rm --entrypoint /usr/bin/tailscale "$IMAGE" version 2>&1 | grep -qE '^1\.[0-9]+'
+
+echo "Testing tailscaled version (both binaries shipped)..."
+docker run --rm --entrypoint /usr/bin/tailscaled "$IMAGE" --version 2>&1 | grep -qE '^1\.[0-9]+'
+
+echo "Testing tailscaled starts in userspace-networking mode..."
+# Boots the daemon without /dev/net/tun or NET_ADMIN, which is how it runs in
+# Kubernetes. Proves the daemon initialises its state dir and opens its local
+# API socket — not just that a version string prints.
+CID=$(docker run -d "$IMAGE" --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state --socket=/tmp/tailscaled.sock)
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+ok=""
+for _ in $(seq 1 30); do
+  logs=$(docker logs "$CID" 2>&1 || true)
+  case "$logs" in
+    *"logtail started"*|*"Program starting"*|*"wgengine.NewUserspaceEngine"*|*"Backend: logs"*) ok=1; break ;;
+  esac
+  sleep 1
+done
+[ -n "$ok" ] || { echo "FAIL: tailscaled did not start"; docker logs "$CID" 2>&1 | tail -20; exit 1; }
+
+# The CLI must be able to reach the daemon over the local socket. `status`
+# exits non-zero when logged out, which is expected here — what matters is that
+# it talked to the daemon rather than failing to connect.
+out=$(docker exec "$CID" /usr/bin/tailscale --socket=/tmp/tailscaled.sock status 2>&1 || true)
+case "$out" in
+  *"Logged out"*|*"NeedsLogin"*|*"stopped"*|*100.*) ;;
+  *) echo "FAIL: CLI could not reach the daemon (got: $out)"; exit 1 ;;
+esac
+echo "✓ tailscaled started and the CLI reached it"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All tailscale tests passed!"

--- a/vex/descheduler.openvex.json
+++ b/vex/descheduler.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/descheduler",
+  "author": "rtvkiz",
+  "timestamp": "2026-08-27T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/tailscale.openvex.json
+++ b/vex/tailscale.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/tailscale",
+  "author": "rtvkiz",
+  "timestamp": "2026-08-27T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Catalog to **106**. Both permissive, both absent from Chainguard's free catalog, both source-built with live `versions.yaml` rows.

```
tailscale   1.102.3  BSD-3-Clause  35k ⭐   WireGuard mesh VPN
descheduler 0.36.0   Apache-2.0    k8s SIG  rebalances pods after scheduling drift
```

## tailscale ships both binaries

One module, one release, two programs: `tailscaled` (the daemon holding the mesh) and `tailscale` (the CLI that talks to it over a local socket). Shipping either alone would be useless.

The smoke test boots the daemon in **userspace-networking mode** — no `/dev/net/tun`, no `NET_ADMIN`, which is how it actually runs in Kubernetes — then proves the CLI reaches it over the socket. `Logged out` counts as success there: the point is the two halves talking, not authentication.

## descheduler is pinned to go-1.26, and that finding is bigger than this PR

It vendors `k8s.io/kube-openapi`, which carries a copy of `go-json-experiment`:

```
vendor/k8s.io/kube-openapi/.../json/alias.go:618:21: undefined: json.SkipFunc
```

`json.SkipFunc` and `json.DiscardUnknownMembers` were removed from `encoding/json/v2` in go1.27. **This is the same break that took trivy out on 2026-08-19** — so the go-1.27 incompatibility was never trivy-specific. Anything vendoring kube-openapi hits it, and we should expect more.

Pinned the same way trivy is. `update-wolfi-packages` retries the bump each toolchain release and the repair loop holds the image back until upstream adapts, so the pin clears itself rather than becoming a permanent decision.

## A smaller one worth recording

`descheduler --version` doesn't exist — `version` is a cobra **subcommand** and the binary rejects the flag. The recipe's own verify step caught it locally, before CI. That step earns its keep.

## Validation

All 11 registration points per `docs/onboarding.md`:

```
make tailscale-melange     ✓  1.102.3, both binaries
make descheduler-melange   ✓  GitVersion:v0.36.0 GoVersion:go1.26.7
make test-tailscale        ✓  daemon boots, CLI reaches it over the socket
make test-descheduler      ✓  version · flags · clean no-cluster failure
dev variants               ✓  both built + tested
make check-autoupdate      ✓  106/106
make check-docs            ✓  README matches catalog
make lint-workflows        ✓
check-toolchain-pins       ✓  94 environments, no bare providers
```