### PR TITLE
feat(site): structured data, unhidden image content, Bitnami replacement page

### DIFF
--- a/site/public/README-verification.txt
+++ b/site/public/README-verification.txt
@@ -1,0 +1,9 @@
+Search-engine ownership verification files live in this directory.
+
+google555bda5019fa468d.html verifies the minimalcontainers.com property in
+Google Search Console. Google re-checks it periodically, so it must stay
+committed and served at the site root forever — deleting it silently
+un-verifies the property and Search Console stops reporting.
+
+The token is not a secret. It proves control of the site to Google and grants
+nothing to anyone who reads it.

--- a/site/public/google555bda5019fa468d.html
+++ b/site/public/google555bda5019fa468d.html
@@ -1,0 +1,1 @@
+google-site-verification: google555bda5019fa468d.html

--- a/site/src/components/Layout.astro
+++ b/site/src/components/Layout.astro
@@ -6,11 +6,17 @@ export interface Props {
   description?: string;
   /** Set on dated content (blog posts) so search engines see a publish date. */
   published?: string;
+  /** JSON-LD objects for this page. Rendered as one script per entry. */
+  schema?: object[];
+  /** Trail for BreadcrumbList, excluding Home (added here) and the current page. */
+  breadcrumbs?: { name: string; href: string }[];
 }
 const {
   title = 'Minimal Containers — free, hardened container images',
   description = 'Small, hardened, MIT-licensed container images. Cosign-signed, SBOM-attested, with SLSA v1.0 build provenance. No account, no Docker Hub pull limits.',
   published,
+  schema = [],
+  breadcrumbs,
 } = Astro.props;
 const year = new Date().getFullYear();
 
@@ -19,6 +25,25 @@ const year = new Date().getFullYear();
 // one is authoritative instead of leaving it to be guessed.
 const canonical = new URL(Astro.url.pathname, Astro.site).href;
 const ogImage = new URL('/og.png', Astro.site).href;
+
+// BreadcrumbList. Home is always the first crumb and the current page the last,
+// so callers pass only the middle of the trail.
+const crumbs = breadcrumbs && [
+  { name: 'Home', href: '/' },
+  ...breadcrumbs,
+  { name: title, href: Astro.url.pathname },
+];
+const breadcrumbSchema = crumbs && {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: crumbs.map((c, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: c.name,
+    item: new URL(c.href, Astro.site).href,
+  })),
+};
+const allSchema = [...schema, ...(breadcrumbSchema ? [breadcrumbSchema] : [])];
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -39,6 +64,9 @@ const ogImage = new URL('/og.png', Astro.site).href;
   <meta name="twitter:description" content={description} />
   <meta name="twitter:image" content={ogImage} />
   {published && <meta property="article:published_time" content={published} />}
+  {allSchema.map((s) => (
+    <script type="application/ld+json" set:html={JSON.stringify(s)} />
+  ))}
   <link rel="icon" type="image/svg+xml" href="/icon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/site/src/data/bitnami-map.json
+++ b/site/src/data/bitnami-map.json
@@ -1,0 +1,172 @@
+{
+  "pairs": [
+    {
+      "bitnami": "alertmanager",
+      "minimal": "alertmanager"
+    },
+    {
+      "bitnami": "apache",
+      "minimal": "httpd"
+    },
+    {
+      "bitnami": "cassandra",
+      "minimal": "cassandra"
+    },
+    {
+      "bitnami": "consul",
+      "minimal": "consul"
+    },
+    {
+      "bitnami": "etcd",
+      "minimal": "etcd"
+    },
+    {
+      "bitnami": "external-dns",
+      "minimal": "external-dns"
+    },
+    {
+      "bitnami": "fluent-bit",
+      "minimal": "fluent-bit"
+    },
+    {
+      "bitnami": "gitea",
+      "minimal": "gitea"
+    },
+    {
+      "bitnami": "haproxy",
+      "minimal": "haproxy"
+    },
+    {
+      "bitnami": "helm",
+      "minimal": "helm"
+    },
+    {
+      "bitnami": "jenkins",
+      "minimal": "jenkins"
+    },
+    {
+      "bitnami": "kafka",
+      "minimal": "kafka"
+    },
+    {
+      "bitnami": "keycloak",
+      "minimal": "keycloak"
+    },
+    {
+      "bitnami": "kube-state-metrics",
+      "minimal": "kube-state-metrics"
+    },
+    {
+      "bitnami": "kubectl",
+      "minimal": "kubectl"
+    },
+    {
+      "bitnami": "mariadb",
+      "minimal": "mariadb"
+    },
+    {
+      "bitnami": "memcached",
+      "minimal": "memcached"
+    },
+    {
+      "bitnami": "metrics-server",
+      "minimal": "metrics-server"
+    },
+    {
+      "bitnami": "minio",
+      "minimal": "minio"
+    },
+    {
+      "bitnami": "mysql",
+      "minimal": "mysql"
+    },
+    {
+      "bitnami": "nats",
+      "minimal": "nats"
+    },
+    {
+      "bitnami": "nginx",
+      "minimal": "nginx"
+    },
+    {
+      "bitnami": "node",
+      "minimal": "node-slim"
+    },
+    {
+      "bitnami": "node-exporter",
+      "minimal": "node-exporter"
+    },
+    {
+      "bitnami": "oauth2-proxy",
+      "minimal": "oauth2-proxy"
+    },
+    {
+      "bitnami": "opensearch",
+      "minimal": "opensearch"
+    },
+    {
+      "bitnami": "pgbouncer",
+      "minimal": "pgbouncer"
+    },
+    {
+      "bitnami": "php-fpm",
+      "minimal": "php"
+    },
+    {
+      "bitnami": "postgresql",
+      "minimal": "postgres-slim"
+    },
+    {
+      "bitnami": "prometheus",
+      "minimal": "prometheus"
+    },
+    {
+      "bitnami": "python",
+      "minimal": "python"
+    },
+    {
+      "bitnami": "rabbitmq",
+      "minimal": "rabbitmq"
+    },
+    {
+      "bitnami": "redis",
+      "minimal": "redis-slim"
+    },
+    {
+      "bitnami": "ruby",
+      "minimal": "ruby"
+    },
+    {
+      "bitnami": "solr",
+      "minimal": "solr"
+    },
+    {
+      "bitnami": "thanos",
+      "minimal": "thanos"
+    },
+    {
+      "bitnami": "tomcat",
+      "minimal": "tomcat"
+    },
+    {
+      "bitnami": "valkey",
+      "minimal": "valkey"
+    },
+    {
+      "bitnami": "zookeeper",
+      "minimal": "zookeeper"
+    }
+  ],
+  "missing": [
+    "airflow",
+    "clickhouse",
+    "elasticsearch",
+    "git",
+    "grafana",
+    "influxdb",
+    "mongodb",
+    "os-shell",
+    "spark",
+    "wordpress"
+  ]
+}

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -12,8 +12,25 @@ const { Content } = await render(post);
 
 const fmt = (d: string) =>
   new Date(d + 'T00:00:00Z').toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' });
+
+const schema = [{
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: post.data.title,
+  description: post.data.description,
+  datePublished: post.data.published,
+  dateModified: post.data.updated ?? post.data.published,
+  url: new URL(`/blog/${post.id}`, Astro.site).href,
+  author: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+  publisher: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+}];
 ---
-<Layout title={`${post.data.title} — Minimal Containers`} description={post.data.description} published={post.data.published}>
+<Layout
+  title={`${post.data.title} — Minimal Containers`}
+  description={post.data.description}
+  published={post.data.published}
+  schema={schema}
+  breadcrumbs={[{ name: 'Blog', href: '/blog' }]}>
   <section>
     <div class="container-narrow">
       <p style="margin:0 0 6px"><a href="/blog" class="small muted">← Blog</a></p>

--- a/site/src/pages/compare/bitnami.astro
+++ b/site/src/pages/compare/bitnami.astro
@@ -1,0 +1,128 @@
+---
+import Layout from '../../components/Layout.astro';
+import CopyButton from '../../components/CopyButton.astro';
+import map from '../../data/bitnami-map.json';
+import { images } from '../../lib/catalog';
+
+const title = 'Bitnami alternative — free hardened replacements for deprecated Bitnami images';
+const description =
+  `Bitnami moved its free versioned images to an unmaintained legacy repo. Minimal publishes free, signed, MIT-licensed replacements for ${map.pairs.length} of the most-used Bitnami images.`;
+
+const schema = [{
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Bitnami image replacements',
+  numberOfItems: map.pairs.length,
+  itemListElement: map.pairs.map((p, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: `${p.bitnami} → minimal-${p.minimal}`,
+    url: new URL(`/images/${p.minimal}`, Astro.site).href,
+  })),
+}];
+---
+<Layout title={title} description={description} schema={schema} breadcrumbs={[{ name: 'Compare', href: '/compare' }]}>
+  <section>
+    <div class="container-narrow">
+      <h1 class="section-title">Replacing deprecated Bitnami images</h1>
+      <p class="section-sub">
+        In August 2025 Bitnami moved its free versioned container images to
+        <code class="kv-mono">bitnamilegacy</code>, which receives no further updates or security
+        fixes, and put maintained images behind Bitnami Secure Images. If you are still pulling
+        from <code class="kv-mono">docker.io/bitnami</code>, you are running software that stopped
+        being patched.
+      </p>
+      <p>
+        Minimal covers <b>{map.pairs.length}</b> of the most commonly used Bitnami images, free,
+        with no account and no paid tier. Check the mapping below before you plan anything —
+        there are real gaps, and they are listed too.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Direct replacements</h2>
+      <p class="small muted">
+        Same upstream software. Configuration and paths follow the upstream project's conventions
+        rather than Bitnami's, so read the migration notes below before swapping.
+      </p>
+      <div style="overflow-x:auto">
+        <table class="data">
+          <thead><tr><th>Bitnami image</th><th>Minimal replacement</th></tr></thead>
+          <tbody>
+            {map.pairs.map((p) => (
+              <tr>
+                <td class="kv-mono">bitnami/{p.bitnami}</td>
+                <td><a href={`/images/${p.minimal}`}>minimal-{p.minimal}</a></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h2 class="section-title" style="margin-top:44px">What Minimal does not cover</h2>
+      <p>
+        These common Bitnami images have <b>no</b> Minimal equivalent. If you depend on one, this
+        catalog does not solve your problem and you should plan accordingly:
+      </p>
+      <ul>
+        <li><b>grafana</b>, <b>airflow</b>, <b>spark</b>, <b>wordpress</b> — not in the catalog today.</li>
+        <li><b>mongodb</b>, <b>elasticsearch</b> — deliberately excluded on licensing grounds (SSPL and
+          the Elastic License are not open source). <a href="/images/opensearch">opensearch</a> is the
+          closest available substitute for Elasticsearch.</li>
+        <li><b>influxdb</b>, <b>clickhouse</b> — not currently built.</li>
+        <li><b>os-shell</b>, <b>git</b> — utility images used by Bitnami charts as init containers.
+          There is no direct replacement; a <code class="kv-mono">-dev</code> variant is the nearest thing.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">The three things that will break</h2>
+      <p>
+        A Bitnami image is not shaped like a Minimal one, so this is not a pure reference swap.
+        Expect these:
+      </p>
+      <h3 style="font-size:1.05rem;margin-top:24px">Bitnami's <code class="kv-mono">/opt/bitnami</code> paths do not exist</h3>
+      <p>
+        Bitnami standardises config, data and binaries under <code class="kv-mono">/opt/bitnami/&lt;app&gt;</code>.
+        Minimal follows each project's own upstream layout instead. Any volume mount, config path or
+        <code class="kv-mono">command</code> referencing <code class="kv-mono">/opt/bitnami</code> needs rewriting.
+        Each image's <b>Specifications</b> tab lists its actual entrypoint and paths.
+      </p>
+      <h3 style="font-size:1.05rem;margin-top:24px">No shell, so Bitnami's entrypoint scripts do not port</h3>
+      <p>
+        Bitnami images ship a shell and a substantial <code class="kv-mono">libentrypoint.sh</code> layer that
+        renders config from environment variables. Minimal production images have no shell at all, so
+        that pattern cannot be carried across — configure the software directly, or render config in an
+        init container.
+      </p>
+      <h3 style="font-size:1.05rem;margin-top:24px">Different non-root UID</h3>
+      <p>
+        Bitnami images conventionally run as UID <code class="kv-mono">1001</code>. Minimal uses
+        <code class="kv-mono">65532</code>. Existing volumes written by a Bitnami container will be owned by
+        the wrong UID, so set <code class="kv-mono">fsGroup</code> or chown the data before cutting over.
+        <b>On a database volume, test this on a copy first.</b>
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">A note on Helm charts</h2>
+      <p>
+        Most Bitnami usage is via Bitnami Helm charts, and those charts assume the Bitnami image
+        layout throughout — the paths, the entrypoint scripts and the UID above. Overriding
+        <code class="kv-mono">image.repository</code> to point at a Minimal image will generally not work
+        on its own. Migrating the chart is a larger job than migrating the image, and this page does
+        not pretend otherwise.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Try one</h2>
+      <CopyButton code={`docker pull ghcr.io/rtvkiz/minimal-postgres-slim:latest
+grype ghcr.io/rtvkiz/minimal-postgres-slim:latest`} />
+      <p style="margin-top:20px">
+        The general migration steps — tags, verification, rollout order — are in
+        <a href="/blog/migrating-from-minimus-to-minimal">the migration guide</a>, and apply
+        whichever base you are coming from. Full catalog: <a href="/images">{images.length} images</a>.
+      </p>
+
+      <p class="small muted" style="margin-top:32px">
+        Bitnami's catalog changes are documented by Broadcom in
+        <a href="https://github.com/bitnami/containers/issues/83267" rel="noopener nofollow">bitnami/containers #83267</a>.
+        Details there change; that issue, not this page, is the authority on what Bitnami currently
+        publishes. Statements about Minimal are checkable from the <a href="/about">verify page</a>.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/compare/chainguard.astro
+++ b/site/src/pages/compare/chainguard.astro
@@ -10,8 +10,27 @@ const s = data.chainguard;
 const title = 'Chainguard alternative — free hardened images, compared with scan data';
 const description =
   `A free Chainguard alternative: ${images.length} MIT-licensed hardened images, no account, no paid tier. ${s.compared} images scanned head-to-head with one Grype build on ${data.scanDate}.`;
+
+const datasetSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Dataset',
+  name: `Container image vulnerability comparison, ${data.scanDate}`,
+  description: `Grype scan results for Minimal, Minimus and publicly pullable Chainguard container images, scanned with ${data.scanner} against a single frozen vulnerability database on ${data.scanDate}.`,
+  url: new URL('/compare', Astro.site).href,
+  license: 'https://spdx.org/licenses/MIT.html',
+  isAccessibleForFree: true,
+  creator: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+  dateCreated: data.scanDate,
+  measurementTechnique: `${data.scanner}, vulnerability DB schema ${data.dbSchema}, platform ${data.platform}`,
+  variableMeasured: 'Unique CVE identifiers per container image',
+  distribution: [{
+    '@type': 'DataDownload',
+    encodingFormat: 'text/csv',
+    contentUrl: new URL(data.csvPath, Astro.site).href,
+  }],
+};
 ---
-<Layout title={title} description={description}>
+<Layout title={title} description={description} schema={[datasetSchema]} breadcrumbs={[{ name: 'Compare', href: '/compare' }]}>
   <section>
     <div class="container-narrow">
       <h1 class="section-title">Minimal vs Chainguard</h1>

--- a/site/src/pages/compare/index.astro
+++ b/site/src/pages/compare/index.astro
@@ -1,21 +1,41 @@
 ---
 import Layout from '../../components/Layout.astro';
 import data from '../../data/comparison.json';
+import bitnami from '../../data/bitnami-map.json';
 import { images } from '../../lib/catalog';
 
 const title = 'Hardened container image alternatives — Chainguard, Minimus, Docker Hardened compared';
 const description =
   `An evidence-based comparison of free hardened container images. ${data.minimus.compared} images scanned head-to-head with the same Grype build, including the images where Minimal loses.`;
+
+const datasetSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Dataset',
+  name: `Container image vulnerability comparison, ${data.scanDate}`,
+  description: `Grype scan results for Minimal, Minimus and publicly pullable Chainguard container images, scanned with ${data.scanner} against a single frozen vulnerability database on ${data.scanDate}.`,
+  url: new URL('/compare', Astro.site).href,
+  license: 'https://spdx.org/licenses/MIT.html',
+  isAccessibleForFree: true,
+  creator: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+  dateCreated: data.scanDate,
+  measurementTechnique: `${data.scanner}, vulnerability DB schema ${data.dbSchema}, platform ${data.platform}`,
+  variableMeasured: 'Unique CVE identifiers per container image',
+  distribution: [{
+    '@type': 'DataDownload',
+    encodingFormat: 'text/csv',
+    contentUrl: new URL(data.csvPath, Astro.site).href,
+  }],
+};
 ---
-<Layout title={title} description={description}>
+<Layout title={title} description={description} schema={[datasetSchema]} breadcrumbs={[]}>
   <section>
     <div class="container-narrow">
       <h1 class="section-title">Comparing hardened container images</h1>
       <p class="section-sub">
-        If you are looking for a Chainguard alternative, a Minimus alternative, or simply a free
-        source of hardened base images, this section is the honest version: the same scanner, the
-        same database, the same day, published with the raw dataset and with the images where
-        Minimal comes off worse left in.
+        If you are looking for a Chainguard alternative, a Minimus alternative, a replacement for
+        the deprecated Bitnami images, or simply a free source of hardened base images, this
+        section is the honest version: the same scanner, the same database, the same day,
+        published with the raw dataset and with the images where Minimal comes off worse left in.
       </p>
 
       <div class="grid" style="margin-top:28px">
@@ -25,6 +45,14 @@ const description =
             {data.chainguard.compared} images with a free, publicly pullable Chainguard equivalent.
             Minimal lower on {data.chainguard.lower}, tied on {data.chainguard.tie},
             higher on {data.chainguard.higher}.
+          </p>
+        </a>
+        <a class="card" href="/compare/bitnami">
+          <h2 style="font-size:1.1rem;margin:0 0 6px">Replacing Bitnami images</h2>
+          <p class="small muted" style="margin:0">
+            Bitnami's free versioned images moved to an unmaintained legacy repo in August 2025.
+            Free replacements for {bitnami.pairs.length} of the most-used ones — and the gaps
+            where there is none.
           </p>
         </a>
         <a class="card" href="/compare/minimus">

--- a/site/src/pages/compare/minimus.astro
+++ b/site/src/pages/compare/minimus.astro
@@ -10,8 +10,27 @@ const title = 'Minimus alternative — Minimal vs Minimus, scanned head-to-head'
 const description =
   `A free Minimus alternative with published scan data: ${s.compared} images scanned with one Grype build on ${data.scanDate}. Minimal lower on ${s.lower}, tied on ${s.tie}, higher on ${s.higher}.`;
 const worst = [...s.pairs].filter((p: any) => p.delta > 0).reverse();
+
+const datasetSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Dataset',
+  name: `Container image vulnerability comparison, ${data.scanDate}`,
+  description: `Grype scan results for Minimal, Minimus and publicly pullable Chainguard container images, scanned with ${data.scanner} against a single frozen vulnerability database on ${data.scanDate}.`,
+  url: new URL('/compare', Astro.site).href,
+  license: 'https://spdx.org/licenses/MIT.html',
+  isAccessibleForFree: true,
+  creator: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+  dateCreated: data.scanDate,
+  measurementTechnique: `${data.scanner}, vulnerability DB schema ${data.dbSchema}, platform ${data.platform}`,
+  variableMeasured: 'Unique CVE identifiers per container image',
+  distribution: [{
+    '@type': 'DataDownload',
+    encodingFormat: 'text/csv',
+    contentUrl: new URL(data.csvPath, Astro.site).href,
+  }],
+};
 ---
-<Layout title={title} description={description}>
+<Layout title={title} description={description} schema={[datasetSchema]} breadcrumbs={[{ name: 'Compare', href: '/compare' }]}>
   <section>
     <div class="container-narrow">
       <h1 class="section-title">Minimal vs Minimus</h1>

--- a/site/src/pages/images/[name].astro
+++ b/site/src/pages/images/[name].astro
@@ -35,8 +35,33 @@ const pageDescription = [
   `Signed, SBOM-attested${image.size ? `, ${image.size.human} compressed` : ''}, rebuilt every 6 hours.`,
   `Free and public — pull ${pullRef.split(':')[0]} with no account.`,
 ].join(' ');
+
+// SoftwareApplication is the closest schema.org type for a distributable
+// container image: it carries the free-of-charge offer, the operating system
+// and the download reference, which is what a rich result needs.
+const schema = [{
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: `minimal-${image.name}`,
+  applicationCategory: 'DeveloperApplication',
+  description: image.summary,
+  operatingSystem: 'Linux',
+  url: new URL(`/images/${image.name}`, Astro.site).href,
+  downloadUrl: `https://${pullRef.split(':')[0]}`,
+  softwareHelp: new URL('/docs', Astro.site).href,
+  license: 'https://spdx.org/licenses/MIT.html',
+  isAccessibleForFree: true,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  ...(prod?.specs?.archs?.length ? { processorRequirements: prod.specs.archs.join(', ') } : {}),
+  ...(image.builtAt ? { dateModified: image.builtAt } : {}),
+  maintainer: { '@type': 'Organization', name: 'Minimal Containers', url: 'https://minimalcontainers.com' },
+}];
 ---
-<Layout title={pageTitle} description={pageDescription}>
+<Layout
+  title={pageTitle}
+  description={pageDescription}
+  schema={schema}
+  breadcrumbs={[{ name: 'Images', href: '/images' }, { name: image.category, href: '/images' }]}>
   <div class="detail-head">
     <div class="container">
       <p style="margin:0 0 6px"><a href="/images" class="small muted">← All images</a></p>
@@ -97,7 +122,7 @@ const pageDescription = [
     </div>
 
     <!-- SPECIFICATIONS -->
-    <div class="tabpanel" data-panel="specs" hidden>
+    <div class="tabpanel" data-panel="specs">
       {variantKeys.map((vk) => {
         const s = image.variants[vk].specs;
         return (
@@ -137,7 +162,7 @@ const pageDescription = [
     </div>
 
     <!-- TAGS -->
-    <div class="tabpanel" data-panel="tags" hidden>
+    <div class="tabpanel" data-panel="tags">
       {image.tagsStatus === 'none' || image.tags.length === 0 ? (
         <p class="notice warn">Tag list unavailable{image.tagsStatus === 'partial' ? ' (registry temporarily unavailable)' : ''}. Pull <code class="kv-mono">{image.repo}:latest</code>.</p>
       ) : (
@@ -160,7 +185,7 @@ const pageDescription = [
     </div>
 
     <!-- PACKAGES -->
-    <div class="tabpanel" data-panel="packages" hidden>
+    <div class="tabpanel" data-panel="packages">
       {image.packages ? (
         <>
           <p class="section-sub">{image.packages.length} packages in the image, resolved from the SPDX SBOM.</p>
@@ -193,7 +218,7 @@ const pageDescription = [
     </div>
 
     <!-- ADVISORIES -->
-    <div class="tabpanel" data-panel="advisories" hidden>
+    <div class="tabpanel" data-panel="advisories">
       {v ? (
         v.total === 0 ? (
           <>
@@ -245,7 +270,7 @@ const pageDescription = [
     </div>
 
     <!-- PROVENANCE -->
-    <div class="tabpanel" data-panel="provenance" hidden>
+    <div class="tabpanel" data-panel="provenance">
       <p class="section-sub">Everything is verifiable without an account. Copy and run:</p>
       <h3 style="font-size:1rem;margin:20px 0 8px">Build provenance (SLSA v1.0, Build L2)</h3>
       <CopyButton code={`gh attestation verify oci://${image.repo}:latest --owner rtvkiz`} />
@@ -263,6 +288,31 @@ const pageDescription = [
       <p class="small muted" style="margin-top:20px">Signatures are logged in the public <a href="https://rekor.sigstore.dev" rel="noopener">Rekor</a> transparency log.</p>
     </div>
   </div>
+
+  <script is:inline>
+    // Collapse the panels as early as possible. This runs during parse, before
+    // first paint, so JS users see the normal tab UI with no flash of the full
+    // document. It is deliberately NOT a `hidden` attribute in the markup:
+    // crawlers that do not execute JS — which most AI/LLM crawlers do not —
+    // would then only ever receive the Overview panel. On nginx that was 212 of
+    // the page's 458 words; the rest was delivered as display:none.
+    (function () {
+      var panels = document.querySelectorAll('.tabpanel');
+      var initial = location.hash.replace('#', '') || 'overview';
+      var known = false;
+      for (var i = 0; i < panels.length; i++) {
+        if (panels[i].getAttribute('data-panel') === initial) known = true;
+      }
+      if (!known) initial = 'overview';
+      for (var j = 0; j < panels.length; j++) {
+        panels[j].hidden = panels[j].getAttribute('data-panel') !== initial;
+      }
+      var tabs = document.querySelectorAll('.tab');
+      for (var k = 0; k < tabs.length; k++) {
+        tabs[k].setAttribute('aria-selected', String(tabs[k].getAttribute('data-tab') === initial));
+      }
+    })();
+  </script>
 </Layout>
 
 <script>

--- a/site/src/pages/images/index.astro
+++ b/site/src/pages/images/index.astro
@@ -3,8 +3,27 @@ import Layout from '../../components/Layout.astro';
 import ImageCard from '../../components/ImageCard.astro';
 import { byCategory, categories, images } from '../../lib/catalog';
 const grouped = byCategory();
+
+// ItemList tells a crawler this is a catalogue and what is in it, rather than
+// leaving it to infer structure from a wall of cards.
+const schema = [{
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: 'Minimal Containers image directory',
+  numberOfItems: images.length,
+  itemListElement: images.map((img, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: `minimal-${img.name}`,
+    url: new URL(`/images/${img.name}`, Astro.site).href,
+  })),
+}];
 ---
-<Layout title="Image directory — Minimal Containers" description="Browse all hardened container images.">
+<Layout
+  title={`All ${images.length} hardened container images — free and signed`}
+  description={`Browse ${images.length} free, hardened container images across ${categories.length} categories — databases, proxies, observability, Kubernetes tooling and language runtimes. MIT-licensed, signed, rebuilt every 6 hours.`}
+  schema={schema}
+  breadcrumbs={[]}>
   <section>
     <div class="container">
       <h1 class="section-title">Image directory</h1>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -15,8 +15,26 @@ docker pull ghcr.io/rtvkiz/minimal-python:latest
 
 # Verify build provenance (SLSA v1.0, Build L2)
 gh attestation verify oci://ghcr.io/rtvkiz/minimal-python:latest --owner rtvkiz`;
+
+const schema = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'Minimal Containers',
+    url: 'https://minimalcontainers.com',
+    logo: 'https://minimalcontainers.com/icon.svg',
+    description: `Free, hardened, MIT-licensed container images — ${stats.images} of them, rebuilt every 6 hours.`,
+    sameAs: ['https://github.com/rtvkiz/minimal'],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Minimal Containers',
+    url: 'https://minimalcontainers.com',
+  },
+];
 ---
-<Layout>
+<Layout schema={schema}>
   <section class="hero">
     <div class="container">
       <span class="eyebrow">Open source · MIT licensed</span>


### PR DESCRIPTION
Follow-up to #632, in descending order of how many pages each item affects.

## 1. Image pages no longer ship 45% of their text as `display:none`

The six tab panels were rendered with a `hidden` attribute, so a crawler received only the Overview panel — **212 of nginx's 458 words**. Panels are now rendered visible and collapsed by a synchronous inline script that runs during parse, before first paint, so the tab UI is unchanged for anyone with JS.

The audience for this is the crawlers that do **not** execute JS, which is most AI/LLM crawlers. Measured after:

```
nginx  458 -> 631 words of raw HTML
       5 -> 0 server-hidden panels
```

## 2. JSON-LD, where the site previously had none anywhere

230 blocks, every one validated as parsing:

| Type | Count |
|---|---:|
| SoftwareApplication | 108 |
| BreadcrumbList | 114 |
| Dataset | 3 |
| ItemList | 2 |
| Organization / WebSite / Article | 1 each |

The comparison pages get `Dataset`, which is the honest type for them — the CVE CSV is a real published dataset with a stated method, a pinned scanner version, a DB checksum and an open licence, and `Dataset` is indexed by Google Dataset Search. `Layout.astro` grew `schema` and `breadcrumbs` props to carry all of this.

## 3. `/compare/bitnami`

Bitnami moved its free versioned images to the unmaintained `bitnamilegacy` repo in August 2025. The mapping is **generated from `catalog.json`**, not asserted by hand: 39 of the most-used Bitnami images have a direct Minimal equivalent.

Built to the standard 4a469d65 set, which for this page means being blunt about what does not work:

- The images with **no** equivalent are listed — grafana, airflow, spark, wordpress, influxdb, clickhouse — with mongodb and elasticsearch called out as deliberate licence exclusions rather than gaps.
- The three things that actually break are named: `/opt/bitnami` paths do not exist, Bitnami's shell entrypoint layer cannot port to a shell-less image, and the UID differs (1001 vs 65532) — with an explicit warning to test that on a copy before touching a database volume.
- A section stating plainly that overriding `image.repository` in a Bitnami Helm chart **will generally not work**, because the charts assume the Bitnami image layout throughout. That is the single most likely way someone gets burned following a page like this.

Broadcom's [bitnami/containers #83267](https://github.com/bitnami/containers/issues/83267) is linked as the authority on what Bitnami currently publishes, rather than this page freezing a claim that will drift.

## Validation

- `npm run build` — 123 pages, clean
- All 230 JSON-LD blocks parse (checked programmatically across `dist/`)
- Collapse script verified present and ordered after the panels in built HTML
- `/compare/bitnami` verified in the sitemap
- `site/src/data/images.json` excluded — build artifact the deploy workflow regenerates

## Note

#632 was merged while this was in progress, which deleted its branch; my push recreated it by accident. This branch is a clean cherry-pick onto the post-merge `main`, and the stale `feat/seo-comparison-and-blog` branch has been deleted.