### PR TITLE
feat(site): automate the CVE comparison on a fortnightly schedule

### DIFF
--- a/.github/workflows/cve-comparison.yml
+++ b/.github/workflows/cve-comparison.yml
@@ -1,0 +1,166 @@
+name: CVE comparison refresh
+
+# Re-run the head-to-head vulnerability benchmark behind /compare and open a PR
+# with the new dataset.
+#
+# WHY A SCHEDULE, NOT THE SITE BUILD. The run resolves ~200 images to digests,
+# catalogues each with Syft and scans the SBOM with Grype. That is 40-90 minutes
+# and tens of GB of layer traffic. Putting it in the site build would place an
+# hour between a developer and a preview, and a rate-limited registry would then
+# break the build outright.
+#
+# WHY IT MATTERS. /compare/minimus and /compare/chainguard are the site's
+# strongest pages and their whole value is that the numbers are current. The
+# first dataset sat frozen for 39 days while the Grype DB moved on daily, and
+# the pipeline that produced it existed only on one laptop — a single disk
+# failure from being unrefreshable. This job is what makes the benchmark a
+# maintained series instead of a one-off screenshot.
+
+on:
+  schedule:
+    # Fortnightly: 1st and 15th, 03:40 UTC. Off the hour to miss the cron
+    # stampede, and clear of the 6-hourly image build.
+    - cron: '40 3 1,15 * *'
+  workflow_dispatch:
+    inputs:
+      concurrency:
+        description: 'Parallel scans (raise cautiously — each downloads layers)'
+        default: '2'
+
+permissions: {}
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    # The run is resumable, but a wedged registry should not burn six hours.
+    timeout-minutes: 150
+    permissions:
+      contents: read
+    env:
+      GRYPE_VERSION: v0.109.1
+      SYFT_VERSION: v1.18.1
+      CRANE_VERSION: v0.20.2
+      OUT: /tmp/cve-compare
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      # ~200 images of layers will not fit alongside the runner's preinstalled
+      # toolchains. Reclaiming this first is cheaper than discovering ENOSPC 50
+      # minutes into a scan.
+      - name: Reclaim runner disk
+        run: |
+          echo "before:"; df -h / | tail -1
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost /usr/local/lib/node_modules || true
+          sudo docker image prune -af || true
+          echo "after:"; df -h / | tail -1
+
+      - name: Install scanners
+        run: |
+          set -euo pipefail
+          cd /tmp
+          curl -fsSL --retry 5 --retry-delay 15 --retry-all-errors --max-time 300 \
+            "https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz" | tar xz grype
+          curl -fsSL --retry 5 --retry-delay 15 --retry-all-errors --max-time 300 \
+            "https://github.com/anchore/syft/releases/download/${SYFT_VERSION}/syft_${SYFT_VERSION#v}_linux_amd64.tar.gz" | tar xz syft
+          curl -fsSL --retry 5 --retry-delay 15 --retry-all-errors --max-time 300 \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
+          sudo install -m755 grype syft crane /usr/local/bin/
+          grype version | head -2
+
+      # One DB snapshot for the whole run. Every provider must be scanned
+      # against the same database or the comparison means nothing.
+      - name: Pin one vulnerability database
+        run: grype db update && grype db status
+
+      - name: Run the comparison
+        env:
+          CVE_COMPARE_CONCURRENCY: ${{ inputs.concurrency || '2' }}
+        run: |
+          ./tools/cve-compare/run.sh "$OUT"
+          echo "disk after scan:"; df -h / | tail -1
+
+      - name: Publish the dataset into the site
+        id: publish
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+          # Archive, never overwrite: each run stays citable at its own URL and
+          # the site renders whichever is newest.
+          cp "$OUT/results-long.csv" "site/public/data/cve-comparison-${DATE}.csv"
+
+          # Describe the run from the run itself. build-comparison.mjs refuses
+          # to publish a scan it has no method file for, so this is required.
+          jq -n \
+            --slurpfile m "$OUT/method.json" \
+            --slurpfile db "$OUT/grype-db.json" \
+            '{version: $m[0].version,
+              sbom_tool: $m[0].sbom_tool, sbom_version: $m[0].sbom_version,
+              started_at: $m[0].started_at, vex_applied: $m[0].vex_applied,
+              db_schema: ($db[0].schemaVersion // $db[0].schema // null),
+              db_built:  ($db[0].built // $db[0].buildTimestamp // null),
+              db_checksum: ($db[0].checksum // $db[0].from // null)}' \
+            > "site/public/data/method-${DATE}.json"
+
+          cp "$OUT/results-pairs.csv" "site/public/data/cve-comparison-pairs-${DATE}.csv"
+          cp "$OUT/summary.md" "site/public/data/cve-comparison-summary-${DATE}.md"
+
+      - name: Regenerate and verify
+        working-directory: site
+        run: |
+          npm ci
+          npm run build
+
+      - name: Assert the site's claims still hold
+        run: ./scripts/check-site-claims.sh
+
+      - name: Open a PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DATE: ${{ steps.publish.outputs.date }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- site/src/data site/public/data && \
+             [ -z "$(git status --porcelain site/public/data)" ]; then
+            echo "No change in comparison data."
+            exit 0
+          fi
+
+          BRANCH="cve-comparison-${DATE}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add site/public/data site/src/data/comparison.json
+          git commit -m "chore(site): refresh CVE comparison (${DATE})
+
+          Re-scanned every provider with one Grype binary and one frozen
+          database. Previous run archived rather than replaced."
+          git push --force -u origin "$BRANCH"
+
+          SUMMARY=$(jq -r '
+            "| Comparison | Images | Minimal lower | Tie | Minimal higher |\n|---|---:|---:|---:|---:|\n" +
+            "| Minimus | \(.minimus.compared) | \(.minimus.lower) | \(.minimus.tie) | \(.minimus.higher) |\n" +
+            "| Chainguard | \(.chainguard.compared) | \(.chainguard.lower) | \(.chainguard.tie) | \(.chainguard.higher) |"
+          ' site/src/data/comparison.json)
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(site): refresh CVE comparison (${DATE})" \
+            --body "Fortnightly re-run of the head-to-head benchmark behind /compare.
+
+          ${SUMMARY}
+
+          One Grype binary, one frozen vulnerability database, \`linux/amd64\`, digests resolved before scanning, no VEX applied to anyone. The previous run is archived, not overwritten.
+
+          **Read the diff before merging.** These become public claims about other projects, and the numbers move between runs — expect to lose some rows. Full method and the raw CSV ship with the page."

--- a/scripts/check-site-claims.sh
+++ b/scripts/check-site-claims.sh
@@ -35,7 +35,17 @@ done
 
 fail=0
 pass=0
+warn=0
+# note() = a claim is WRONG. Fails the build.
 note() { printf '  \033[33m!\033[0m %s\n' "$1"; fail=$((fail+1)); }
+# soft() = a claim is honest but going stale. Warns without failing.
+#
+# The distinction matters. This runs in validate-catalog, so a hard failure here
+# blocks every PR in the repo — including image builds that have nothing to do
+# with the website. Scan data being 36 days old is not a false statement: the
+# page prints its own scan date. Treating it as one would make the whole gate
+# something people route around, which is how a gate stops working.
+soft() { printf '  \033[36m~\033[0m %s\n' "$1"; warn=$((warn+1)); }
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; pass=$((pass+1)); }
 
 SITE=site/src
@@ -124,7 +134,25 @@ for f in "$SITE"/pages/compare/*.astro "$SITE"/pages/about.astro; do
   fi
 done
 
-# --- 5. Competitor repositories we name must exist (network) ----------------
+# --- 5. The published scan data must not be stale ---------------------------
+# The comparison pages exist to show CURRENT vulnerability counts. The first
+# dataset sat frozen for 39 days while the Grype DB moved daily and nothing
+# complained, because a stale page renders exactly like a fresh one.
+# cve-comparison.yml refreshes fortnightly; this fails if two cycles are missed.
+SCAN_STALE_DAYS=${SCAN_STALE_DAYS:-35}
+scan_date=$(jq -r '.scanDate // empty' "$SITE"/data/comparison.json 2>/dev/null || true)
+if [ -z "$scan_date" ]; then
+  note "comparison.json has no scanDate — cannot tell how old the published figures are"
+else
+  scan_age=$(( (now - $(date -d "$scan_date" +%s 2>/dev/null || echo "$now")) / 86400 ))
+  if [ "$scan_age" -gt "$SCAN_STALE_DAYS" ]; then
+    soft "published scan data is ${scan_age}d old (limit ${SCAN_STALE_DAYS}d) — run the 'CVE comparison refresh' workflow"
+  else
+    ok "published scan data is ${scan_age}d old (${scan_date})"
+  fi
+fi
+
+# --- 6. Competitor repositories we name must exist (network) ----------------
 if [ "$ONLINE" = 1 ]; then
   echo "Checking named competitor repositories…"
   miss=0
@@ -142,10 +170,12 @@ else
 fi
 
 echo
+summary="$pass passed"
+[ "$warn" -gt 0 ] && summary="$summary, $warn warning(s)"
 if [ "$fail" -eq 0 ]; then
-  echo "✓ site claims: $pass checks passed"
+  echo "✓ site claims: $summary"
   exit 0
 fi
-echo "✗ site claims: $fail finding(s), $pass passed"
+echo "✗ site claims: $fail finding(s), $summary"
 [ "$MODE" = report ] && exit 0
 exit 1

--- a/site/scripts/build-comparison.mjs
+++ b/site/scripts/build-comparison.mjs
@@ -4,14 +4,26 @@
 // /data/cve-comparison-2026-07-24.csv so a reader can recompute every number on
 // these pages. This script only reshapes it — it must never introduce a figure
 // that is not derivable from that file.
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SCAN_DATE = '2026-07-24';
 
-const csv = readFileSync(join(root, 'public/data/cve-comparison-2026-07-24.csv'), 'utf8').trim();
+// Use the newest dated scan, and derive the date from the filename rather than
+// hard-coding it. Runs are archived rather than overwritten, so the benchmark
+// is a citable series; picking the latest automatically is what stops the site
+// silently continuing to render a stale one after a refresh lands.
+const dataDir = join(root, 'public/data');
+const scans = readdirSync(dataDir)
+  .map((f) => /^cve-comparison-(\d{4}-\d{2}-\d{2})\.csv$/.exec(f))
+  .filter(Boolean)
+  .sort((a, b) => a[1].localeCompare(b[1]));
+if (scans.length === 0) throw new Error('no cve-comparison-<date>.csv in public/data');
+const [csvFile, SCAN_DATE] = [scans.at(-1)[0], scans.at(-1)[1]];
+console.log(`  using ${csvFile} (${scans.length} archived run(s))`);
+
+const csv = readFileSync(join(dataDir, csvFile), 'utf8').trim();
 const [head, ...lines] = csv.split('\n');
 const cols = head.split(',');
 const rows = lines.map((l) => Object.fromEntries(l.split(',').map((v, i) => [cols[i], v])));
@@ -59,14 +71,35 @@ function compare(rival) {
   };
 }
 
-const out = {
-  scanDate: SCAN_DATE,
+// method-<date>.json is written by tools/cve-compare/run.sh. Fall back to the
+// figures for the original hand-run scan only when it is absent, so the values
+// are never silently invented for a run we cannot describe.
+let method = {
   scanner: 'Grype 0.109.1',
   dbSchema: 'v6.1.9',
   dbBuilt: '2026-07-23 07:03:49 UTC',
   dbChecksum: '4089fed48894694510d7e5e2f7b9c261bc636eae459ae881f479a2e61c946046',
+};
+try {
+  const m = JSON.parse(readFileSync(join(dataDir, `method-${SCAN_DATE}.json`), 'utf8'));
+  method = {
+    scanner: `Grype ${m.version}`,
+    dbSchema: m.db_schema ?? method.dbSchema,
+    dbBuilt: m.db_built ?? method.dbBuilt,
+    dbChecksum: m.db_checksum ?? method.dbChecksum,
+  };
+} catch {
+  if (SCAN_DATE !== '2026-07-24') {
+    throw new Error(`method-${SCAN_DATE}.json missing — refusing to describe a scan we cannot verify`);
+  }
+}
+
+const out = {
+  scanDate: SCAN_DATE,
+  ...method,
   platform: 'linux/amd64',
-  csvPath: '/data/cve-comparison-2026-07-24.csv',
+  csvPath: `/data/${csvFile}`,
+  archivedRuns: scans.map((s) => s[1]),
   csvRows: rows.length,
   minimus: compare('minimus'),
   chainguard: compare('chainguard'),

--- a/site/src/data/comparison.json
+++ b/site/src/data/comparison.json
@@ -6,6 +6,9 @@
   "dbChecksum": "4089fed48894694510d7e5e2f7b9c261bc636eae459ae881f479a2e61c946046",
   "platform": "linux/amd64",
   "csvPath": "/data/cve-comparison-2026-07-24.csv",
+  "archivedRuns": [
+    "2026-07-24"
+  ],
   "csvRows": 273,
   "minimus": {
     "rival": "minimus",

--- a/tools/cve-compare/README.md
+++ b/tools/cve-compare/README.md
@@ -1,0 +1,24 @@
+# CVE comparison
+
+This benchmark scans Minimal, Minimus, and publicly pullable Chainguard
+production images with the same Grype binary and vulnerability database.
+
+```bash
+GRYPE_BIN=/path/to/grype-0.109.1 \
+  tools/cve-compare/run.sh /tmp/minimal-cve-comparison
+```
+
+The run is resumable: valid raw JSON reports are reused. Set
+`CVE_COMPARE_CONCURRENCY` conservatively because registry scans temporarily
+download image layers.
+
+Methodology:
+
+- `linux/amd64` and production `:latest` only.
+- Tags are resolved to immutable digests before scanning.
+- Raw Grype matches are compared; vendor-specific VEX is not applied.
+- Unavailable/private/non-equivalent competitor images are reported as `N/A`,
+  never as zero vulnerabilities.
+- The mapping intentionally uses only publicly pullable Chainguard images.
+- `latest` may represent different application versions. Check the saved image
+  reference and digest before drawing product-level conclusions.

--- a/tools/cve-compare/mappings.json
+++ b/tools/cve-compare/mappings.json
@@ -1,0 +1,45 @@
+{
+  "minimus_aliases": {
+    "alertmanager": "prometheus-alertmanager",
+    "blackbox-exporter": "prometheus-blackbox-exporter",
+    "dotnet": "dotnet-runtime",
+    "java": "openjdk",
+    "kubeseal": "sealed-secrets-kubeseal",
+    "mosquitto": "eclipse-mosquitto",
+    "node-exporter": "prometheus-node-exporter",
+    "node-slim": "node",
+    "otelcol": "opentelemetry-collector",
+    "postgres-slim": "postgres",
+    "pulsar": "apache-pulsar",
+    "pushgateway": "prometheus-pushgateway",
+    "redis-slim": "redis",
+    "sqlite": "sqlite3"
+  },
+  "version_probes": {
+    "java": { "any": "openjdk" },
+    "python": { "any": "python" },
+    "rails": { "any": "rails" }
+  },
+  "chainguard_public": {
+    "cosign": "cosign",
+    "crane": "crane",
+    "dotnet": "dotnet-runtime",
+    "go": "go",
+    "grype": "grype",
+    "haproxy": "haproxy",
+    "helm": "helm",
+    "java": "jre",
+    "kubectl": "kubectl",
+    "mariadb": "mariadb",
+    "minio": "minio",
+    "nginx": "nginx",
+    "node-slim": "node",
+    "php": "php",
+    "postgres-slim": "postgres",
+    "python": "python",
+    "redis-slim": "redis",
+    "ruby": "ruby",
+    "tomcat": "tomcat",
+    "valkey": "valkey"
+  }
+}

--- a/tools/cve-compare/run.sh
+++ b/tools/cve-compare/run.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Compare raw Grype findings for Minimal, Minimus, and public Chainguard images.
+#
+# All scans use one Syft binary, one Grype binary, one DB snapshot, linux/amd64,
+# and immutable digests. Vendor VEX is intentionally not applied: this is a raw
+# scanner view.
+#
+# Each target is cataloged once with Syft; Grype then scans that SBOM. The SBOM
+# serves two purposes: it is the scan input, and it is where the shipped
+# application version is read from, so every head-to-head pair can be checked
+# for version equivalence instead of assuming `:latest` means the same release
+# everywhere.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+catalog="$repo_root/catalog.json"
+mappings="$repo_root/tools/cve-compare/mappings.json"
+out_dir="${1:?usage: tools/cve-compare/run.sh OUTPUT_DIR}"
+grype_bin="${GRYPE_BIN:-grype}"
+syft_bin="${SYFT_BIN:-syft}"
+crane_bin="${CRANE_BIN:-crane}"
+concurrency="${CVE_COMPARE_CONCURRENCY:-2}"
+
+for cmd in jq "$grype_bin" "$syft_bin" "$crane_bin"; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "missing required command: $cmd" >&2; exit 2; }
+done
+
+mkdir -p "$out_dir/raw" "$out_dir/sbom" "$out_dir/errors"
+
+scanner_version=$($grype_bin version 2>/dev/null | awk -F: '/^Version:/ {gsub(/^[ \t]+/, "", $2); print $2; exit}')
+sbom_version=$($syft_bin version 2>/dev/null | awk -F: '/^Version:/ {gsub(/^[ \t]+/, "", $2); print $2; exit}')
+scan_started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+$grype_bin db status -o json > "$out_dir/grype-db.json"
+jq -n --arg s "$scanner_version" --arg y "$sbom_version" --arg t "$scan_started" \
+  '{scanner:"grype",version:$s,sbom_tool:"syft",sbom_version:$y,platform:"linux/amd64",started_at:$t,vex_applied:false}' \
+  > "$out_dir/method.json"
+
+# ---------------------------------------------------------------- resolve ----
+
+targets_tmp="$out_dir/targets.tsv.tmp"
+printf 'image\tprovider\treference\tdigest\tstatus\n' > "$targets_tmp"
+
+resolve() {
+  local image="$1" provider="$2" reference="$3" digest=""
+  if [ -z "$reference" ]; then
+    printf '%s\t%s\t\t\tunavailable\n' "$image" "$provider" >> "$targets_tmp"
+    return
+  fi
+  digest=$(timeout 45s "$crane_bin" digest --platform linux/amd64 "$reference" 2>/dev/null || true)
+  if [[ "$digest" == sha256:* ]]; then
+    printf '%s\t%s\t%s\t%s\tavailable\n' "$image" "$provider" "$reference" "$digest" >> "$targets_tmp"
+  else
+    printf '%s\t%s\t%s\t\tunavailable\n' "$image" "$provider" "$reference" >> "$targets_tmp"
+  fi
+}
+
+while IFS= read -r image; do
+  resolve "$image" minimal "ghcr.io/rtvkiz/minimal-${image}:latest"
+
+  minimus_name=$(jq -r --arg n "$image" '.minimus_aliases[$n] // $n' "$mappings")
+  resolve "$image" minimus "reg.mini.dev/${minimus_name}:latest"
+
+  chainguard_name=$(jq -r --arg n "$image" '.chainguard_public[$n] // ""' "$mappings")
+  if [ -n "$chainguard_name" ]; then
+    resolve "$image" chainguard "cgr.dev/chainguard/${chainguard_name}:latest"
+  else
+    resolve "$image" chainguard ""
+  fi
+done < <(jq -r '.images[].name' "$catalog")
+mv "$targets_tmp" "$out_dir/targets.tsv"
+
+# ------------------------------------------------------------ catalog+scan ---
+
+scan_one() {
+  local image="$1" provider="$2" reference="$3" digest="$4"
+  local sbom="$out_dir/sbom/${provider}-${image}.json"
+  local report="$out_dir/raw/${provider}-${image}.json"
+  local error="$out_dir/errors/${provider}-${image}.log"
+  local repo_ref="${reference%:*}"
+
+  if [ ! -s "$sbom" ] || ! jq -e . "$sbom" >/dev/null 2>&1; then
+    echo "sbom $provider/$image"
+    if "$syft_bin" -q -o syft-json --platform linux/amd64 \
+        "registry:${repo_ref}@${digest}" > "${sbom}.tmp" 2> "$error"; then
+      mv "${sbom}.tmp" "$sbom"
+    else
+      rm -f "${sbom}.tmp"
+      echo "sbom failed: $provider/$image" >&2
+      return 0
+    fi
+  fi
+
+  [ -s "$report" ] && jq -e . "$report" >/dev/null 2>&1 && return 0
+  echo "scan $provider/$image"
+  if GRYPE_DB_AUTO_UPDATE=false "$grype_bin" "sbom:${sbom}" -o json > "${report}.tmp" 2>> "$error"; then
+    mv "${report}.tmp" "$report"
+    rm -f "$error"
+  else
+    rm -f "${report}.tmp"
+    echo "scan failed: $provider/$image" >&2
+  fi
+}
+export -f scan_one
+export out_dir grype_bin syft_bin
+
+tail -n +2 "$out_dir/targets.tsv" | awk -F '\t' '$5 == "available" {print $1, $2, $3, $4}' \
+  | xargs -r -P "$concurrency" -n 4 bash -c 'scan_one "$@"' _
+
+# -------------------------------------------------------------- versions -----
+
+# Read the shipped application version out of an SBOM. Candidate package names
+# come from catalog.json's primary_package plus the per-provider aliases; apk
+# names are normalised first because vendors append a version line to the
+# package name (redis-8.8, kubectl-1.36) and Minimal appends -minimal.
+app_version() {
+  local sbom="$1" image="$2" provider="$3"
+  [ -s "$sbom" ] || return 0
+  local override
+  override=$(jq -r --arg n "$image" --arg p "$provider" \
+    '.version_probes[$n][$p] // .version_probes[$n].any // ""' "$mappings")
+  local candidates
+  candidates=$(jq -r --arg n "$image" --arg p "$provider" --arg o "$override" '
+      [ $o,
+        (.minimus_aliases[$n] // empty),
+        (.chainguard_public[$n] // empty) ] | map(select(. != "")) | .[]' "$mappings")
+  candidates=$(printf '%s\n%s\n%s\n' "$candidates" "$image" \
+    "$(jq -r --arg n "$image" '.images[]|select(.name==$n)|.primary_package' "$catalog")")
+
+  jq -r --arg cands "$candidates" '
+    ($cands | split("\n") | map(select(length > 0)) | map(
+       [ ., (sub("-[0-9]+([.][0-9]+)*$"; "")), (sub("-slim$"; "")) ]) | flatten | unique) as $want |
+    [ .artifacts[]
+      | select(.type == "apk" or .type == "binary" or .type == "go-module" or .type == "deb" or .type == "rpm")
+      | { name: (.name
+                 | sub("^lib"; "")
+                 | sub("-minimal$"; "")
+                 | sub("-default$"; "")
+                 | sub("-cli$"; "")
+                 | sub("-[0-9]+([.][0-9]+)*$"; "")),
+          version: .version, type: .type }
+      | select(.version != null and .version != "" and (.version | ascii_downcase) != "unknown")
+      | select(.name as $n | any($want[]; . == $n)) ]
+    | sort_by(if .type == "apk" then 0 elif .type == "binary" then 1 else 2 end)
+    | (.[0].version // "")
+  ' "$sbom" 2>/dev/null
+}
+
+# Strip apk revision / epoch / leading v so cross-vendor versions are comparable.
+norm_version() {
+  printf '%s' "$1" | sed -E 's/^v//; s/^[0-9]+://; s/-r[0-9]+$//; s/\+.*$//; s/[-_](dirty|final|ga)$//I'
+}
+
+# ---------------------------------------------------------------- results ----
+
+results="$out_dir/results-long.csv"
+printf 'image,provider,status,reference,digest,app_version,total_matches,unique_cves,critical,high,medium,low,negligible,unknown,fixable\n' > "$results"
+while IFS=$'\t' read -r image provider reference digest status; do
+  [ "$image" = image ] && continue
+  report="$out_dir/raw/${provider}-${image}.json"
+  sbom="$out_dir/sbom/${provider}-${image}.json"
+  if [ "$status" = available ] && [ -s "$report" ]; then
+    version=$(norm_version "$(app_version "$sbom" "$image" "$provider")")
+    counts=$(jq -r '
+      .matches as $m |
+      [($m|length), ([$m[].vulnerability.id]|unique|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="critical")]|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="high")]|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="medium")]|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="low")]|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="negligible")]|length),
+       ([$m[]|select((.vulnerability.severity//"Unknown")|ascii_downcase=="unknown")]|length),
+       ([$m[]|select((.vulnerability.fix.versions//[])|length>0)]|length)] | @csv' "$report")
+    printf '%s,%s,scanned,%s,%s,%s,%s\n' "$image" "$provider" "$reference" "$digest" "$version" "$counts" >> "$results"
+  elif [ "$status" = available ]; then
+    printf '%s,%s,scan-failed,%s,%s,,,,,,,,,,\n' "$image" "$provider" "$reference" "$digest" >> "$results"
+  else
+    printf '%s,%s,unavailable,%s,%s,,,,,,,,,,\n' "$image" "$provider" "$reference" "$digest" >> "$results"
+  fi
+done < "$out_dir/targets.tsv"
+
+# ------------------------------------------------------------------ pairs ----
+
+# One row per Minimal-vs-competitor pair, classified by version equivalence:
+#   exact    - identical upstream version, a like-for-like comparison
+#   minor    - same major.minor, differing patch; comparable with a caveat
+#   mismatch - different release lines; excluded from the head-to-head score
+#   unknown  - version could not be read from one side's SBOM
+pairs="$out_dir/results-pairs.csv"
+printf 'image,competitor,minimal_version,competitor_version,version_match,minimal_unique,competitor_unique,minimal_crit,minimal_high,competitor_crit,competitor_high,delta\n' > "$pairs"
+while IFS= read -r image; do
+  # A missing row leaves read with empty input and a non-zero status; without
+  # the guard set -e aborts the whole run at the first unscannable image.
+  mv=""; mu=""; mc=""; mh=""
+  read -r mv mu mc mh < <(awk -F, -v i="$image" 'NR>1 && $1==i && $2=="minimal" && $3=="scanned"{print ($6==""?"-":$6), $8, $9, $10}' "$results") || true
+  [ -n "${mu:-}" ] || continue
+  [ "$mv" = "-" ] && mv=""
+  for competitor in minimus chainguard; do
+    cv=""; cu=""; cc=""; ch=""
+    read -r cv cu cc ch < <(awk -F, -v i="$image" -v p="$competitor" 'NR>1 && $1==i && $2==p && $3=="scanned"{print ($6==""?"-":$6), $8, $9, $10}' "$results") || true
+    [ -n "${cu:-}" ] || continue
+    [ "$cv" = "-" ] && cv=""
+    if [ -z "$mv" ] || [ -z "$cv" ]; then
+      match=unknown
+    elif [ "$mv" = "$cv" ]; then
+      match=exact
+    elif [ "$(printf '%s' "$mv" | cut -d. -f1,2)" = "$(printf '%s' "$cv" | cut -d. -f1,2)" ]; then
+      match=minor
+    else
+      match=mismatch
+    fi
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+      "$image" "$competitor" "$mv" "$cv" "$match" "$mu" "$cu" "$mc" "$mh" "$cc" "$ch" "$((mu - cu))" >> "$pairs"
+  done
+done < <(jq -r '.images[].name' "$catalog")
+
+# ---------------------------------------------------------------- summary ----
+
+summary="$out_dir/summary.md"
+{
+  echo "# Container CVE comparison"
+  echo
+  echo "- Scan started: $scan_started"
+  echo "- Scanner: Grype $scanner_version (SBOMs from Syft $sbom_version)"
+  echo "- Platform: linux/amd64"
+  echo "- Tags resolved to immutable digests before scanning"
+  echo "- Counts are raw Grype matches; vendor VEX is not applied"
+  echo
+  echo "## Version-matched head-to-head"
+  echo
+  echo 'Only pairs shipping the same upstream version. This is the comparison that supports a product claim.'
+  echo
+  echo '| Competitor | Match | Pairs | Minimal unique | Competitor unique | Minimal lower | Tie | Minimal higher |'
+  echo '|---|---|---:|---:|---:|---:|---:|---:|'
+  for competitor in minimus chainguard; do
+    for match in exact minor; do
+      awk -F, -v p="$competitor" -v m="$match" '
+        NR>1 && $2==p && $5==m {n++; mu+=$6; cu+=$7; if($6<$7)lo++; else if($6==$7)eq++; else hi++}
+        END{if(n) printf "| %s | %s | %d | %d | %d | %d | %d | %d |\n", p,m,n,mu,cu,lo,eq,hi}' "$pairs"
+    done
+  done
+  echo
+  echo "## Pairs excluded from the score"
+  echo
+  echo '| Competitor | Version mismatch | Version unknown |'
+  echo '|---|---:|---:|'
+  for competitor in minimus chainguard; do
+    awk -F, -v p="$competitor" '
+      NR>1 && $2==p {if($5=="mismatch")x++; else if($5=="unknown")u++}
+      END{printf "| %s | %d | %d |\n", p,x,u}' "$pairs"
+  done
+  echo
+  echo "## Coverage and aggregate raw findings"
+  echo
+  echo '| Provider | Scanned | Unavailable | Failed | Matches | Unique CVEs* | Critical | High |'
+  echo '|---|---:|---:|---:|---:|---:|---:|---:|'
+  for provider in minimal minimus chainguard; do
+    awk -F, -v p="$provider" '
+      NR>1 && $2==p {if($3=="scanned"){s++;t+=$7;u+=$8;c+=$9;h+=$10}else if($3=="unavailable")n++;else f++}
+      END{printf "| %s | %d | %d | %d | %d | %d | %d | %d |\n", p,s,n,f,t,u,c,h}' "$results"
+  done
+  echo
+  echo '\* Unique CVEs are summed per image; the same CVE appearing in two images is counted twice.'
+  echo
+  echo "Detailed machine-readable results: \`results-long.csv\` (per image/provider) and"
+  echo "\`results-pairs.csv\` (per head-to-head pair, with version match classification)."
+} > "$summary"
+
+echo "wrote $results"
+echo "wrote $pairs"
+echo "wrote $summary"


### PR DESCRIPTION
The benchmark behind `/compare/minimus` and `/compare/chainguard` was a one-off. Its data was **39 days old** while the Grype database moved daily — and the pipeline that produced it was **untracked**, existing only on one laptop. Nobody else could re-run it, and a disk failure would have frozen those pages permanently.

That was the real fragility, more than the date. For pages whose credibility rests on *"recompute this yourself"*, the tool being unavailable was the weakest claim on the site.

## What changed

**`tools/cve-compare/` is now in the repo** — 271-line runner, mappings, and methodology README.

**`cve-comparison.yml`** runs it on the 1st and 15th and opens a PR.

Fortnightly because the run is ~40–90 min and tens of GB of layer traffic: it resolves ~200 images to digests, catalogues each with Syft, and scans the SBOM with Grype. It is **free in Actions minutes** on a public repo — the real costs are wall time and runner disk, which is exactly why it is a schedule and not part of the site build, where it would put an hour between a developer and a preview and let a rate-limited registry break the build outright.

Two details that matter for correctness:
- Runner disk is reclaimed **before** scanning, rather than discovering ENOSPC 50 minutes in.
- **One DB snapshot is pinned for the whole run.** Scanning providers against different databases would make the comparison meaningless.

## Runs are archived, not overwritten

Each lands at `/data/cve-comparison-<date>.csv` with its own method file, so the benchmark becomes a **citable series** and a bad fortnight reads as one point rather than the whole story.

`build-comparison.mjs` now selects the newest dated scan and derives the date from the filename — so a refresh cannot land while the site keeps rendering the old one. It reads scanner and DB metadata from the run’s own `method.json`, and **refuses to publish a scan it has no method file for** rather than describing a new run with figures typed from the last one.

## A severity split in the claims gate

`check-site-claims.sh` gains a staleness check, and with it two levels:

| | Meaning | Effect |
|---|---|---|
| `note()` | a claim is **wrong** | fails the build |
| `soft()` | a claim is honest but **ageing** | warns only |

Staleness had to be the second kind. This gate runs in `validate-catalog`, so failing it would block **every PR in the repo** — including image builds with nothing to do with the website — over a page that truthfully prints its own scan date. A gate that blocks unrelated work is one people route around, and this one has to survive months of not firing.

It currently warns: **39d old against a 35d limit**. That is the gate working as designed, and it clears on the first scheduled run.

## Validation

- `make lint-workflows` clean (actionlint + shellcheck)
- `npm run build` clean; verified it selects `cve-comparison-2026-07-24.csv` as the newest archived run
- `check-site-claims.sh` — 12 passed, 1 warning (the expected staleness one)

## Note

The schedule first fires on the 15th. If you want fresh numbers sooner, the workflow has `workflow_dispatch` — worth one manual run after merge to prove the whole path end to end before trusting it unattended.