### PR TITLE
feat(site): category pages, Docker Hardened comparison, sitemap freshness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,6 +330,17 @@ jobs:
         # bespoke updater). Same check as local `make check-autoupdate`.
         run: make check-autoupdate
 
+      - name: Assert the website's factual claims still hold
+        # Invariant: nothing on minimalcontainers.com contradicts this repo, and
+        # no retracted claim comes back. A page renders identically whether its
+        # numbers are right or wrong, so nothing failed when /about kept saying
+        # Docker Hardened had "Hundreds" of images months after Docker released
+        # 1,000+ free, or when a page shipped claiming bitnami/helm exists (it
+        # 404s). Offline only here — competitor repo lookups need --online and
+        # must not make a third party's outage fail our build. Same check as
+        # local `make check-site-claims`.
+        run: make check-site-claims
+
       - name: Assert no build environment uses a bare toolchain provider
         # Invariant: melange build environments pin the versioned toolchain
         # package (go-1.26, nodejs-26, rust-1.97), never the bare provider.

--- a/.github/workflows/refresh-site-data.yml
+++ b/.github/workflows/refresh-site-data.yml
@@ -1,0 +1,105 @@
+name: Refresh site data
+
+# Regenerate the datasets the website's factual pages are built from, and open a
+# PR when they have changed.
+#
+# WHY. The comparison and replacement pages make claims about the outside world:
+# what Bitnami publishes, how many CVEs each provider's images carry. Those facts
+# drift, and a page renders identically whether its numbers are current or two
+# years old. /about claimed Docker Hardened had "Hundreds" of images for months
+# after Docker released 1,000+ free, under a footnote saying it had been
+# verified. Nothing failed, because nothing was checking.
+#
+# The site build deliberately does NOT do this: it would put ~380 third-party
+# requests between a developer and a working preview, and a rate-limited Docker
+# Hub would then break the build. Refresh on a schedule, commit the result, and
+# let the build stay hermetic.
+#
+# The PR is the point. These datasets drive public claims about other projects,
+# so a human reads the diff before it ships.
+
+on:
+  schedule:
+    # Weekly, Monday 04:20 UTC. Off the hour to avoid the GitHub cron stampede,
+    # and clear of the 6-hourly image build.
+    - cron: '20 4 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Regenerate the Bitnami replacement map
+        working-directory: site
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node scripts/build-bitnami-map.mjs
+
+      - name: Verify the site's claims still hold
+        # Both modes: the offline checks must pass, and --online re-confirms that
+        # every competitor repository the site names still resolves. Running it
+        # here rather than only in CI is the point — this is the job that would
+        # notice a vendor renaming or withdrawing an image.
+        run: ./scripts/check-site-claims.sh --online
+
+      - name: Rebuild the site to prove the new data renders
+        working-directory: site
+        run: |
+          npm ci
+          npm run build
+
+      - name: Open a PR if anything changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if git diff --quiet -- site/src/data; then
+            echo "No change in site data — nothing to do."
+            exit 0
+          fi
+
+          BRANCH="refresh-site-data-$(date -u +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          # Only the datasets. The build also writes images.json and og.png,
+          # which the deploy regenerates and must not ride along in this PR.
+          git add site/src/data/bitnami-map.json
+          git commit -m "chore(site): refresh generated comparison data
+
+          Regenerated from source: the Bitnami image list from
+          github.com/bitnami/containers, pull counts from the Docker Hub API.
+          Opened automatically because the upstream data changed."
+          git push --force -u origin "$BRANCH"
+
+          SUMMARY=$(jq -r '"\(.bitnamiImages) Bitnami images, \(.pairs | length) with a Minimal equivalent, \(.gapCount) without."' site/src/data/bitnami-map.json)
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(site): refresh generated comparison data" \
+            --body "Upstream data behind the public comparison pages has changed.
+
+          **Now:** ${SUMMARY}
+
+          Generated from github.com/bitnami/containers (image list) and the Docker Hub API (pull counts and pullability). A row ships only when both sources agree.
+
+          \`check-site-claims.sh --online\` passed and the site builds. **Read the diff before merging** — these numbers become public claims about another project."

--- a/Makefile
+++ b/Makefile
@@ -4372,6 +4372,14 @@ check-toolchain-pins:
 check-curl-retries:
 	@./scripts/check-curl-retries.sh
 
+# Verify the website's factual claims against this repo. --online additionally
+# checks that competitor repositories we name actually exist.
+check-site-claims:
+	@./scripts/check-site-claims.sh
+
+check-site-claims-online:
+	@./scripts/check-site-claims.sh --online
+
 test-classifier:
 	@./tests/test-classify-build-failure.sh
 

--- a/scripts/check-site-claims.sh
+++ b/scripts/check-site-claims.sh
@@ -107,8 +107,10 @@ for f in "$SITE"/pages/compare/*.astro "$SITE"/pages/about.astro; do
   if [ -z "$d" ] && grep -q 'data\.scanDate' "$f"; then
     d=$(jq -r '.scanDate' "$SITE"/data/comparison.json)
   fi
-  if [ -z "$d" ] && grep -q 'map\.verified' "$f"; then
-    d=$(jq -r '.verified // empty' "$SITE"/data/bitnami-map.json)
+  # Accept whatever field the dataset uses for its own date; the page renaming
+  # map.verified -> map.generated must not read as "undated".
+  if [ -z "$d" ] && grep -qE 'map\.(verified|generated)' "$f"; then
+    d=$(jq -r '.generated // .verified // empty' "$SITE"/data/bitnami-map.json)
   fi
   if [ -z "$d" ]; then
     note "$(basename "$f") makes competitor claims with no review date"

--- a/scripts/check-site-claims.sh
+++ b/scripts/check-site-claims.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Verify the factual claims on minimalcontainers.com against this repo and,
+# optionally, against the outside world.
+#
+# WHY THIS EXISTS. Site claims drift silently and in both directions. Commit
+# 4a469d65 had to retract four of our own overstatements. Later, /about still
+# said Docker Hardened had "Hundreds" of images months after Docker released
+# 1,000+ free under Apache-2.0 — understating a competitor under a footnote that
+# said the table had been verified. And a Bitnami replacement page shipped
+# claiming bitnami/helm exists; it 404s.
+#
+# None of those were caught by a build. A page renders identically whether its
+# numbers are right or wrong, so nothing failed until a human re-read it. This
+# is the checker that re-reads it.
+#
+# Two modes, matching the other gates in this repo:
+#   (default)  assert  — exit non-zero on any hard failure. For CI.
+#   --report           — print findings and always exit 0. For a human sweep.
+#
+# Network checks (competitor repositories) are skipped unless --online is given,
+# so CI stays hermetic by default and does not fail on someone else's outage.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+MODE=assert
+ONLINE=0
+for a in "$@"; do
+  case "$a" in
+    --report) MODE=report ;;
+    --online) ONLINE=1 ;;
+    *) echo "usage: $0 [--report] [--online]" >&2; exit 2 ;;
+  esac
+done
+
+fail=0
+pass=0
+note() { printf '  \033[33m!\033[0m %s\n' "$1"; fail=$((fail+1)); }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
+
+SITE=site/src
+
+echo "Checking site claims against the repo…"
+
+# --- 1. Counts the site states must match catalog.json ----------------------
+# The templates read images.json, so a hard-coded count in prose is the risk.
+CAT_IMAGES=$(jq '.images | length' catalog.json)
+CAT_CATS=$(jq '.categories | length' catalog.json)
+for n in $(grep -rhoE '\b(1[0-9]{2})\b images' "$SITE"/pages | grep -oE '^[0-9]+' | sort -u); do
+  if [ "$n" != "$CAT_IMAGES" ]; then
+    note "a page hard-codes '$n images' but catalog.json has $CAT_IMAGES"
+  fi
+done
+ok "hard-coded image counts agree with catalog.json ($CAT_IMAGES)"
+[ "$CAT_CATS" -gt 0 ] && ok "catalog declares $CAT_CATS categories"
+
+# --- 2. Rebuild cadence -----------------------------------------------------
+# "rebuilt every 6 hours" appears in meta descriptions on every image page.
+CRON=$(grep -oE "cron: *'[^']+'" .github/workflows/build.yml | head -1 | grep -oE "'[^']+'" | tr -d "'")
+CLAIMED_H=$(grep -rhoE 'every [0-9]+ hours' "$SITE" | grep -oE '[0-9]+' | sort -u | head -1)
+CRON_H=$(printf '%s' "$CRON" | awk '{print $2}' | grep -oE '[0-9]+$')
+if [ -n "$CLAIMED_H" ] && [ "$CLAIMED_H" != "${CRON_H:-}" ]; then
+  note "site claims a ${CLAIMED_H}h rebuild cadence but build.yml cron is '$CRON'"
+else
+  ok "rebuild cadence claim (${CLAIMED_H}h) matches build.yml cron '$CRON'"
+fi
+
+# --- 3. Claims we retracted and must not reintroduce ------------------------
+# Each of these was removed for a stated reason. Reintroducing one is a
+# regression, not a new decision.
+#   reproducible   — SOURCE_DATE_EPOCH alone proves nothing; nothing verifies it
+#   Build L3       — needs a reusable workflow; this repo has none
+#   no rate limits — GHCR does apply limits; only the Docker Hub claim is safe
+if grep -rniE '\breproducib' "$SITE" >/dev/null 2>&1; then
+  note "'reproducible' is back on the site — retracted in 4a469d65, still unverified"
+else
+  ok "no unproven reproducibility claim"
+fi
+# Only an ASSERTION about our own level matters. "Docker: yes (L3)" and "if you
+# need L3, use a vendor" are both correct and must not trip this.
+if grep -rnE '(Minimal|we|this project) [a-z ]{0,20}publish[a-z]* [^.<]{0,20}SLSA[^.<]{0,20}L(evel )?3' "$SITE" >/dev/null 2>&1; then
+  note "SLSA L3 asserted for Minimal; this repo publishes Build L2 (no reusable workflow)"
+elif grep -rnE '(Minimal|we|this project) [a-z ]{0,20}publish[a-z]* [^.<]{0,20}SLSA' "$SITE" >/dev/null 2>&1; then
+  ok "SLSA level asserted for Minimal is L2"
+elif grep -rn 'Build L2' "$SITE" >/dev/null 2>&1; then
+  ok "SLSA level stated for Minimal is Build L2"
+else
+  note "the site states no SLSA level at all — it publishes Build L2 provenance"
+fi
+if grep -rnE 'no rate limits' "$SITE" >/dev/null 2>&1; then
+  note "'no rate limits' — GHCR applies limits; claim only 'no Docker Hub pull limits'"
+else
+  ok "rate-limit claim is scoped to Docker Hub"
+fi
+
+# --- 4. Competitor claims must carry a review date --------------------------
+# A dated claim can be re-checked. An undated one silently rots, which is
+# exactly how the Docker Hardened row went stale.
+STALE_DAYS=${STALE_DAYS:-120}
+now=$(date +%s)
+for f in "$SITE"/pages/compare/*.astro "$SITE"/pages/about.astro; do
+  [ -f "$f" ] || continue
+  # A page may carry its date literally, or inject it from a dated dataset
+  # (comparison.json scanDate, bitnami-map.json verified). Resolve both — a
+  # template variable is still a date shown to the reader.
+  d=$(grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}' "$f" | sort | tail -1)
+  if [ -z "$d" ] && grep -q 'data\.scanDate' "$f"; then
+    d=$(jq -r '.scanDate' "$SITE"/data/comparison.json)
+  fi
+  if [ -z "$d" ] && grep -q 'map\.verified' "$f"; then
+    d=$(jq -r '.verified // empty' "$SITE"/data/bitnami-map.json)
+  fi
+  if [ -z "$d" ]; then
+    note "$(basename "$f") makes competitor claims with no review date"
+    continue
+  fi
+  age=$(( (now - $(date -d "$d" +%s 2>/dev/null || echo "$now")) / 86400 ))
+  if [ "$age" -gt "$STALE_DAYS" ]; then
+    note "$(basename "$f") last reviewed $d (${age}d ago, limit ${STALE_DAYS}d) — re-verify competitor facts"
+  else
+    ok "$(basename "$f") reviewed $d (${age}d ago)"
+  fi
+done
+
+# --- 5. Competitor repositories we name must exist (network) ----------------
+if [ "$ONLINE" = 1 ]; then
+  echo "Checking named competitor repositories…"
+  miss=0
+  while read -r b; do
+    code=$(curl -s -m 15 -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/bitnami/$b/" || echo 000)
+    case "$code" in
+      200) ;;
+      000) echo "    (skipped $b — network unreachable)" ;;
+      *)   note "bitnami/$b returns HTTP $code — the Bitnami page claims it exists"; miss=$((miss+1)) ;;
+    esac
+  done < <(jq -r '.pairs[].bitnami' "$SITE"/data/bitnami-map.json)
+  [ "$miss" -eq 0 ] && ok "every bitnami/<name> named on the site resolves"
+else
+  echo "  (competitor repository checks skipped — pass --online to run them)"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "✓ site claims: $pass checks passed"
+  exit 0
+fi
+echo "✗ site claims: $fail finding(s), $pass passed"
+[ "$MODE" = report ] && exit 0
+exit 1

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -13,5 +13,26 @@ export default defineConfig({
   },
   // Without a sitemap the catalogue's ~110 image pages are reachable only by
   // crawling /images. `site` above is what makes the emitted URLs absolute.
-  integrations: [sitemap()],
+  integrations: [
+    sitemap({
+      // The whole catalogue is rebuilt and redeployed every 6 hours, but nothing
+      // external could see that. lastmod is the signal that earns a faster
+      // recrawl; without it a crawler has to guess the site is worth revisiting.
+      lastmod: new Date(),
+      serialize(item) {
+        // Priority ordering, highest intent first: the comparison pages exist to
+        // catch "<vendor> alternative" queries, and the catalogue root is the
+        // main entry point. Leaf image pages are the long tail.
+        const p = new URL(item.url).pathname;
+        if (p === '/') item.priority = 1.0;
+        else if (p.startsWith('/compare')) item.priority = 0.9;
+        else if (p === '/images/' || p.startsWith('/images/category/')) item.priority = 0.8;
+        else if (p.startsWith('/blog')) item.priority = 0.7;
+        else if (p.startsWith('/docs') || p === '/about/') item.priority = 0.6;
+        else item.priority = 0.5;
+        item.changefreq = p.startsWith('/images/') ? 'daily' : 'weekly';
+        return item;
+      },
+    }),
+  ],
 });

--- a/site/scripts/build-bitnami-map.mjs
+++ b/site/scripts/build-bitnami-map.mjs
@@ -1,0 +1,126 @@
+// Derive the Bitnami -> Minimal replacement map from data, never from memory.
+//
+// The first version of this map was a hand-written list. It claimed a
+// replacement for `bitnami/helm`, which does not exist — a fabricated fact that
+// shipped because nothing checked it. Fixing the entry was not the fix; this is.
+//
+// Sources, both enumerated rather than recalled:
+//   1. github.com/bitnami/containers, one directory per published image. This
+//      is the authoritative list of what Bitnami builds, and unlike the Docker
+//      Hub listing endpoint it paginates reliably (that returns 403 on page 2
+//      for anonymous callers, so a Hub-derived list would silently truncate).
+//   2. Docker Hub per-repository lookups for pull counts, which DO work one at
+//      a time. Used only to rank; a name is never included or excluded on it.
+//   3. catalog.json — what we actually ship.
+//
+// The only hand-maintained input is ALIASES, for software the two projects name
+// differently. Every entry is validated against both sides before emitting, so
+// a stale alias fails the build instead of producing a wrong row.
+//
+// Run by .github/workflows/refresh-site-data.yml, not by the site build: it
+// makes ~380 third-party requests and must not sit between a developer and a
+// working site.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const ALIASES = {
+  postgresql: 'postgres-slim',
+  redis: 'redis-slim',
+  node: 'node-slim',
+  apache: 'httpd',
+  'php-fpm': 'php',
+};
+
+// --- 1. What Bitnami publishes ---------------------------------------------
+const listing = execFileSync(
+  'gh',
+  ['api', '--paginate', 'repos/bitnami/containers/contents/bitnami', '--jq', '.[] | select(.type=="dir") | .name'],
+  { encoding: 'utf8', maxBuffer: 8 << 20 }
+);
+const bitnamiNames = listing.trim().split('\n').filter(Boolean);
+if (bitnamiNames.length < 100) {
+  throw new Error(`only ${bitnamiNames.length} Bitnami images enumerated — refusing to publish a truncated map`);
+}
+console.log(`  bitnami/containers: ${bitnamiNames.length} published images`);
+
+// --- 2. What we ship --------------------------------------------------------
+const catalog = JSON.parse(readFileSync(join(root, '..', 'catalog.json'), 'utf8'));
+const ours = new Set(catalog.images.map((i) => i.name));
+
+for (const [b, m] of Object.entries(ALIASES)) {
+  if (!bitnamiNames.includes(b)) throw new Error(`ALIASES: bitnami/${b} is no longer published — remove or correct it`);
+  if (!ours.has(m)) throw new Error(`ALIASES: ${b} -> ${m}, but ${m} is not in catalog.json`);
+}
+
+// --- 3. Pull counts, for ranking only ---------------------------------------
+async function pullCount(name) {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const res = await fetch(`https://hub.docker.com/v2/repositories/bitnami/${name}/`, {
+        headers: { 'User-Agent': 'curl/8.5.0', Accept: 'application/json' },
+      });
+      if (res.ok) return (await res.json()).pull_count ?? null;
+      if (res.status === 404) return null;          // legacy-only or unlisted
+      await sleep(1500 * attempt);
+    } catch {
+      await sleep(1500 * attempt);
+    }
+  }
+  return null;                                       // unknown, not zero
+}
+
+const pairs = [];
+const gaps = [];
+for (const name of bitnamiNames) {
+  const mapped = ALIASES[name] ?? name;
+  const target = ours.has(mapped) ? pairs : gaps;
+  target.push({ bitnami: name, ...(ours.has(mapped) ? { minimal: mapped } : {}) });
+}
+console.log(`  mapped ${pairs.length}, gaps ${gaps.length} — fetching pull counts…`);
+
+// Rank every mapped pair, and enough of the gaps to name the notable ones.
+for (const p of pairs) { p.pulls = await pullCount(p.bitnami); await sleep(250); }
+for (const g of gaps)  { g.pulls = await pullCount(g.bitnami); await sleep(250); }
+
+// Cross-validate the two sources. The GitHub repo lists what Bitnami BUILDS;
+// a Docker Hub lookup proves what is actually PULLABLE, and they disagree —
+// bitnami/containers has a `helm` directory, but hub.docker.com/r/bitnami/helm
+// 404s. Claiming "replace bitnami/helm" on the strength of the source tree
+// alone is exactly the fabricated row this rewrite exists to prevent, so a pair
+// only ships when both sources agree. Unresolvable lookups are reported, never
+// silently dropped: a Hub outage must not quietly shrink the page.
+const unpullable = pairs.filter((p) => p.pulls === null).map((p) => p.bitnami);
+const publishable = pairs.filter((p) => p.pulls !== null);
+if (unpullable.length) {
+  console.log(`  excluded ${unpullable.length} built-but-not-pullable: ${unpullable.join(', ')}`);
+}
+
+const byPulls = (a, b) => (b.pulls ?? -1) - (a.pulls ?? -1);
+publishable.sort(byPulls);
+gaps.sort(byPulls);
+
+writeFileSync(
+  join(root, 'src/data/bitnami-map.json'),
+  JSON.stringify(
+    {
+      generated: new Date().toISOString().slice(0, 10),
+      source: 'github.com/bitnami/containers (image list) + Docker Hub API (pull counts)',
+      bitnamiImages: bitnamiNames.length,
+      pairs: publishable,
+      excludedNotPullable: unpullable,
+      topGaps: gaps.slice(0, 12),
+      gapCount: gaps.length,
+    },
+    null,
+    2
+  ) + '\n'
+);
+console.log(
+  `bitnami-map.json — ${bitnamiNames.length} seen, ${publishable.length} mapped and pullable, ` +
+  `${unpullable.length} excluded, ${gaps.length} gaps`
+);

--- a/site/src/data/bitnami-map.json
+++ b/site/src/data/bitnami-map.json
@@ -37,10 +37,6 @@
       "minimal": "haproxy"
     },
     {
-      "bitnami": "helm",
-      "minimal": "helm"
-    },
-    {
       "bitnami": "jenkins",
       "minimal": "jenkins"
     },
@@ -168,5 +164,7 @@
     "os-shell",
     "spark",
     "wordpress"
-  ]
+  ],
+  "verified": "2026-09-01",
+  "verifiedMethod": "Each bitnami/<name> repository confirmed to exist via the Docker Hub API."
 }

--- a/site/src/data/bitnami-map.json
+++ b/site/src/data/bitnami-map.json
@@ -1,170 +1,344 @@
 {
+  "generated": "2026-09-01",
+  "source": "github.com/bitnami/containers (image list) + Docker Hub API (pull counts)",
+  "bitnamiImages": 380,
   "pairs": [
     {
-      "bitnami": "alertmanager",
-      "minimal": "alertmanager"
-    },
-    {
-      "bitnami": "apache",
-      "minimal": "httpd"
-    },
-    {
-      "bitnami": "cassandra",
-      "minimal": "cassandra"
-    },
-    {
-      "bitnami": "consul",
-      "minimal": "consul"
-    },
-    {
-      "bitnami": "etcd",
-      "minimal": "etcd"
-    },
-    {
-      "bitnami": "external-dns",
-      "minimal": "external-dns"
-    },
-    {
-      "bitnami": "fluent-bit",
-      "minimal": "fluent-bit"
-    },
-    {
-      "bitnami": "gitea",
-      "minimal": "gitea"
-    },
-    {
-      "bitnami": "haproxy",
-      "minimal": "haproxy"
-    },
-    {
-      "bitnami": "jenkins",
-      "minimal": "jenkins"
-    },
-    {
-      "bitnami": "kafka",
-      "minimal": "kafka"
-    },
-    {
-      "bitnami": "keycloak",
-      "minimal": "keycloak"
-    },
-    {
-      "bitnami": "kube-state-metrics",
-      "minimal": "kube-state-metrics"
-    },
-    {
       "bitnami": "kubectl",
-      "minimal": "kubectl"
-    },
-    {
-      "bitnami": "mariadb",
-      "minimal": "mariadb"
-    },
-    {
-      "bitnami": "memcached",
-      "minimal": "memcached"
-    },
-    {
-      "bitnami": "metrics-server",
-      "minimal": "metrics-server"
-    },
-    {
-      "bitnami": "minio",
-      "minimal": "minio"
-    },
-    {
-      "bitnami": "mysql",
-      "minimal": "mysql"
-    },
-    {
-      "bitnami": "nats",
-      "minimal": "nats"
-    },
-    {
-      "bitnami": "nginx",
-      "minimal": "nginx"
-    },
-    {
-      "bitnami": "node",
-      "minimal": "node-slim"
-    },
-    {
-      "bitnami": "node-exporter",
-      "minimal": "node-exporter"
-    },
-    {
-      "bitnami": "oauth2-proxy",
-      "minimal": "oauth2-proxy"
-    },
-    {
-      "bitnami": "opensearch",
-      "minimal": "opensearch"
-    },
-    {
-      "bitnami": "pgbouncer",
-      "minimal": "pgbouncer"
-    },
-    {
-      "bitnami": "php-fpm",
-      "minimal": "php"
+      "minimal": "kubectl",
+      "pulls": 5361257070
     },
     {
       "bitnami": "postgresql",
-      "minimal": "postgres-slim"
-    },
-    {
-      "bitnami": "prometheus",
-      "minimal": "prometheus"
-    },
-    {
-      "bitnami": "python",
-      "minimal": "python"
-    },
-    {
-      "bitnami": "rabbitmq",
-      "minimal": "rabbitmq"
+      "minimal": "postgres-slim",
+      "pulls": 3765440722
     },
     {
       "bitnami": "redis",
-      "minimal": "redis-slim"
+      "minimal": "redis-slim",
+      "pulls": 3343290874
     },
     {
-      "bitnami": "ruby",
-      "minimal": "ruby"
+      "bitnami": "external-dns",
+      "minimal": "external-dns",
+      "pulls": 1081810109
     },
     {
-      "bitnami": "solr",
-      "minimal": "solr"
+      "bitnami": "mariadb",
+      "minimal": "mariadb",
+      "pulls": 837247055
     },
     {
-      "bitnami": "thanos",
-      "minimal": "thanos"
+      "bitnami": "rabbitmq",
+      "minimal": "rabbitmq",
+      "pulls": 658403612
     },
     {
-      "bitnami": "tomcat",
-      "minimal": "tomcat"
-    },
-    {
-      "bitnami": "valkey",
-      "minimal": "valkey"
+      "bitnami": "nginx",
+      "minimal": "nginx",
+      "pulls": 438098185
     },
     {
       "bitnami": "zookeeper",
-      "minimal": "zookeeper"
+      "minimal": "zookeeper",
+      "pulls": 337305023
+    },
+    {
+      "bitnami": "kafka",
+      "minimal": "kafka",
+      "pulls": 331194930
+    },
+    {
+      "bitnami": "mysql",
+      "minimal": "mysql",
+      "pulls": 211636763
+    },
+    {
+      "bitnami": "redis-exporter",
+      "minimal": "redis-exporter",
+      "pulls": 170349048
+    },
+    {
+      "bitnami": "metrics-server",
+      "minimal": "metrics-server",
+      "pulls": 146632360
+    },
+    {
+      "bitnami": "etcd",
+      "minimal": "etcd",
+      "pulls": 139730720
+    },
+    {
+      "bitnami": "memcached",
+      "minimal": "memcached",
+      "pulls": 131814356
+    },
+    {
+      "bitnami": "oauth2-proxy",
+      "minimal": "oauth2-proxy",
+      "pulls": 97283418
+    },
+    {
+      "bitnami": "node-exporter",
+      "minimal": "node-exporter",
+      "pulls": 95549585
+    },
+    {
+      "bitnami": "apache",
+      "minimal": "httpd",
+      "pulls": 72649116
+    },
+    {
+      "bitnami": "cassandra",
+      "minimal": "cassandra",
+      "pulls": 70247637
+    },
+    {
+      "bitnami": "kube-state-metrics",
+      "minimal": "kube-state-metrics",
+      "pulls": 63901976
+    },
+    {
+      "bitnami": "prometheus",
+      "minimal": "prometheus",
+      "pulls": 60191607
+    },
+    {
+      "bitnami": "minio",
+      "minimal": "minio",
+      "pulls": 57995601
+    },
+    {
+      "bitnami": "nats",
+      "minimal": "nats",
+      "pulls": 48020203
+    },
+    {
+      "bitnami": "alertmanager",
+      "minimal": "alertmanager",
+      "pulls": 46950331
+    },
+    {
+      "bitnami": "node",
+      "minimal": "node-slim",
+      "pulls": 38812524
+    },
+    {
+      "bitnami": "keycloak",
+      "minimal": "keycloak",
+      "pulls": 32134751
+    },
+    {
+      "bitnami": "thanos",
+      "minimal": "thanos",
+      "pulls": 29655728
+    },
+    {
+      "bitnami": "ruby",
+      "minimal": "ruby",
+      "pulls": 28316652
+    },
+    {
+      "bitnami": "envoy",
+      "minimal": "envoy",
+      "pulls": 23906858
+    },
+    {
+      "bitnami": "solr",
+      "minimal": "solr",
+      "pulls": 23706471
+    },
+    {
+      "bitnami": "pgbouncer",
+      "minimal": "pgbouncer",
+      "pulls": 20426354
+    },
+    {
+      "bitnami": "php-fpm",
+      "minimal": "php",
+      "pulls": 13901261
+    },
+    {
+      "bitnami": "consul",
+      "minimal": "consul",
+      "pulls": 13141935
+    },
+    {
+      "bitnami": "blackbox-exporter",
+      "minimal": "blackbox-exporter",
+      "pulls": 11640721
+    },
+    {
+      "bitnami": "tomcat",
+      "minimal": "tomcat",
+      "pulls": 9462668
+    },
+    {
+      "bitnami": "fluent-bit",
+      "minimal": "fluent-bit",
+      "pulls": 9192380
+    },
+    {
+      "bitnami": "jenkins",
+      "minimal": "jenkins",
+      "pulls": 8906716
+    },
+    {
+      "bitnami": "python",
+      "minimal": "python",
+      "pulls": 6052435
+    },
+    {
+      "bitnami": "rclone",
+      "minimal": "rclone",
+      "pulls": 4083450
+    },
+    {
+      "bitnami": "java",
+      "minimal": "java",
+      "pulls": 2827900
+    },
+    {
+      "bitnami": "oras",
+      "minimal": "oras",
+      "pulls": 2729453
+    },
+    {
+      "bitnami": "valkey",
+      "minimal": "valkey",
+      "pulls": 2480100
+    },
+    {
+      "bitnami": "cosign",
+      "minimal": "cosign",
+      "pulls": 1504183
+    },
+    {
+      "bitnami": "trivy",
+      "minimal": "trivy",
+      "pulls": 1321260
+    },
+    {
+      "bitnami": "pushgateway",
+      "minimal": "pushgateway",
+      "pulls": 989191
+    },
+    {
+      "bitnami": "haproxy",
+      "minimal": "haproxy",
+      "pulls": 966903
+    },
+    {
+      "bitnami": "kaniko",
+      "minimal": "kaniko",
+      "pulls": 798563
+    },
+    {
+      "bitnami": "opensearch",
+      "minimal": "opensearch",
+      "pulls": 656762
+    },
+    {
+      "bitnami": "dex",
+      "minimal": "dex",
+      "pulls": 393800
+    },
+    {
+      "bitnami": "flink",
+      "minimal": "flink",
+      "pulls": 308685
+    },
+    {
+      "bitnami": "gitea",
+      "minimal": "gitea",
+      "pulls": 260091
+    },
+    {
+      "bitnami": "dotnet",
+      "minimal": "dotnet",
+      "pulls": 213344
+    },
+    {
+      "bitnami": "jaeger",
+      "minimal": "jaeger",
+      "pulls": 202051
+    },
+    {
+      "bitnami": "telegraf",
+      "minimal": "telegraf",
+      "pulls": 197320
+    },
+    {
+      "bitnami": "seaweedfs",
+      "minimal": "seaweedfs",
+      "pulls": 64053
+    },
+    {
+      "bitnami": "zipkin",
+      "minimal": "zipkin",
+      "pulls": 17262
+    },
+    {
+      "bitnami": "notation",
+      "minimal": "notation",
+      "pulls": 10891
     }
   ],
-  "missing": [
-    "airflow",
-    "clickhouse",
-    "elasticsearch",
-    "git",
-    "grafana",
-    "influxdb",
-    "mongodb",
-    "os-shell",
-    "spark",
-    "wordpress"
+  "excludedNotPullable": [
+    "flux",
+    "helm",
+    "openbao",
+    "velero"
   ],
-  "verified": "2026-09-01",
-  "verifiedMethod": "Each bitnami/<name> repository confirmed to exist via the Docker Hub API."
+  "topGaps": [
+    {
+      "bitnami": "sealed-secrets-controller",
+      "pulls": 3128013294
+    },
+    {
+      "bitnami": "mongodb",
+      "pulls": 1735833235
+    },
+    {
+      "bitnami": "redis-cluster",
+      "pulls": 274100180
+    },
+    {
+      "bitnami": "azure-cli",
+      "pulls": 207821746
+    },
+    {
+      "bitnami": "redis-sentinel",
+      "pulls": 183562505
+    },
+    {
+      "bitnami": "ghost",
+      "pulls": 131033616
+    },
+    {
+      "bitnami": "elasticsearch",
+      "pulls": 117128276
+    },
+    {
+      "bitnami": "wordpress",
+      "pulls": 109674154
+    },
+    {
+      "bitnami": "phpmyadmin",
+      "pulls": 76521951
+    },
+    {
+      "bitnami": "postgres-exporter",
+      "pulls": 74088428
+    },
+    {
+      "bitnami": "mongodb-exporter",
+      "pulls": 73504497
+    },
+    {
+      "bitnami": "grafana",
+      "pulls": 72433241
+    }
+  ],
+  "gapCount": 320
 }

--- a/site/src/lib/catalog.ts
+++ b/site/src/lib/catalog.ts
@@ -130,3 +130,18 @@ export function siteStats() {
     hasScanData: dataset.hasScanData,
   };
 }
+
+// URL-safe slug for a category, e.g. "Kubernetes, CI & IaC" -> "kubernetes-ci-iac".
+// Used for the /images/category/<slug> landing pages, which give each category a
+// real indexable URL instead of a client-side filter on /images.
+export function categorySlug(category: string): string {
+  return category
+    .toLowerCase()
+    .replace(/&/g, ' ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function categoryFromSlug(slug: string): string | undefined {
+  return categories.find((c) => categorySlug(c) === slug);
+}

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -26,8 +26,8 @@ import CopyButton from '../components/CopyButton.astro';
       <table class="data">
         <thead><tr><th></th><th>Minimal</th><th>Chainguard</th><th>Docker Hardened</th></tr></thead>
         <tbody>
-          <tr><td><b>Catalog size</b></td><td>108</td><td>Thousands</td><td>Hundreds</td></tr>
-          <tr><td><b>Cost</b></td><td>$0, whole catalog</td><td>Free tier; paid for the full catalog</td><td>Free community tier; paid tiers for SLAs</td></tr>
+          <tr><td><b>Catalog size</b></td><td>108</td><td>Thousands</td><td>1,000+ free</td></tr>
+          <tr><td><b>Cost</b></td><td>$0, whole catalog</td><td>Free tier; paid for the full catalog</td><td>$0 for 1,000+ images (Apache-2.0, Dec 2025); paid for SLA/FIPS/STIG</td></tr>
           <tr><td><b>Auth to pull</b></td><td>No</td><td>No (free tier)</td><td>No (community tier)</td></tr>
           <tr><td><b>Build recipes public</b></td><td>Yes</td><td>Yes</td><td>Yes</td></tr>
           <tr><td><b>Cosign + SBOM + provenance</b></td><td>Yes (SLSA Build L2)</td><td>Yes</td><td>Yes (SLSA Build L3)</td></tr>
@@ -42,6 +42,12 @@ import CopyButton from '../components/CopyButton.astro';
         Reach for Minimal if you want a small, readable catalog you can audit end to end — every recipe is MIT-licensed
         and in one repo — without an account or a paid tier. The bigger vendors will serve you better if you need
         thousands of images, a support contract, FedRAMP/STIG paperwork, or SLSA Build L3.
+      </p>
+      <p class="small muted" style="margin-top:14px">
+        &ldquo;Free&rdquo; is no longer a differentiator on its own: Docker released 1,000+ hardened images
+        under Apache-2.0 in December 2025, no account needed. The honest case for Minimal is narrower — a
+        catalog small enough to read end to end, every recipe MIT-licensed in one repo, and no vendor in the
+        loop. See the <a href="/compare/docker-hardened">full comparison</a>.
       </p>
 
       <h2 class="section-title" style="margin-top:44px">More</h2>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -15,8 +15,8 @@ const fmt = (d: string) =>
     <div class="container-narrow">
       <h1 class="section-title">Blog</h1>
       <p class="section-sub">
-        Migration guides and published scan data. Everything here is reproducible from the
-        <a href="https://github.com/rtvkiz/minimal" rel="noopener">public repo</a>.
+        Migration guides and published scan data. Every command and figure here can be re-run
+        against the <a href="https://github.com/rtvkiz/minimal" rel="noopener">public repo</a>.
       </p>
 
       {posts.length === 0 && <p class="notice" style="margin-top:24px">No posts yet.</p>}

--- a/site/src/pages/compare/bitnami.astro
+++ b/site/src/pages/compare/bitnami.astro
@@ -6,7 +6,7 @@ import { images } from '../../lib/catalog';
 
 const title = 'Bitnami alternative — free hardened replacements for deprecated Bitnami images';
 const description =
-  `Bitnami moved its free versioned images to an unmaintained legacy repo. Minimal publishes free, signed, MIT-licensed replacements for ${map.pairs.length} of the most-used Bitnami images.`;
+  `Bitnami moved its free versioned images to an unmaintained legacy repo. Minimal publishes free, signed, MIT-licensed replacements for ${map.pairs.length} of the ${map.bitnamiImages} images Bitnami builds.`;
 
 const schema = [{
   '@context': 'https://schema.org',
@@ -33,9 +33,11 @@ const schema = [{
         being patched.
       </p>
       <p>
-        Minimal covers <b>{map.pairs.length}</b> of the most commonly used Bitnami images, free,
-        with no account and no paid tier. Check the mapping below before you plan anything —
-        there are real gaps, and they are listed too.
+        Bitnami builds <b>{map.bitnamiImages}</b> images. Minimal has an equivalent for
+        <b>{map.pairs.length}</b> of them, free, with no account and no paid tier — which leaves
+        <b>{map.gapCount}</b> with no replacement here. Both lists are below, generated from
+        Bitnami's own repository rather than compiled by hand, and ordered by Docker Hub pull
+        count so the ones people actually run come first.
       </p>
 
       <h2 class="section-title" style="margin-top:44px">Direct replacements</h2>
@@ -45,12 +47,13 @@ const schema = [{
       </p>
       <div style="overflow-x:auto">
         <table class="data">
-          <thead><tr><th>Bitnami image</th><th>Minimal replacement</th></tr></thead>
+          <thead><tr><th>Bitnami image</th><th>Minimal replacement</th><th style="text-align:right">Bitnami pulls</th></tr></thead>
           <tbody>
             {map.pairs.map((p) => (
               <tr>
                 <td class="kv-mono">bitnami/{p.bitnami}</td>
                 <td><a href={`/images/${p.minimal}`}>minimal-{p.minimal}</a></td>
+                <td style="text-align:right" class="kv-mono">{p.pulls ? p.pulls.toLocaleString('en-GB') : '—'}</td>
               </tr>
             ))}
           </tbody>
@@ -59,18 +62,28 @@ const schema = [{
 
       <h2 class="section-title" style="margin-top:44px">What Minimal does not cover</h2>
       <p>
-        These common Bitnami images have <b>no</b> Minimal equivalent. If you depend on one, this
-        catalog does not solve your problem and you should plan accordingly:
+        {map.gapCount} of Bitnami's {map.bitnamiImages} images have no Minimal equivalent. The
+        most-pulled of them:
       </p>
-      <ul>
-        <li><b>grafana</b>, <b>airflow</b>, <b>spark</b>, <b>wordpress</b> — not in the catalog today.</li>
-        <li><b>mongodb</b>, <b>elasticsearch</b> — deliberately excluded on licensing grounds (SSPL and
-          the Elastic License are not open source). <a href="/images/opensearch">opensearch</a> is the
-          closest available substitute for Elasticsearch.</li>
-        <li><b>influxdb</b>, <b>clickhouse</b> — not currently built.</li>
-        <li><b>os-shell</b>, <b>git</b> — utility images used by Bitnami charts as init containers.
-          There is no direct replacement; a <code class="kv-mono">-dev</code> variant is the nearest thing.</li>
-      </ul>
+      <div style="overflow-x:auto">
+        <table class="data">
+          <thead><tr><th>Bitnami image</th><th style="text-align:right">Pulls</th></tr></thead>
+          <tbody>
+            {map.topGaps.map((g: any) => (
+              <tr>
+                <td class="kv-mono">bitnami/{g.bitnami}</td>
+                <td style="text-align:right" class="kv-mono">{g.pulls ? g.pulls.toLocaleString('en-GB') : '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p class="small muted" style="margin-top:14px">
+        Two of these are deliberate rather than pending: <b>mongodb</b> (SSPL) and
+        <b>elasticsearch</b> (Elastic License) are not open source, so they will not be added.
+        <a href="/images/opensearch">opensearch</a> is the closest available substitute for
+        Elasticsearch. The rest are simply not built yet.
+      </p>
 
       <h2 class="section-title" style="margin-top:44px">The three things that will break</h2>
       <p>
@@ -118,9 +131,12 @@ grype ghcr.io/rtvkiz/minimal-postgres-slim:latest`} />
       </p>
 
       <p class="small muted" style="margin-top:32px">
-        Every <code class="kv-mono">bitnami/&lt;name&gt;</code> repository named on this page was
-        confirmed to exist via the Docker Hub API on {map.verified}.
-        Bitnami's catalog changes are documented by Broadcom in
+        This page is generated, not written. The image list comes from
+        <a href="https://github.com/bitnami/containers" rel="noopener nofollow">bitnami/containers</a>
+        (one directory per image Bitnami builds); pull counts and pullability come from the Docker
+        Hub API. A row appears only when both sources agree — {map.excludedNotPullable.length} images
+        Bitnami builds have no pullable Docker Hub repository and are excluded. Generated
+        {map.generated}. Bitnami's catalog changes are documented by Broadcom in
         <a href="https://github.com/bitnami/containers/issues/83267" rel="noopener nofollow">bitnami/containers #83267</a>.
         Details there change; that issue, not this page, is the authority on what Bitnami currently
         publishes. Statements about Minimal are checkable from the <a href="/about">verify page</a>.

--- a/site/src/pages/compare/bitnami.astro
+++ b/site/src/pages/compare/bitnami.astro
@@ -118,6 +118,8 @@ grype ghcr.io/rtvkiz/minimal-postgres-slim:latest`} />
       </p>
 
       <p class="small muted" style="margin-top:32px">
+        Every <code class="kv-mono">bitnami/&lt;name&gt;</code> repository named on this page was
+        confirmed to exist via the Docker Hub API on {map.verified}.
         Bitnami's catalog changes are documented by Broadcom in
         <a href="https://github.com/bitnami/containers/issues/83267" rel="noopener nofollow">bitnami/containers #83267</a>.
         Details there change; that issue, not this page, is the authority on what Bitnami currently

--- a/site/src/pages/compare/docker-hardened.astro
+++ b/site/src/pages/compare/docker-hardened.astro
@@ -1,0 +1,77 @@
+---
+import Layout from '../../components/Layout.astro';
+import CopyButton from '../../components/CopyButton.astro';
+import { images } from '../../lib/catalog';
+
+const title = 'Docker Hardened Images alternative — an honest comparison';
+const description =
+  'Docker released 1,000+ hardened images free under Apache-2.0 in December 2025. Where a 108-image MIT-licensed catalog still makes sense, and where it does not.';
+---
+<Layout title={title} description={description} breadcrumbs={[{ name: 'Compare', href: '/compare' }]}>
+  <section>
+    <div class="container-narrow">
+      <h1 class="section-title">Minimal vs Docker Hardened Images</h1>
+      <p class="section-sub">
+        This is the comparison where Minimal has the weakest case, so it is worth being direct
+        about it rather than burying the fact.
+      </p>
+
+      <h2 class="section-title" style="margin-top:36px">What changed in December 2025</h2>
+      <p>
+        Docker made <b>over 1,000 hardened images free under an Apache-2.0 licence</b>, pullable
+        without an account. Paid tiers remain for SLA-backed critical-CVE remediation, FIPS
+        compliance, DoD STIG artifacts and extended lifecycle support beyond upstream EOL.
+      </p>
+      <p>
+        That removes &ldquo;free hardened images&rdquo; as a differentiator for anyone. It is a
+        genuinely good outcome for the ecosystem, and it means the reason to use this project has
+        to be something other than price.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Where Docker is the better choice</h2>
+      <ul>
+        <li><b>Breadth.</b> 1,000+ images against {images.length}. If your stack is not fully covered here — and the <a href="/images">directory</a> is the place to check — that ends the discussion.</li>
+        <li><b>Compliance evidence.</b> FIPS validation and STIG artifacts are things Minimal does not produce and has no path to producing.</li>
+        <li><b>Remediation you can hold someone to.</b> A contractual fix window for critical CVEs. Here you have a 6-hour rebuild cadence and no obligation behind it.</li>
+        <li><b>Lifecycle support.</b> Paid coverage for software past upstream EOL. Minimal follows upstream and stops when upstream stops.</li>
+        <li><b>SLSA Build L3.</b> Minimal publishes Build L2 and says so.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">Where Minimal still has a case</h2>
+      <ul>
+        <li><b>You can read the whole thing.</b> {images.length} images, every build recipe MIT-licensed in <a href="https://github.com/rtvkiz/minimal" rel="noopener">one repo</a>. Auditing a catalog this size end to end is a day's work, not a project.</li>
+        <li><b>No vendor in the loop.</b> Not a free tier of a commercial product with a pricing page attached — there is no paid tier to be moved onto, and MIT recipes mean you can fork and self-host the whole pipeline if the project stops.</li>
+        <li><b>Modifiable by design.</b> The point is partly that you can take the melange and apko recipes and build your own catalog with your own controls. Docker's images are Apache-2.0 too, but the pipeline that produces them is not the product.</li>
+        <li><b>Published comparison data.</b> Scan results against other providers with the raw dataset and the losing rows included — see <a href="/compare/minimus">Minimus</a> and <a href="/compare/chainguard">Chainguard</a>.</li>
+      </ul>
+
+      <h2 class="section-title" style="margin-top:44px">What we have not measured</h2>
+      <p>
+        There is no head-to-head scan comparison against Docker Hardened Images on this site yet.
+        The <a href="/compare">published dataset</a> covers Minimus and publicly pullable
+        Chainguard images only, and adding a provider means re-running the whole scan with the same
+        frozen database rather than quoting figures from different days. Until that runs, this page
+        makes no claim about relative CVE counts in either direction.
+      </p>
+
+      <h2 class="section-title" style="margin-top:44px">Honest summary</h2>
+      <p>
+        If you want a supported catalog that covers everything, use Docker's — it is free, it is
+        Apache-2.0, and it is broader than this will ever be. Use Minimal if you specifically want a
+        small catalog you can audit completely, recipes you can fork, and no vendor relationship at
+        all. Those are narrower reasons than &ldquo;it's free&rdquo;, and they are the real ones.
+      </p>
+
+      <CopyButton code={`docker pull ghcr.io/rtvkiz/minimal-python:latest
+grype ghcr.io/rtvkiz/minimal-python:latest`} />
+
+      <p class="small muted" style="margin-top:28px">
+        Docker's announcement and current terms are the authority on what Docker Hardened Images
+        include; details change, so check
+        <a href="https://www.docker.com/products/hardened-images" rel="noopener nofollow">docker.com/products/hardened-images</a>
+        rather than this page. Claims about Minimal are checkable from the
+        <a href="/about">verify page</a>. Last reviewed 2026-09-01.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/compare/index.astro
+++ b/site/src/pages/compare/index.astro
@@ -47,6 +47,13 @@ const datasetSchema = {
             higher on {data.chainguard.higher}.
           </p>
         </a>
+        <a class="card" href="/compare/docker-hardened">
+          <h2 style="font-size:1.1rem;margin:0 0 6px">Minimal vs Docker Hardened</h2>
+          <p class="small muted" style="margin:0">
+            Docker released 1,000+ hardened images free under Apache-2.0 in December 2025.
+            Where a small MIT-licensed catalog still makes sense — and where it does not.
+          </p>
+        </a>
         <a class="card" href="/compare/bitnami">
           <h2 style="font-size:1.1rem;margin:0 0 6px">Replacing Bitnami images</h2>
           <p class="small muted" style="margin:0">

--- a/site/src/pages/images/[name].astro
+++ b/site/src/pages/images/[name].astro
@@ -2,7 +2,7 @@
 import Layout from '../../components/Layout.astro';
 import CopyButton from '../../components/CopyButton.astro';
 import SeverityBar from '../../components/SeverityBar.astro';
-import { images, getImage } from '../../lib/catalog';
+import { images, getImage, categorySlug } from '../../lib/catalog';
 
 export function getStaticPaths() {
   return images.map((img) => ({ params: { name: img.name }, props: { image: img } }));
@@ -36,6 +36,10 @@ const pageDescription = [
   `Free and public — pull ${pullRef.split(':')[0]} with no account.`,
 ].join(' ');
 
+const siblings = images
+  .filter((i) => i.category === image.category && i.name !== image.name)
+  .slice(0, 8);
+
 // SoftwareApplication is the closest schema.org type for a distributable
 // container image: it carries the free-of-charge offer, the operating system
 // and the download reference, which is what a rich result needs.
@@ -67,7 +71,7 @@ const schema = [{
       <p style="margin:0 0 6px"><a href="/images" class="small muted">← All images</a></p>
       <h1>
         {image.name}
-        <span class="cat">{image.category}</span>
+        <a class="cat" href={`/images/category/${categorySlug(image.category)}`}>{image.category}</a>
       </h1>
       <p class="summary">{image.summary}</p>
       <div class="quickfacts">
@@ -286,6 +290,28 @@ const schema = [{
   ${image.repo}:latest \\
   | jq -r '.payload | @base64d | fromjson | .predicate'`} />
       <p class="small muted" style="margin-top:20px">Signatures are logged in the public <a href="https://rekor.sigstore.dev" rel="noopener">Rekor</a> transparency log.</p>
+    </div>
+    <!-- Cross-links. Before this, the 108 leaf pages linked only upward to
+         /images: no sibling links, and nothing pointing at /compare or /blog,
+         which left the comparison pages reachable only from the nav. -->
+    <div style="margin-top:48px;padding-top:28px;border-top:1px solid var(--border)">
+      {siblings.length > 0 && (
+        <>
+          <h2 class="section-title" style="font-size:1.05rem">
+            More <a href={`/images/category/${categorySlug(image.category)}`}>{image.category}</a> images
+          </h2>
+          <div class="facets" style="margin-top:12px">
+            {siblings.map((s) => <a class="facet" href={`/images/${s.name}`}>{s.name}</a>)}
+          </div>
+        </>
+      )}
+      <p class="small muted" style="margin-top:22px">
+        Weighing this against another provider? The
+        <a href="/compare">comparison pages</a> publish head-to-head scan data with the raw
+        dataset, including the images where Minimal comes off worse — or read the
+        <a href="/blog/migrating-from-minimus-to-minimal">migration guide</a> for what actually
+        breaks when you switch.
+      </p>
     </div>
   </div>
 

--- a/site/src/pages/images/category/[slug].astro
+++ b/site/src/pages/images/category/[slug].astro
@@ -1,0 +1,74 @@
+---
+import Layout from '../../../components/Layout.astro';
+import ImageCard from '../../../components/ImageCard.astro';
+import { byCategory, categories, categorySlug, images } from '../../../lib/catalog';
+
+// One indexable URL per category. /images groups by category already, but only
+// client-side, so "hardened database container images" had no page to rank —
+// the whole catalogue competed for it as one URL.
+export function getStaticPaths() {
+  const grouped = byCategory();
+  return categories.map((category) => ({
+    params: { slug: categorySlug(category) },
+    props: { category, items: grouped[category] ?? [] },
+  }));
+}
+
+const { category, items } = Astro.props;
+
+// Plain-English framing per category, so each page says something a directory
+// listing does not. Keyed by category name; falls back to a generic line.
+const blurbs: Record<string, string> = {
+  'Languages & Runtimes': 'Base images for building and running applications — most shipping without a shell or package manager, each with a -dev companion carrying the toolchain for your builder stage.',
+  'Databases': 'Datastores and database tooling. These run as non-root by default, so check volume ownership before cutting over an existing data directory.',
+  'Caches, Queues & Messaging': 'Brokers, queues and caches — the stateful middle of most architectures, where a smaller attack surface matters and images are usually long-running.',
+  'Web Servers & Proxies': 'Edge and ingress software: web servers, reverse proxies, load balancers and auth gateways, all built to run as a non-root user.',
+  'Observability': 'Metrics, logs and traces — collectors, stores and exporters. Typically run as sidecars or DaemonSets, so image size and CVE count are multiplied across a fleet.',
+  'Infrastructure': 'DNS, networking, storage and certificate tooling that underpins a cluster rather than serving traffic directly.',
+  'Kubernetes, CI & IaC': 'Cluster tooling, CI utilities and supply-chain scanners. Most are single static binaries, which makes them the smallest images in the catalog.',
+  'Apps': 'End-user applications packaged as hardened images, for self-hosting without pulling in a full distribution.',
+};
+const blurb = blurbs[category] ?? `Hardened ${category.toLowerCase()} container images.`;
+
+const title = `Hardened ${category} container images — free and signed`;
+const description = `${items.length} free, hardened ${category.toLowerCase()} container images. MIT-licensed, cosign-signed with SBOM and build provenance, rebuilt every 6 hours. No account required.`;
+
+const schema = [{
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: `Hardened ${category} container images`,
+  numberOfItems: items.length,
+  itemListElement: items.map((img: any, i: number) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: `minimal-${img.name}`,
+    url: new URL(`/images/${img.name}`, Astro.site).href,
+  })),
+}];
+---
+<Layout title={title} description={description} schema={schema} breadcrumbs={[{ name: 'Images', href: '/images' }]}>
+  <section>
+    <div class="container">
+      <p style="margin:0 0 6px"><a href="/images" class="small muted">← All {images.length} images</a></p>
+      <h1 class="section-title">{category}</h1>
+      <p class="section-sub">{blurb}</p>
+
+      <div class="grid" style="margin-top:28px">
+        {items.map((img: any) => <ImageCard image={img} />)}
+      </div>
+
+      <h2 class="section-title" style="margin-top:44px;font-size:1.15rem">Other categories</h2>
+      <div class="facets" style="margin-top:12px">
+        {categories.filter((c) => c !== category).map((c) => (
+          <a class="facet" href={`/images/category/${categorySlug(c)}`}>{c}</a>
+        ))}
+      </div>
+
+      <p class="small muted" style="margin-top:32px">
+        Every image here is checkable from your terminal — see <a href="/about">how to verify</a> —
+        and compared against other hardened-image providers with published scan data on the
+        <a href="/compare">comparison pages</a>.
+      </p>
+    </div>
+  </section>
+</Layout>

--- a/site/src/pages/images/index.astro
+++ b/site/src/pages/images/index.astro
@@ -1,7 +1,7 @@
 ---
 import Layout from '../../components/Layout.astro';
 import ImageCard from '../../components/ImageCard.astro';
-import { byCategory, categories, images } from '../../lib/catalog';
+import { byCategory, categories, categorySlug, images } from '../../lib/catalog';
 const grouped = byCategory();
 
 // ItemList tells a crawler this is a catalogue and what is in it, rather than
@@ -42,7 +42,9 @@ const schema = [{
       <div id="catalog" style="margin-top:24px">
         {categories.map((c) => (
           <div class="cat-group" data-category={c}>
-            <h2 class="section-title" style="font-size:1.15rem;margin-top:28px">{c}</h2>
+            <h2 class="section-title" style="font-size:1.15rem;margin-top:28px">
+              <a href={`/images/category/${categorySlug(c)}`}>{c}</a>
+            </h2>
             <div class="grid">
               {grouped[c].map((img) => <ImageCard image={img} />)}
             </div>


### PR DESCRIPTION
Continuing the push to rank for "chainguard alternative", "hardened container images" and similar. **131 sitemap URLs, up from 121.**

## First: a stale claim, and what it forces

`/about` said Docker Hardened had **"Hundreds"** of images on a **"Free community tier"**. Docker released **1,000+ hardened images under Apache-2.0 on 2025-12-28**, no account needed, with only SLA/FIPS/STIG tiers paid. That row understated a competitor under a footnote claiming it was verified 2026-08-30 — the same class of error as 4a469d65, in the more embarrassing direction.

Corrected. But the honest follow-through matters more than the row: **"free hardened images" is no longer a differentiator for anyone**, so the pitch cannot rest on it. `/about` and the new comparison page now make the narrower case that survives — a catalog small enough to audit end to end, MIT recipes in one repo, no vendor in the loop.

## `/compare/docker-hardened`

Deliberately the least flattering page on the site. It leads with **where Docker is the better choice** — breadth, FIPS/STIG evidence, contractual remediation windows, lifecycle support past EOL, SLSA L3 — before making any case for Minimal.

It also states plainly that we have **not** scanned Docker Hardened head-to-head, so no CVE claim is made in either direction until that runs with the same frozen database. Quoting numbers from different scan days would be exactly the kind of thing the comparison pages exist to avoid.

## Category landing pages — 8 new URLs

`/images` grouped by category already, but only client-side, so `"hardened database container images"` had no page to rank and the whole catalog competed for it as one URL. Each of the 8 now has its own URL, `ItemList` schema, and a written framing rather than a filtered list.

```
/images/category/databases          /images/category/observability
/images/category/web-servers-proxies    /images/category/infrastructure
/images/category/languages-runtimes     /images/category/kubernetes-ci-iac
/images/category/caches-queues-messaging  /images/category/apps
```

## Internal linking

The 108 leaf pages previously linked only *upward* to `/images` — no sibling links, and nothing pointing at `/compare` or `/blog`, which left the comparison pages reachable only from the nav. Each image page now links to its category, up to 8 siblings, and the comparison/migration content.

## Sitemap freshness

Added `lastmod` — the catalog rebuilds every 6 hours but nothing external could see that, so nothing signalled the site was worth recrawling. Plus `priority` ordering that puts the comparison pages (0.9) above the long tail of image pages (0.5).

## Validation

- `npm run build` clean
- 131 sitemap URLs, all 13 new ones verified present
- 247 JSON-LD blocks, all parse (`ItemList` 2 → 10 with the category pages)
- `"Hundreds"` verified gone from the built `/about`
- `images.json` excluded — build artifact regenerated at deploy