### PR TITLE
fix(toolchain): stop the repair loop deadlocking on retry branches

### DIFF
--- a/.github/scripts/repair-toolchain-pr.sh
+++ b/.github/scripts/repair-toolchain-pr.sh
@@ -37,9 +37,14 @@ MAX_REVERT_SHARE=50
 
 echo "Repairing $BRANCH from failed run $RUN_ID"
 
-bumped=$(git diff --name-only "origin/main...HEAD" -- images/ | wc -l)
+# Count distinct IMAGES, not changed files. An image whose bump touches two
+# files would otherwise inflate the denominator of the share guard below and
+# make a genuine incompatibility look like a bad toolchain release.
+mapfile -t BUMPED_IMAGES < <(git diff --name-only "origin/main...HEAD" -- images/ \
+  | sed -n 's#^images/\([^/]*\)/.*#\1#p' | sort -u)
+bumped=${#BUMPED_IMAGES[@]}
 [ "$bumped" -gt 0 ] || { echo "branch has no image changes; nothing to repair"; exit 0; }
-echo "  images bumped on this branch: $bumped"
+echo "  images bumped on this branch: $bumped (${BUMPED_IMAGES[*]})"
 
 # Collect every failed job, resolve it to an image, and classify its log.
 tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
@@ -172,6 +177,24 @@ fi
 n_revert=$(printf '%s\n' "$REVERT" | wc -w)
 share=$(( n_revert * 100 / bumped ))
 echo "  compile failures: $n_revert/$bumped (${share}%)"
+
+# Every bumped image failed, so there is nothing left to keep — reverting them
+# all would just reproduce main. That is NOT a verdict on the toolchain release.
+# On a RETRY branch the bumped set is only the images held back last time, so
+# "all of them still fail" is the expected outcome while upstream catches up.
+#
+# This must be decided BEFORE the share guard below. Testing share first meant a
+# retry branch always tripped "too-many-failures" (2/2 = 100%) and asked a human
+# to judge a release that nothing is actually wrong with, when the real answer is
+# "nothing to revert, wait for the next one". That is what left PR #629
+# (go-1.27, holding trivy + descheduler) permanently red while re-running a
+# 13-minute build every ~4h on the auto-update-PR-branches schedule.
+if [ "$n_revert" -ge "$bumped" ]; then
+  echo "Every bumped image failed to compile — nothing advances. Closing the PR."
+  { echo "repaired=false"; echo "reason=nothing-advances"; } >> "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
+fi
+
 if [ "$share" -gt "$MAX_REVERT_SHARE" ]; then
   echo "More than ${MAX_REVERT_SHARE}% of bumped images fail to compile — the toolchain"
   echo "release looks bad, not the images. Not auto-reverting; leaving this for review."

--- a/.github/workflows/repair-toolchain-pr.yml
+++ b/.github/workflows/repair-toolchain-pr.yml
@@ -118,8 +118,21 @@ jobs:
             too-many-failures)
               MSG="More than half the bumped images fail to compile on this toolchain. That points at the release rather than the images, so nothing was auto-reverted — this one needs a human decision about whether to adopt it at all." ;;
             nothing-advances)
-              MSG="Every bumped image failed to compile, so the branch would be identical to main. Nothing to merge; this bump should be retried on the next toolchain release." ;;
+              MSG="Every bumped image failed to compile, so the branch would be identical to main. Nothing to merge; closing. The bump is retried automatically on the next toolchain release." ;;
             *)
               MSG="No automatic repair was applied (${REASON})." ;;
           esac
           gh pr comment "$PR_URL" --body "$MSG"
+
+          # Only "nothing advances" is terminal for THIS branch: the bump had
+          # nothing left to offer, so leaving the PR open just re-runs a full
+          # image build on every auto-update-PR-branches tick and keeps a red PR
+          # on the board forever (go-1.27 did exactly that). update-wolfi-packages
+          # force-pushes the branch and reopens a PR on the next toolchain
+          # release, so closing here is how the loop returns to normal.
+          #
+          # The other reasons stay open on purpose: no-build-failures wants a
+          # retry, and too-many-failures is waiting on a human decision.
+          if [ "$REASON" = "nothing-advances" ]; then
+            gh pr close "$PR_URL" --delete-branch
+          fi


### PR DESCRIPTION
The self-healing toolchain loop has been stuck since the go-1.27 bump. PR #629 has been red and re-running a ~13-minute full image build every ~4h without ever converging.

## What was actually wrong

Two separate things, only one of them ours.

**Upstream (expected, not a bug).** `trivy` and `descheduler` genuinely do not compile on Go 1.27:

```
trivy       pkg/x/json/json.go:109:16: undefined: json.SkipFunc
descheduler vendor/k8s.io/kube-openapi/.../json/alias.go:618:21: undefined: json.SkipFunc
                                                     :957:14: undefined: json.DiscardUnknownMembers
```

Both reach `encoding/json/v2` symbols that 1.27 changed. `images/trivy/melange.yaml` already documents exactly this. The other 66 pins are on go-1.27 and building fine, so the release itself is good.

**Ours (the real bug).** `repair-toolchain-pr.sh` guards against auto-reverting the catalogue: if more than 50% of bumped images fail to compile, blame the release rather than the images and stop for a human.

That guard assumes the bump branch carries the whole catalogue. **On a retry branch it does not** — the bumped set is only the images held back last time, so any remaining failure is >=50% by construction:

```
images bumped on this branch: 2
compile failures: 2/2 (100%)
More than 50% of bumped images fail to compile - the toolchain
release looks bad, not the images. Not auto-reverting; leaving this for review.
```

The loop asked for a human decision that was not needed. The correct verdict was `nothing-advances` (nothing to revert, close and wait for the next release) — but that check ran *after* the share guard, so it was never reached. And `nothing-advances` printed "Closing the PR" while nothing ever closed anything.

## Changes

- Decide `nothing-advances` **before** the share guard. If every bumped image failed there is nothing to revert and no catalogue-wide risk, so the answer is close-and-wait, not escalate.
- Count distinct **images** rather than changed files, so a bump touching two files in one image cannot skew the denominator.
- Actually `gh pr close --delete-branch` on `nothing-advances`. `update-wolfi-packages` force-pushes the branch and reopens a PR on the next toolchain release, so this is how the loop returns to normal. The other two reasons stay open on purpose: `no-build-failures` wants a retry, `too-many-failures` is waiting on a human.

## The guard is preserved

| n_revert / bumped | verdict |
|---|---|
| 2/2 (the go-1.27 case) | nothing-advances -> close |
| 1/2 | revert + push |
| 40/60 | too-many-failures -> human |
| 3/60 | revert + push |
| 60/60 | nothing-advances -> close |

## Validation

- `make lint-workflows` — clean (actionlint + shellcheck, required for any `.github/workflows/**` change)
- `make test-classifier` — 10/10
- `./scripts/check-toolchain-pins.sh` — clean, 96 melange build environments
- `bash -n` + `shellcheck -S error` on the changed script — clean

No image build inputs are touched, so the image build gate does not apply.

## After merge

`repair-toolchain-pr.yml` runs main's tooling (`git restore --source=origin/main -- .github/scripts scripts`), so the next failed build on #629 picks this up, re-classifies as `nothing-advances`, and closes #629 and deletes its branch on its own. go-1.27 is then retried automatically for trivy and descheduler on the next toolchain release.