### PR TITLE
feat: onboard kube-vip and zipkin

### DIFF
--- a/.github/patch-deps.yaml
+++ b/.github/patch-deps.yaml
@@ -214,3 +214,22 @@
       jar-root: opt/zookeeper
       strategy: rename
       splice-before: "update:"
+    # report-only at onboarding (2026-08-29). Zipkin ships a Spring Boot fat jar
+    # that this image explodes onto disk, so all 157 bundled dependencies are
+    # visible and swappable — but they are exactly the tightly coupled families
+    # (Spring, Jackson, Netty, Armeria) that broke cassandra and kafka in PR
+    # #608: jackson-annotations publishes no matching micro release, so a
+    # databind bump lands beside a stale annotations jar and the context fails
+    # to refresh. Same unfixed lift limitation, same expected outcome, so it
+    # starts reporting rather than patching.
+    #
+    # Its smoke test already clears the promotion bar — it boots the server and
+    # completes a span ingest -> query round-trip, and the layout is proven
+    # rename-safe (the launcher scans BOOT-INF/lib rather than trusting
+    # classpath.idx; see images/zipkin/melange.yaml). Promote to auto once the
+    # lift falls back to the newest in-series version.
+    - name: zipkin
+      jar-root: opt/zipkin
+      policy: report-only
+      strategy: rename
+      splice-before: "  # Verify the build."

--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -295,6 +295,28 @@
     releases: "https://github.com/kubernetes-sigs/descheduler/releases"
     notes: "https://github.com/kubernetes-sigs/descheduler/releases/tag/v{version}"
 
+
+- name: kube-vip
+  cron-enabled: true   # validated 2026-08-29 (see PR)
+  files: [images/kube-vip/melange.yaml]
+  source: { type: github-releases-latest, repo: kube-vip/kube-vip, strip-v: true }
+  tarball: { url: "https://github.com/kube-vip/kube-vip/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  links:
+    releases: "https://github.com/kube-vip/kube-vip/releases"
+    notes: "https://github.com/kube-vip/kube-vip/releases/tag/v{version}"
+
+- name: zipkin
+  cron-enabled: true   # validated 2026-08-29 (see PR)
+  files: [images/zipkin/melange.yaml]
+  source: { type: github-releases-latest, repo: openzipkin/zipkin, strip-v: true }
+  # Upstream publishes no binary tarball — the Spring Boot "exec" jar on Maven
+  # Central IS the distribution, so that is what gets checksummed.
+  tarball:
+    url: "https://repo1.maven.org/maven2/io/zipkin/zipkin-server/{version}/zipkin-server-{version}-exec.jar"
+    field: sha256
+  links:
+    releases: "https://github.com/openzipkin/zipkin/releases"
+    notes: "https://github.com/openzipkin/zipkin/releases/tag/{version}"
 - name: rclone
   cron-enabled: true   # validated 2026-08-26 (see PR)
   files: [images/rclone/melange.yaml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,8 @@ jobs:
             {"name":"dex","variants":["prod","dev"]},
             {"name":"tailscale","variants":["prod","dev"]},
             {"name":"descheduler","variants":["prod","dev"]},
+            {"name":"kube-vip","variants":["prod","dev"]},
+            {"name":"zipkin","variants":["prod","dev"]},
             {"name":"rclone","variants":["prod","dev"]},
             {"name":"restic","variants":["prod","dev"]},
             {"name":"seaweedfs","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -139,6 +139,7 @@ jobs:
             [dex]="/home/build/dex-${D}{{package.version}}"
             [tailscale]="/home/build/tailscale-${D}{{package.version}}"
             [descheduler]="/home/build/descheduler-${D}{{package.version}}"
+            [kube-vip]="/home/build/kube-vip-${D}{{package.version}}"
             [rclone]="/home/build/rclone-${D}{{package.version}}"
             [restic]="/home/build/restic-${D}{{package.version}}"
             [seaweedfs]="/home/build/seaweedfs-${D}{{package.version}}"
@@ -212,6 +213,7 @@ jobs:
             [dex]="github.com/dexidp/dex"
             [tailscale]="tailscale.com"
             [descheduler]="sigs.k8s.io/descheduler"
+            [kube-vip]="github.com/kube-vip/kube-vip"
             [rclone]="github.com/rclone/rclone"
             [restic]="github.com/restic/restic"
             [seaweedfs]="github.com/seaweedfs/seaweedfs"
@@ -284,6 +286,7 @@ jobs:
             [dex]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [tailscale]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [descheduler]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [kube-vip]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [rclone]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [restic]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [seaweedfs]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ STEP_VERSION ?= $(call melange_version,images/step-cli/melange.yaml)
 OPA_VERSION ?= $(call melange_version,images/opa/melange.yaml)
 OSV_SCANNER_VERSION ?= $(call melange_version,images/osv-scanner/melange.yaml)
 DEX_VERSION ?= $(call melange_version,images/dex/melange.yaml)
+KUBE_VIP_VERSION ?= $(call melange_version,images/kube-vip/melange.yaml)
+ZIPKIN_VERSION ?= $(call melange_version,images/zipkin/melange.yaml)
 SEAWEEDFS_VERSION ?= $(call melange_version,images/seaweedfs/melange.yaml)
 RCLONE_VERSION ?= $(call melange_version,images/rclone/melange.yaml)
 RESTIC_VERSION ?= $(call melange_version,images/restic/melange.yaml)
@@ -215,6 +217,8 @@ endef
 .PHONY: opa opa-melange test-opa
 .PHONY: osv-scanner osv-scanner-melange test-osv-scanner
 .PHONY: dex dex-melange test-dex
+.PHONY: kube-vip kube-vip-melange test-kube-vip
+.PHONY: zipkin zipkin-melange test-zipkin
 .PHONY: seaweedfs seaweedfs-melange test-seaweedfs
 .PHONY: rclone rclone-melange test-rclone
 .PHONY: restic restic-melange test-restic
@@ -2151,6 +2155,52 @@ dex: dex-melange
 	@rm -f dex.tar sbom-*.spdx.json
 	@echo "✓ minimal-dex built (source build)"
 
+kube-vip-melange: keygen
+	@echo "Building kube-vip $(KUBE_VIP_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/kube-vip/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ kube-vip package built from source"
+
+kube-vip: kube-vip-melange
+	@echo "Assembling minimal-kube-vip image with apko..."
+	apko build images/kube-vip/apko/kube-vip.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-kube-vip:$(VERSION) \
+		kube-vip.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < kube-vip.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-kube-vip:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-kube-vip:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-kube-vip:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-kube-vip:latest
+	@rm -f kube-vip.tar sbom-*.spdx.json
+	@echo "✓ minimal-kube-vip built (source build)"
+
+zipkin-melange: keygen
+	@echo "Building Zipkin $(ZIPKIN_VERSION) via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/zipkin/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Zipkin package built"
+
+zipkin: zipkin-melange
+	@echo "Assembling minimal-zipkin image with apko..."
+	apko build images/zipkin/apko/zipkin.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-zipkin:$(VERSION) \
+		zipkin.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < zipkin.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-zipkin:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-zipkin:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-zipkin:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-zipkin:latest
+	@rm -f zipkin.tar sbom-*.spdx.json
+	@echo "✓ minimal-zipkin built"
+
 oauth2-proxy-melange: keygen
 	@echo "Building OAuth2 Proxy $(OAUTH2_PROXY_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
 	melange build images/oauth2-proxy/melange.yaml \
@@ -3824,6 +3874,18 @@ test-dex:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-dex:latest" && \
 		images/dex/test.sh
 	@echo "✓ dex tests passed"
+
+test-kube-vip:
+	@echo "Testing kube-vip image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-kube-vip:latest" && \
+		images/kube-vip/test.sh
+	@echo "✓ kube-vip tests passed"
+
+test-zipkin:
+	@echo "Testing zipkin image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-zipkin:latest" && \
+		images/zipkin/test.sh
+	@echo "✓ zipkin tests passed"
 
 test-oauth2-proxy:
 	@echo "Testing oauth2-proxy image..."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>106 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
+  <strong>108 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
 </p>
 
 <p align="center">
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/rtvkiz/minimal/actions/workflows/build.yml"><img src="https://github.com/rtvkiz/minimal/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
-  <img src="https://img.shields.io/badge/Images-106-0d9488" alt="Images: 106">
+  <img src="https://img.shields.io/badge/Images-108-0d9488" alt="Images: 108">
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures: amd64 and arm64">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
@@ -34,7 +34,7 @@ docker run --rm -p 8080:80 ghcr.io/rtvkiz/minimal-nginx:latest
 docker run --rm -p 6379:6379 ghcr.io/rtvkiz/minimal-redis-slim:latest
 ```
 
-**[Find an image →](https://minimalcontainers.com/images)** — all 106, with live
+**[Find an image →](https://minimalcontainers.com/images)** — all 108, with live
 sizes and CVE counts.
 
 ## Verify what you pulled

--- a/catalog.json
+++ b/catalog.json
@@ -553,6 +553,17 @@
       "summary": "Shell-less Kubernetes descheduler, built from source via melange."
     },
     {
+      "name": "kube-vip",
+      "category": "Kubernetes, CI & IaC",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "kube-vip",
+      "upstream_url": "https://kube-vip.io/",
+      "summary": "Shell-less kube-vip control-plane VIP and load balancer, built from source via melange."
+    },
+    {
       "name": "oauth2-proxy",
       "category": "Web Servers & Proxies",
       "variants": [
@@ -628,6 +639,17 @@
       "primary_package": "jaeger",
       "upstream_url": "https://www.jaegertracing.io",
       "summary": "Jaeger distributed tracing backend built from source via melange."
+    },
+    {
+      "name": "zipkin",
+      "category": "Observability",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "zipkin",
+      "upstream_url": "https://zipkin.io/",
+      "summary": "Shell-less Zipkin distributed tracing server on a custom jlink JRE."
     },
     {
       "name": "loki",

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,9 @@
 # Image Roadmap — the road to 100 (demand-ranked)
 
-**Status: 96 / 100 images.** This is the source-of-truth plan for growing the catalog.
+**Status: 108 images — the 100 target is met.** This is the source-of-truth plan for
+growing the catalog. The tier tables below stay useful as the demand-ranked backlog;
+the "road to 100" batch section near the end is kept as a build log of how the first
+100 were reached, not as remaining work.
 It supersedes the batch order from earlier sessions, which was ordered by *build ease* and
 *GitHub popularity*. This version is ordered by **actual container demand first**, then
 build effort.
@@ -56,6 +59,7 @@ Single static Go binaries **and** genuinely run as containers. Best impact-per-e
 | [x] | helmfile | helmfile/helmfile | 🟢 MIT | — | 5k | declarative Helm, CD pipelines |
 | [x] | regctl | regclient/regclient | 🟢 Apache-2.0 | — | 2k | registry client, CI |
 | [x] | stern | stern/stern | 🟢 Apache-2.0 | — | 5k | multi-pod log tail (borderline: often local) |
+| [x] | kube-vip | kube-vip/kube-vip | 🟢 Apache-2.0 | — | 3k | control-plane VIP + LB for bare metal — shipped; runs as root (NET_ADMIN/NET_RAW for netlink+ARP) |
 
 ## Tier 3 — high demand, heavier builds (deliberate; fills thin DB/proxy/app categories)
 
@@ -72,6 +76,7 @@ by effort. Fills the catalog's thinnest categories (databases, proxies, apps).
 | [ ] | kvrocks | apache/kvrocks | 🟢 Apache-2.0 | C++ | 3.5M | 4k | Redis-on-RocksDB |
 | [x] | patroni | patroni/patroni | 🟢 MIT | Python | — | 9k | Postgres HA — shipped; first Python-daemon pattern |
 | [ ] | woodpecker | woodpecker-ci/woodpecker | 🟢 Apache-2.0 | Go+frontend | 2.7M | 7k | CI server (has web UI) |
+| [x] | zipkin | openzipkin/zipkin | 🟢 Apache-2.0 | JVM-jlink | 60M | 17k | distributed tracing — shipped; Spring Boot fat jar EXPLODED so its 157 bundled jars are scannable/patchable |
 
 ## Deferred / heavier efforts (own project, not a batch)
 
@@ -111,7 +116,8 @@ Policy filter = buildable under the shell-less/minimal thesis: ✅ static-Go bin
 C daemon (no *runtime* compiler — the varnish lesson) · JVM-jlink · interpreter ·
 binary-repackage. Excluded from the 100-path: frontend-in-bwrap (grafana/argocd/uptime-kuma),
 runtime-compiler (varnish), tangled force-bump graphs, huge-disk C++ (clickhouse), and
-🔴 SSPL/BUSL/EULA. At the current 96-image catalog, 4 images remain to reach 100.
+🔴 SSPL/BUSL/EULA. This section is a completed build log — the 100 target was reached and
+the catalog now stands at 108.
 
 ### Batch F — static Go (the crank) → 88   [DONE]
 | Image | Upstream | License | Build notes |

--- a/images/kube-vip/apko/kube-vip-dev.yaml
+++ b/images/kube-vip/apko/kube-vip-dev.yaml
@@ -1,0 +1,51 @@
+# Development variant of minimal-kube-vip.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - kube-vip
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+    # Network troubleshooting — the whole point of this image is manipulating
+    # interfaces and ARP, so the dev variant carries the tools to inspect that.
+    - iproute2
+    - iputils
+
+# Root for the same reason as prod (netlink / ARP / BGP need CAP_NET_ADMIN and
+# CAP_NET_RAW, which Kubernetes only grants to uid 0 without file or ambient
+# caps). See the comment in kube-vip.yaml.
+accounts:
+  run-as: 0
+
+entrypoint:
+  command: /usr/bin/kube-vip
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-kube-vip-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-kube-vip: same kube-vip + shell + curl/openssl/dig/jq/git/ip. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/kube-vip"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/kube-vip/apko/kube-vip.yaml
+++ b/images/kube-vip/apko/kube-vip.yaml
@@ -1,0 +1,63 @@
+# Minimal kube-vip image - Kubernetes control-plane VIP / load balancer,
+# built from source via melange.
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - kube-vip
+    - ca-certificates-bundle
+
+# Runs as ROOT — deliberate, and the "unless the service genuinely needs it"
+# exception in docs/onboarding.md.
+#
+# `kube-vip manager` does raw network work: it adds and removes the virtual IP
+# on a host interface (netlink), answers ARP for it, and optionally speaks BGP
+# and adjusts nftables. That needs CAP_NET_ADMIN and CAP_NET_RAW.
+#
+# Dropping to a nonroot uid does NOT work here even when the caps are granted.
+# Kubernetes puts securityContext capabilities into the container's bounding
+# and permitted sets only for uid 0; for any other uid the permitted set comes
+# up empty unless the binary carries file capabilities or ambient caps are set,
+# neither of which apko can author. A nonroot kube-vip therefore starts and
+# then fails at the first netlink call — the failure is at VIP-assignment time,
+# not at boot, which makes it especially unpleasant to debug.
+#
+# Upstream ships the same way. Deploy it with an explicit capability set rather
+# than as a privileged container:
+#
+#   securityContext:
+#     capabilities:
+#       add: ["NET_ADMIN", "NET_RAW"]
+#
+# The read-only manifest/sample subcommands need none of this and run fine
+# under any uid you override with.
+accounts:
+  run-as: 0
+
+# No default subcommand: kube-vip is multi-mode (manager / manifest / sample /
+# kubeadm) and `manager` requires flags describing the interface, VIP and
+# election mode, which cannot be guessed. Supply the subcommand as container
+# args, as upstream's static-pod manifest does.
+entrypoint:
+  command: /usr/bin/kube-vip
+
+environment:
+  PATH: /usr/bin:/bin
+
+annotations:
+  org.opencontainers.image.title: "minimal-kube-vip"
+  org.opencontainers.image.description: "Hardened shell-less kube-vip Kubernetes control-plane VIP and load balancer built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/kube-vip"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/kube-vip/melange.yaml
+++ b/images/kube-vip/melange.yaml
@@ -1,0 +1,89 @@
+# Melange build configuration for minimal kube-vip
+# Pure Go from source. Single static `kube-vip` binary — provides a virtual IP
+# and load balancer for the Kubernetes control plane (and optionally for
+# LoadBalancer Services) on bare metal, without an external LB appliance.
+# License: Apache-2.0 (the kube-vip authors).
+
+package:
+  # Named `kube-vip` (not `kube-vip-minimal`) so vulnerability scanners can
+  # identify it. Syft derives a package's CPE from its apk name, and every CPE
+  # it generated kept -minimal in the product field
+  # (cpe:2.3:a:kube-vip:kube-vip-minimal:*, ...). NVD indexes this product
+  # bare, so none of them matched.
+  name: kube-vip
+  version: 1.2.3
+  epoch: 0
+  description: "Minimal kube-vip Kubernetes control-plane VIP and load balancer built from source"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    # apko resolves a top-level package name across ALL repositories and picks
+    # the highest version — it does not prefer our local repo (apko v1.1.6
+    # pkg/apk/apk/repo.go, comparePackages: `compare` is nil for a top-level
+    # request, so the repository-matching tiebreak never runs). Wolfi ships a
+    # bare `kube-vip`, so without this apk could install Wolfi's build instead
+    # of this source-built one. provider-priority is evaluated BEFORE version
+    # in that comparator, so this pins resolution to our package permanently.
+    provider-priority: 100
+
+vars:
+  # SHA256 of kube-vip source tarball - updated by update-versions.yml workflow
+  sha256: 5a694c8444cf866216e9d25e745ef998d527e3c4e71ee99554340d5443879f3b
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      # go-1.27 is safe here despite k8s.io/kube-openapi being in the module
+      # graph. That module is what forced descheduler down to go-1.26: its
+      # vendored go-json-experiment copy calls encoding/json/v2 APIs
+      # (json.SkipFunc, json.DiscardUnknownMembers) that go1.27 removed.
+      # kube-vip only carries it as an INDIRECT dependency and never imports
+      # the offending package, so `go build .` never compiles it. Verified by
+      # building green on go-1.27 (2026-08-29). If a future release starts
+      # importing it, the build fails loudly here — drop to go-1.26 then, as
+      # descheduler did.
+      - go-1.27
+      - git
+
+pipeline:
+  # Download and verify kube-vip source
+  - runs: |
+      mkdir -p /home/build/kube-vip-${{package.version}}
+      curl -fsSL --retry 8 --retry-all-errors \
+        "https://github.com/kube-vip/kube-vip/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/kube-vip.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/kube-vip.tar.gz" | sha256sum -c -
+
+      tar xzf /home/build/kube-vip.tar.gz -C /home/build/kube-vip-${{package.version}} --strip-components=1
+      rm /home/build/kube-vip.tar.gz
+
+  # Version is reported via main.Version (see upstream Makefile LDFLAGS); the
+  # main package is at the repo root, not under cmd/. CGO_ENABLED=0 gives a
+  # static binary — upstream passes -extldflags -static for the same reason.
+  - runs: |
+      cd /home/build/kube-vip-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -ldflags="-s -w -buildid= -X main.Version=v${{package.version}}" \
+        -o /home/build/kube-vip-bin \
+        .
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/kube-vip-bin "${{targets.destdir}}/usr/bin/kube-vip"
+      chmod 0755 "${{targets.destdir}}/usr/bin/kube-vip"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying kube-vip binary..."
+      "${{targets.destdir}}/usr/bin/kube-vip" version

--- a/images/kube-vip/test-dev.sh
+++ b/images/kube-vip/test-dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Smoke test for minimal-kube-vip-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing kube-vip version (parity with prod)..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qE 'Version: +v?1\.[0-9]+\.[0-9]+'
+
+echo "Testing kube-vip manifest generation (parity with prod)..."
+docker run --rm "$IMAGE" manifest pod \
+  --interface eth0 --address 192.168.0.40 --controlplane --arp 2>&1 | grep -q 'kind: Pod'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "Testing ip(8) present (network debugging)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "ip -V" | grep -qi 'iproute2'
+
+echo "All kube-vip-dev tests passed!"

--- a/images/kube-vip/test.sh
+++ b/images/kube-vip/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing kube-vip version..."
+docker run --rm "$IMAGE" version 2>&1 | grep -qE 'Version: +v?1\.[0-9]+\.[0-9]+'
+
+echo "Testing kube-vip generates a static pod manifest..."
+# Real work, no cluster needed: `manifest pod` renders the static-pod YAML that
+# kubeadm drops into /etc/kubernetes/manifests. Exercises cobra wiring, the
+# config struct and the manifest renderer — a binary that links but cannot run
+# fails here rather than silently passing a --version check.
+out=$(docker run --rm "$IMAGE" manifest pod \
+        --interface eth0 \
+        --address 192.168.0.40 \
+        --controlplane \
+        --arp \
+        --leaderElection 2>&1)
+printf '%s' "$out" | grep -q 'kind: Pod'
+printf '%s' "$out" | grep -q 'name: kube-vip'
+printf '%s' "$out" | grep -q 'value: eth0'
+printf '%s' "$out" | grep -q '192.168.0.40'
+echo "kube-vip pod manifest OK"
+
+echo "Testing kube-vip generates a daemonset manifest..."
+docker run --rm "$IMAGE" manifest daemonset \
+  --interface eth0 \
+  --address 192.168.0.40 \
+  --services \
+  --inCluster 2>&1 | grep -q 'kind: DaemonSet'
+echo "kube-vip daemonset manifest OK"
+
+echo "Testing kube-vip manager fails cleanly without a kubeconfig..."
+# The manager cannot reach an API server here. It must exit with an error
+# rather than hang or crash — confirms the runtime path is actually reached.
+docker run --rm "$IMAGE" manager --interface lo --address 127.0.0.1 2>&1 \
+  | grep -qiE 'kubernetes|kubeconfig|connection refused|no such file|unable|error' \
+  && echo "kube-vip manager error handling OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All kube-vip tests passed!"

--- a/images/zipkin/apko/zipkin-dev.yaml
+++ b/images/zipkin/apko/zipkin-dev.yaml
@@ -1,0 +1,74 @@
+# Development variant of minimal-zipkin.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - zipkin
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Exploded Spring Boot launch. `-cp /opt/zipkin` (not `-jar`) is what runs an
+# unpacked archive; the launcher then scans BOOT-INF/lib for dependencies.
+# Verified from a foreign working directory, so this does not depend on cwd.
+entrypoint:
+  command: /usr/bin/java -cp /opt/zipkin org.springframework.boot.loader.launch.JarLauncher
+
+environment:
+  JAVA_HOME: /usr/lib/jvm/java-21-minimal
+  PATH: /usr/lib/jvm/java-21-minimal/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  # In-memory storage by default: no external dependency, so the image is
+  # useful the moment it starts. Set STORAGE_TYPE=elasticsearch/mysql/cassandra3
+  # (plus that backend's env vars) for anything persistent — in-memory spans are
+  # lost on restart and bounded by heap.
+  STORAGE_TYPE: mem
+  # 9411 is Zipkin's registered port for both the API and the UI. Above 1024,
+  # so it binds fine as nonroot.
+  SERVER_PORT: "9411"
+  # Container-aware heap sizing; the JVM otherwise reads the host's RAM.
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=75.0"
+
+paths:
+  # Spring Boot and the JVM both want a writable temp dir; the image runs
+  # nonroot, so it must be world-writable + sticky like a normal /tmp.
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-zipkin-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-zipkin: same Zipkin + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/zipkin"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/zipkin/apko/zipkin.yaml
+++ b/images/zipkin/apko/zipkin.yaml
@@ -1,0 +1,65 @@
+# Minimal Zipkin image - distributed tracing server, official exec jar exploded
+# onto a custom jlink JRE via melange.
+# Shell-less, distroless. CVE patching via daily rebuilds + bundled-jar swaps.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - zipkin
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# Exploded Spring Boot launch. `-cp /opt/zipkin` (not `-jar`) is what runs an
+# unpacked archive; the launcher then scans BOOT-INF/lib for dependencies.
+# Verified from a foreign working directory, so this does not depend on cwd.
+entrypoint:
+  command: /usr/bin/java -cp /opt/zipkin org.springframework.boot.loader.launch.JarLauncher
+
+environment:
+  JAVA_HOME: /usr/lib/jvm/java-21-minimal
+  PATH: /usr/lib/jvm/java-21-minimal/bin:/usr/bin:/bin
+  # In-memory storage by default: no external dependency, so the image is
+  # useful the moment it starts. Set STORAGE_TYPE=elasticsearch/mysql/cassandra3
+  # (plus that backend's env vars) for anything persistent — in-memory spans are
+  # lost on restart and bounded by heap.
+  STORAGE_TYPE: mem
+  # 9411 is Zipkin's registered port for both the API and the UI. Above 1024,
+  # so it binds fine as nonroot.
+  SERVER_PORT: "9411"
+  # Container-aware heap sizing; the JVM otherwise reads the host's RAM.
+  JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=75.0"
+
+paths:
+  # Spring Boot and the JVM both want a writable temp dir; the image runs
+  # nonroot, so it must be world-writable + sticky like a normal /tmp.
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-zipkin"
+  org.opencontainers.image.description: "Hardened shell-less Zipkin distributed tracing server on a custom jlink JRE with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/zipkin"
+  org.opencontainers.image.licenses: "Apache-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/zipkin/melange.yaml
+++ b/images/zipkin/melange.yaml
@@ -1,0 +1,175 @@
+# Melange build configuration for minimal Zipkin
+# Official Spring Boot executable jar + custom JRE via jlink (solr/kafka JVM
+# pattern). Zipkin is a distributed tracing system: it collects, stores and
+# queries spans, and serves the trace-explorer UI.
+# License: Apache-2.0 (the OpenZipkin authors).
+#
+# Upstream publishes ONLY a fat "exec" jar to Maven Central — there is no
+# binary tarball and no exploded distribution — so that jar is the source of
+# record here, as jenkins.war is for jenkins.
+#
+# The jar is UNPACKED at build time rather than shipped whole. That is the
+# whole point: a Spring Boot fat jar nests its 157 dependency jars inside
+# BOOT-INF/lib/ *within* the outer archive, where neither syft nor the
+# bundled-jar patcher can see them — every one of those CVEs would be invisible
+# and unfixable. Exploded, each is an ordinary file on disk: syft inventories
+# them and .github/patch-deps.yaml can swap a vulnerable one for its fixed
+# release.
+#
+# Running exploded is a supported Spring Boot mode (`java -cp <dir>
+# org.springframework.boot.loader.launch.JarLauncher`). Verified 2026-08-29 on
+# the jlinked JRE below: boots, /health reports UP, /api/v2/services responds.
+#
+# The launcher resolves BOOT-INF/lib by SCANNING the directory, not by reading
+# BOOT-INF/classpath.idx. Verified by experiment: renaming
+# jackson-databind-2.21.2.jar still boots, while deleting it fails with
+# `NoClassDefFoundError: com/fasterxml/jackson/databind/Module`. So the jar is
+# genuinely load-bearing and a rename is still resolved — which is what makes
+# `strategy: rename` safe for this image in .github/patch-deps.yaml. Do not
+# switch it to keep-filename on the assumption that classpath.idx is strict.
+
+package:
+  # Named `zipkin` (not `zipkin-minimal`) so vulnerability scanners can
+  # identify it. Syft derives a package's CPE from its apk name, and a
+  # -minimal suffix lands in the CPE product field
+  # (cpe:2.3:a:zipkin:zipkin-minimal:*, ...), which NVD does not index — so
+  # none of the CPEs would match.
+  name: zipkin
+  version: 3.6.1
+  epoch: 0
+  description: "Minimal Zipkin distributed tracing server with custom JRE (jlink)"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    # apko resolves a top-level package name across ALL repositories and picks
+    # the highest version — it does not prefer our local repo (apko v1.1.6
+    # pkg/apk/apk/repo.go, comparePackages: `compare` is nil for a top-level
+    # request, so the repository-matching tiebreak never runs). Wolfi ships a
+    # bare `zipkin` TODAY (3.5.1-r14 as of 2026-08-29), so without this apk
+    # could install Wolfi's build instead of this source-built one.
+    # provider-priority is evaluated BEFORE version in that comparator, so this
+    # pins resolution to our package permanently — and keeps doing so even if
+    # Wolfi's version overtakes ours.
+    #
+    # Sharing the name with a Wolfi package also means grype's apk-matcher
+    # attributes Wolfi's `zipkin` advisories to our apk: it keys on
+    # distro+name+version only, so every CVE fixed in a Wolfi rebuild lands on
+    # our r0 as a name-collision artifact (130 of 213 matches on the first
+    # scan, "fixed in 3.6.1-r6/-r10"). Those are claims about Wolfi's package,
+    # not findings in this image, and .github/scripts/reconcile-apk-provenance.sh
+    # is what separates them from the real bundled-jar findings.
+    provider-priority: 100
+
+vars:
+  # SHA256 of zipkin-server-{version}-exec.jar - updated by update-versions.yml
+  sha256: d8326e0ed4f43855dba81228f688554706e52578a7c782d9a90b73f8680654a1
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      # Full JDK 21 needed for jlink (build-time only). The jar targets Java 17
+      # (MANIFEST Java-Version: 17), so 21 satisfies it with room to spare.
+      - openjdk-21-default-jdk
+      - openjdk-21-jmods
+      # binutils provides objcopy required by jlink --strip-debug
+      - binutils
+
+pipeline:
+  # Download and verify the official executable jar.
+  #
+  # Mirror rotation BEFORE widening the wait: repo1.maven.org and
+  # repo.maven.apache.org both sit behind Cloudflare, so a WAF 403 refuses
+  # both; the googleapis mirror is separate infrastructure. Waiting one host
+  # out demonstrably does not work (solr burned 9 attempts over 4m15s on
+  # 2026-08-26 and still failed on an artifact that served fine minutes later).
+  - runs: |
+      mkdir -p /home/build
+      _ZK_MIRRORS="https://repo1.maven.org/maven2 https://maven-central.storage-download.googleapis.com/maven2 https://repo.maven.apache.org/maven2"
+      _path="io/zipkin/zipkin-server/${{package.version}}/zipkin-server-${{package.version}}-exec.jar"
+      ok=0
+      for _r in 1 2 3 4; do
+        for _b in $_ZK_MIRRORS; do
+          if curl -fsSL --connect-timeout 15 --max-time 900 \
+               --retry 2 --retry-all-errors "$_b/$_path" -o /home/build/zipkin-exec.jar; then
+            ok=1; break
+          fi
+        done
+        [ "$ok" = 1 ] && break
+        [ "$_r" -lt 4 ] && sleep $(( _r * 30 ))
+      done
+      [ "$ok" = 1 ] || { echo "ERROR: all Maven mirrors refused $_path"; exit 1; }
+
+      echo "${{vars.sha256}}  /home/build/zipkin-exec.jar" | sha256sum -c -
+
+  # Explode the fat jar so every bundled dependency is a real file on disk.
+  # See the header: this is what makes the 157 nested jars scannable and
+  # patchable instead of invisible.
+  - runs: |
+      mkdir -p /home/build/zipkin-exploded
+      cd /home/build/zipkin-exploded
+      # busybox unzip is present; the jar is a plain zip.
+      unzip -qq /home/build/zipkin-exec.jar
+      rm -f /home/build/zipkin-exec.jar
+
+      # Fail loudly if the archive shape changed — a silently empty BOOT-INF
+      # would produce an image that only fails at boot.
+      [ -d BOOT-INF/lib ] || { echo "ERROR: BOOT-INF/lib missing"; exit 1; }
+      [ -d BOOT-INF/classes ] || { echo "ERROR: BOOT-INF/classes missing"; exit 1; }
+      [ -d org/springframework/boot/loader ] || { echo "ERROR: Spring Boot loader missing"; exit 1; }
+      n=$(find BOOT-INF/lib -name '*.jar' | wc -l)
+      echo "bundled jars: $n"
+      [ "$n" -gt 100 ] || { echo "ERROR: only $n bundled jars, expected >100"; exit 1; }
+
+  # Custom minimal JRE (Java 21). Module set verified 2026-08-29 by booting
+  # this exact exploded layout on a JRE jlinked with precisely these modules:
+  # Spring Boot + Armeria need the servlet/HTTP stack (java.net.http,
+  # jdk.httpserver), broad reflection (java.desktop for java.beans,
+  # java.instrument), crypto + jgss/sasl for TLS/auth, management(.agent)/jfr
+  # for JMX and observability endpoints, java.sql + java.transaction.xa for the
+  # JDBC storage backends, jdk.unsupported for Netty's sun.misc.Unsafe use,
+  # and java.prefs which Spring pulls in during context refresh.
+  - runs: |
+      JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+      $JAVA_HOME/bin/jlink \
+        --module-path $JAVA_HOME/jmods \
+        --add-modules java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.transaction.xa,java.xml,java.xml.crypto,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.httpserver,jdk.jfr,jdk.management,jdk.management.agent,jdk.naming.dns,jdk.net,jdk.security.auth,jdk.unsupported,jdk.zipfs \
+        --strip-debug \
+        --no-man-pages \
+        --no-header-files \
+        --compress=zip-6 \
+        --output /home/build/custom-jre
+
+  - runs: |
+      # Custom JRE
+      mkdir -p "${{targets.destdir}}/usr/lib/jvm/java-21-minimal"
+      cp -a /home/build/custom-jre/* "${{targets.destdir}}/usr/lib/jvm/java-21-minimal/"
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      # Relative symlink: an absolute one dangles during melange's verify step,
+      # which runs against destdir rather than a mounted root.
+      ln -sf ../lib/jvm/java-21-minimal/bin/java "${{targets.destdir}}/usr/bin/java"
+
+      # Exploded Zipkin
+      mkdir -p "${{targets.destdir}}/opt/zipkin"
+      cp -a /home/build/zipkin-exploded/. "${{targets.destdir}}/opt/zipkin/"
+
+  # Verify the build. Use the direct JRE path, not /usr/bin/java — that is a
+  # symlink which does not resolve inside destdir at verify time.
+  - runs: |
+      echo "Verifying custom JRE..."
+      "${{targets.destdir}}/usr/lib/jvm/java-21-minimal/bin/java" -version
+
+      echo "Verifying exploded Zipkin layout..."
+      test -f "${{targets.destdir}}/opt/zipkin/BOOT-INF/classpath.idx"
+      test -d "${{targets.destdir}}/opt/zipkin/BOOT-INF/classes/zipkin"
+      ls "${{targets.destdir}}/opt/zipkin/BOOT-INF/lib"/*.jar >/dev/null
+      echo "bundled jars: $(find "${{targets.destdir}}/opt/zipkin/BOOT-INF/lib" -name '*.jar' | wc -l)"
+
+      echo "Verifying the launcher class is present..."
+      test -f "${{targets.destdir}}/opt/zipkin/org/springframework/boot/loader/launch/JarLauncher.class"

--- a/images/zipkin/test-dev.sh
+++ b/images/zipkin/test-dev.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Smoke test for minimal-zipkin-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing java runtime (parity with prod)..."
+docker run --rm --entrypoint /usr/bin/java "$IMAGE" -version 2>&1 | grep -qE 'openjdk version "21'
+
+echo "Testing exploded layout (bundled jars are real files on disk)..."
+# The dev variant HAS a shell, so it can assert directly what prod can only
+# prove indirectly by booting: the fat jar was unpacked, so syft and the
+# bundled-jar patcher can see every dependency.
+n=$(docker run --rm --entrypoint /bin/sh "$IMAGE" -c 'ls /opt/zipkin/BOOT-INF/lib/*.jar | wc -l')
+echo "  bundled jars: $n"
+[ "$n" -gt 100 ] || { echo "FAIL: only $n bundled jars — fat jar not exploded?"; exit 1; }
+docker run --rm --entrypoint /bin/sh "$IMAGE" \
+  -c 'test -f /opt/zipkin/org/springframework/boot/loader/launch/JarLauncher.class'
+
+echo "Booting Zipkin and probing /health (parity with prod)..."
+CID=$(docker run -d --rm -p 19412:9411 "$IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+ok=""
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 3 http://127.0.0.1:19412/health 2>/dev/null | grep -q '"status" : "UP"'; then
+    ok=1; break
+  fi
+  docker inspect -f '{{.State.Running}}' "$CID" 2>/dev/null | grep -q true || break
+  sleep 2
+done
+[ -n "$ok" ] || { echo "FAIL: Zipkin did not become healthy"; docker logs "$CID" 2>&1 | tail -40; exit 1; }
+echo "Zipkin /health UP"
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "All zipkin-dev tests passed!"

--- a/images/zipkin/test.sh
+++ b/images/zipkin/test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing java runtime..."
+docker run --rm --entrypoint /usr/bin/java "$IMAGE" -version 2>&1 | grep -qE 'openjdk version "21'
+
+echo "Booting Zipkin and probing /health..."
+# Full runtime probe. Exercises the exploded Spring Boot launch, the jlink
+# module set, and the in-memory storage backend. This is also the safety net
+# that lets bundled-jar swaps run in `auto` policy: a swap that breaks the
+# classpath fails CI here instead of shipping.
+CID=$(docker run -d --rm -p 19411:9411 "$IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+ok=""
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 3 http://127.0.0.1:19411/health 2>/dev/null | grep -q '"status"'; then
+    ok=1; break
+  fi
+  docker inspect -f '{{.State.Running}}' "$CID" 2>/dev/null | grep -q true || break
+  sleep 2
+done
+[ -n "$ok" ] || { echo "FAIL: Zipkin did not become healthy"; docker logs "$CID" 2>&1 | tail -40; exit 1; }
+
+curl -fsS --max-time 5 http://127.0.0.1:19411/health | grep -q '"status" : "UP"' \
+  || { echo "FAIL: /health did not report UP"; exit 1; }
+echo "Zipkin /health UP"
+
+echo "Testing the trace query API..."
+curl -fsS --max-time 5 http://127.0.0.1:19411/api/v2/services | grep -q '\[' \
+  || { echo "FAIL: /api/v2/services did not return JSON"; exit 1; }
+echo "Zipkin query API OK"
+
+echo "Testing span ingestion round-trip..."
+# POST a span, then read it back by service name — proves the collector,
+# storage backend and query API are all actually wired, not just listening.
+curl -fsS --max-time 5 -X POST http://127.0.0.1:19411/api/v2/spans \
+  -H 'Content-Type: application/json' \
+  -d '[{"traceId":"1111111111111111","id":"2222222222222222","name":"smoke","timestamp":1600000000000000,"duration":1000,"localEndpoint":{"serviceName":"smoketest"}}]' \
+  >/dev/null
+
+found=""
+for _ in $(seq 1 15); do
+  if curl -fsS --max-time 5 http://127.0.0.1:19411/api/v2/services | grep -q 'smoketest'; then
+    found=1; break
+  fi
+  sleep 1
+done
+[ -n "$found" ] || { echo "FAIL: ingested span never appeared in /api/v2/services"; docker logs "$CID" 2>&1 | tail -20; exit 1; }
+echo "Zipkin span ingestion round-trip OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All zipkin tests passed!"

--- a/vex/kube-vip.openvex.json
+++ b/vex/kube-vip.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/kube-vip",
+  "author": "rtvkiz",
+  "timestamp": "2026-08-29T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/zipkin.openvex.json
+++ b/vex/zipkin.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/zipkin",
+  "author": "rtvkiz",
+  "timestamp": "2026-08-29T00:00:00Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Adds two images, taking the catalog to **108**.

## kube-vip 1.2.3 — control-plane VIP + load balancer
Static Go build from source (Apache-2.0).

**Runs as root, deliberately.** `kube-vip manager` does netlink/ARP/BGP work needing `CAP_NET_ADMIN` + `CAP_NET_RAW`. Kubernetes only puts securityContext capabilities into the *permitted* set for uid 0 — for any other uid it comes up empty unless the binary has file caps or ambient caps are set, and apko can author neither. A nonroot build would start fine and then fail at VIP-assignment time, which is a miserable failure mode to debug. Deploy with an explicit capability set rather than `privileged`.

**Pinned to `go-1.27`** even though `k8s.io/kube-openapi` is in the module graph — the dependency that forced descheduler down to go-1.26. Here it is only *indirect* and never imported, so the `encoding/json/v2` removal never compiles. Verified green; documented in the recipe so nobody re-derives it.

## zipkin 3.6.1 — distributed tracing (JVM-jlink)
Upstream publishes **only** a Spring Boot fat jar — no tarball — so that jar is the source of record, as `jenkins.war` is for jenkins.

**The jar is exploded at build time rather than shipped whole.** Nested inside the archive, its 157 dependency jars are invisible to syft and unreachable by the bundled-jar patcher — every one of those CVEs would be both unseen and unfixable. Exploded, syft reports **163 java-archive artifacts** and each becomes patchable.

Three assumptions were verified *before* the recipe was written:
- exploded launch works on the jlinked JRE from a foreign cwd (`/health` UP, API responds)
- renaming a bundled jar still boots → the launcher scans `BOOT-INF/lib`, `classpath.idx` is not strict
- deleting that same jar fails with `NoClassDefFoundError` → the rename test was genuinely discriminating, so `strategy: rename` is safe

**zipkin starts `report-only`** for bundled-jar patching. Its smoke test clears the documented promotion bar (boots, plus a span ingest → query round-trip), but it bundles the same tightly coupled Spring/Jackson/Netty families that broke cassandra and kafka in #608 — the lift still cannot fall back to a newest-in-series version. Promote to `auto` once that is fixed.

### On zipkin's CVE numbers
First scan: 213 raw matches. The provenance reconciler withholds **69** as apk name-collision artifacts (Wolfi ships its own `zipkin`, currently 3.5.1-r14, so its advisories attach to our `3.6.1-r0` by name) — including 5 of the 7 criticals. That leaves **144 counted**, 2 critical, across 27 distinct fixable bundled artifacts (netty-codec-http, jackson-databind, bcprov, amqp-client, log4j-core…).

That is the normal pre-patch state for a Spring Boot fat app and comparable to what solr/flink/jenkins looked like before the jar patcher reached them — but because zipkin is report-only, these will **not** auto-clear yet. Flagging explicitly since it moves the catalog's headline totals.

## Validation
Both images, prod **and** dev, built and smoke-tested locally on x86_64:
- `make kube-vip` / `make test-kube-vip` — version, static-pod + daemonset manifest generation, clean failure without kubeconfig, no-shell
- `make zipkin` / `make test-zipkin` — boots, `/health` UP, query API, span ingest → query round-trip, no-shell
- dev variants built via apko and tested

Gates green: `check-docs`, `check-autoupdate`, `check-curl-retries`, `lint-workflows`.

**aarch64 is unvalidated locally** (never possible) — that is what this PR is for. Merge on green.

Also corrects `docs/roadmap.md`, which still claimed 96/100 — stale since well before this change.