### PR TITLE
feat(images): onboard syncthing and nsq, source-built from upstream

### DIFF
--- a/.github/versions.yaml
+++ b/.github/versions.yaml
@@ -335,6 +335,28 @@
     releases: "https://github.com/restic/restic/releases"
     notes: "https://github.com/restic/restic/releases/tag/v{version}"
 
+- name: syncthing
+  cron-enabled: true   # validated 2026-09-05 (see PR)
+  files: [images/syncthing/melange.yaml]
+  # Release candidates are published as GitHub pre-releases, and
+  # /releases/latest skips those, so this tracks stable only without a pattern.
+  source: { type: github-releases-latest, repo: syncthing/syncthing, strip-v: true }
+  tarball: { url: "https://github.com/syncthing/syncthing/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/syncthing/syncthing/releases"
+    notes: "https://github.com/syncthing/syncthing/releases/tag/v{version}"
+
+- name: nsq
+  cron-enabled: true   # validated 2026-09-05 (see PR)
+  files: [images/nsq/melange.yaml]
+  source: { type: github-releases-latest, repo: nsqio/nsq, strip-v: true }
+  tarball: { url: "https://github.com/nsqio/nsq/archive/refs/tags/v{version}.tar.gz", field: sha256 }
+  major-issue: true
+  links:
+    releases: "https://github.com/nsqio/nsq/releases"
+    notes: "https://github.com/nsqio/nsq/releases/tag/v{version}"
+
 - name: seaweedfs
   cron-enabled: true   # validated 2026-08-25 (see PR)
   files: [images/seaweedfs/melange.yaml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
             {"name":"rclone","variants":["prod","dev"]},
             {"name":"restic","variants":["prod","dev"]},
             {"name":"seaweedfs","variants":["prod","dev"]},
+            {"name":"syncthing","variants":["prod","dev"]},
+            {"name":"nsq","variants":["prod","dev"]},
             {"name":"oauth2-proxy","variants":["prod","dev"]},
             {"name":"flux","variants":["prod","dev"]},
             {"name":"kustomize","variants":["prod","dev"]},

--- a/.github/workflows/patch-go-deps.yml
+++ b/.github/workflows/patch-go-deps.yml
@@ -121,6 +121,8 @@ jobs:
             [trivy]="/home/build/trivy-${D}{{package.version}}"
             [thanos]="/home/build/thanos-${D}{{package.version}}"
             [cosign]="/home/build/cosign-${D}{{package.version}}"
+            [syncthing]="/home/build/syncthing-${D}{{package.version}}"
+            [nsq]="/home/build/nsq-${D}{{package.version}}"
             [syft]="/home/build/syft-${D}{{package.version}}"
             [grype]="/home/build/grype-${D}{{package.version}}"
             [node-exporter]="/home/build/node_exporter-${D}{{package.version}}"
@@ -195,6 +197,8 @@ jobs:
             [trivy]="github.com/aquasecurity/trivy"
             [thanos]="github.com/thanos-io/thanos"
             [cosign]="github.com/sigstore/cosign/v3"
+            [syncthing]="github.com/syncthing/syncthing"
+            [nsq]="github.com/nsqio/nsq"
             [syft]="github.com/anchore/syft"
             [grype]="github.com/anchore/grype"
             [node-exporter]="github.com/prometheus/node_exporter"
@@ -268,6 +272,8 @@ jobs:
             [trivy]='GOEXPERIMENT=jsonv2 go build'
             [thanos]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [cosign]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [syncthing]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
+            [nsq]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [syft]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [grype]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'
             [node-exporter]='GOTOOLCHAIN=local CGO_ENABLED=0 go build'

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ RCLONE_VERSION ?= $(call melange_version,images/rclone/melange.yaml)
 RESTIC_VERSION ?= $(call melange_version,images/restic/melange.yaml)
 TAILSCALE_VERSION ?= $(call melange_version,images/tailscale/melange.yaml)
 DESCHEDULER_VERSION ?= $(call melange_version,images/descheduler/melange.yaml)
+SYNCTHING_VERSION ?= $(call melange_version,images/syncthing/melange.yaml)
+NSQ_VERSION ?= $(call melange_version,images/nsq/melange.yaml)
 OAUTH2_PROXY_VERSION ?= $(call melange_version,images/oauth2-proxy/melange.yaml)
 FLUX_VERSION ?= $(call melange_version,images/flux/melange.yaml)
 KUSTOMIZE_VERSION ?= $(call melange_version,images/kustomize/melange.yaml)
@@ -224,6 +226,8 @@ endef
 .PHONY: restic restic-melange test-restic
 .PHONY: tailscale tailscale-melange test-tailscale
 .PHONY: descheduler descheduler-melange test-descheduler
+.PHONY: syncthing syncthing-melange syncthing-dev test-syncthing test-syncthing-dev
+.PHONY: nsq nsq-melange nsq-dev test-nsq test-nsq-dev
 .PHONY: oauth2-proxy oauth2-proxy-melange test-oauth2-proxy
 .PHONY: flux flux-melange test-flux
 .PHONY: kustomize kustomize-melange test-kustomize
@@ -363,6 +367,8 @@ $(eval $(call DEV_IMAGE_RULE,kubectl,kubectl-melange,--repository-append ./packa
 $(eval $(call DEV_IMAGE_RULE,opentofu,opentofu-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,trivy,trivy-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,cosign,cosign-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,syncthing,syncthing-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
+$(eval $(call DEV_IMAGE_RULE,nsq,nsq-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,syft,syft-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,grype,grype-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
 $(eval $(call DEV_IMAGE_RULE,osv-scanner,osv-scanner-melange,--repository-append ./packages --keyring-append melange.rsa.pub))
@@ -2132,6 +2138,52 @@ seaweedfs: seaweedfs-melange
 	@rm -f seaweedfs.tar sbom-*.spdx.json
 	@echo "✓ minimal-seaweedfs built (source build)"
 
+syncthing-melange: keygen
+	@echo "Building Syncthing $(SYNCTHING_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/syncthing/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ Syncthing package built from source"
+
+syncthing: syncthing-melange
+	@echo "Assembling minimal-syncthing image with apko..."
+	apko build images/syncthing/apko/syncthing.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-syncthing:$(VERSION) \
+		syncthing.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < syncthing.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-syncthing:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-syncthing:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-syncthing:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-syncthing:latest
+	@rm -f syncthing.tar sbom-*.spdx.json
+	@echo "✓ minimal-syncthing built (source build)"
+
+nsq-melange: keygen
+	@echo "Building NSQ $(NSQ_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
+	melange build images/nsq/melange.yaml \
+		--arch x86_64 \
+		--signing-key melange.rsa
+	@echo "✓ NSQ package built from source"
+
+nsq: nsq-melange
+	@echo "Assembling minimal-nsq image with apko..."
+	apko build images/nsq/apko/nsq.yaml \
+		$(REGISTRY)/$(OWNER)/minimal-nsq:$(VERSION) \
+		nsq.tar \
+		--arch x86_64 \
+		--repository-append ./packages \
+		--keyring-append melange.rsa.pub
+	docker load < nsq.tar
+	docker tag $(REGISTRY)/$(OWNER)/minimal-nsq:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-nsq:$(VERSION)
+	docker tag $(REGISTRY)/$(OWNER)/minimal-nsq:$(VERSION)-amd64 \
+		$(REGISTRY)/$(OWNER)/minimal-nsq:latest
+	@rm -f nsq.tar sbom-*.spdx.json
+	@echo "✓ minimal-nsq built (source build)"
+
 dex-melange: keygen
 	@echo "Building Dex $(DEX_VERSION) from source via melange (x86_64 only locally; CI builds aarch64 natively)..."
 	melange build images/dex/melange.yaml \
@@ -3427,6 +3479,8 @@ $(eval $(call DEV_TEST_RULE,kubectl))
 $(eval $(call DEV_TEST_RULE,opentofu))
 $(eval $(call DEV_TEST_RULE,trivy))
 $(eval $(call DEV_TEST_RULE,cosign))
+$(eval $(call DEV_TEST_RULE,syncthing))
+$(eval $(call DEV_TEST_RULE,nsq))
 $(eval $(call DEV_TEST_RULE,syft))
 $(eval $(call DEV_TEST_RULE,grype))
 $(eval $(call DEV_TEST_RULE,osv-scanner))
@@ -3862,6 +3916,18 @@ test-restic:
 	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-restic:latest" && \
 		images/restic/test.sh
 	@echo "✓ restic tests passed"
+
+test-syncthing:
+	@echo "Testing syncthing image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-syncthing:latest" && \
+		images/syncthing/test.sh
+	@echo "✓ syncthing tests passed"
+
+test-nsq:
+	@echo "Testing nsq image..."
+	export IMAGE="$(REGISTRY)/$(OWNER)/minimal-nsq:latest" && \
+		images/nsq/test.sh
+	@echo "✓ nsq tests passed"
 
 test-seaweedfs:
 	@echo "Testing seaweedfs image..."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>108 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
+  <strong>110 small, hardened container images. Free, MIT-licensed, signed, and rebuilt every six hours.</strong>
 </p>
 
 <p align="center">
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/rtvkiz/minimal/actions/workflows/build.yml"><img src="https://github.com/rtvkiz/minimal/actions/workflows/build.yml/badge.svg" alt="Build status"></a>
-  <img src="https://img.shields.io/badge/Images-108-0d9488" alt="Images: 108">
+  <img src="https://img.shields.io/badge/Images-110-0d9488" alt="Images: 110">
   <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level_3-0d9488" alt="SLSA Level 3"></a>
   <img src="https://img.shields.io/badge/Arch-amd64_%7C_arm64-0d9488" alt="Architectures: amd64 and arm64">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
@@ -34,7 +34,7 @@ docker run --rm -p 8080:80 ghcr.io/rtvkiz/minimal-nginx:latest
 docker run --rm -p 6379:6379 ghcr.io/rtvkiz/minimal-redis-slim:latest
 ```
 
-**[Find an image →](https://minimalcontainers.com/images)** — all 108, with live
+**[Find an image →](https://minimalcontainers.com/images)** — all 110, with live
 sizes and CVE counts.
 
 ## Verify what you pulled

--- a/catalog.json
+++ b/catalog.json
@@ -1308,6 +1308,30 @@
       "upstream_url": "https://mailpit.axllent.org",
       "summary": "Shell-less Mailpit SMTP/email testing tool built from source via melange.",
       "description": "Mailpit SMTP testing server capturing outbound mail with a web UI and API. Shell-less Go binary, signed and SBOM-attested, rebuilt every 6 hours."
+    },
+    {
+      "name": "syncthing",
+      "category": "Infrastructure",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "syncthing",
+      "upstream_url": "https://syncthing.net",
+      "summary": "Shell-less Syncthing continuous file synchronisation daemon, built from source via melange.",
+      "description": "Continuous peer-to-peer file synchronisation between your own devices, no cloud account. Shell-less non-root binary, signed, SBOM-attested, rebuilt 6-hourly."
+    },
+    {
+      "name": "nsq",
+      "category": "Caches, Queues & Messaging",
+      "variants": [
+        "prod",
+        "dev"
+      ],
+      "primary_package": "nsq",
+      "upstream_url": "https://nsq.io",
+      "summary": "Shell-less NSQ realtime distributed messaging platform, built from source via melange.",
+      "description": "NSQ realtime distributed messaging: nsqd, nsqlookupd and nsqadmin in one shell-less non-root image, signed and SBOM-attested, rebuilt every six hours."
     }
   ]
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,7 +72,7 @@ by effort. Fills the catalog's thinnest categories (databases, proxies, apps).
 | [x] | unbound | NLnetLabs/unbound | 🟢 BSD | C | 12M | 5k | DNS resolver — shipped; `--sbindir=/usr/bin`, builtin evloop, local-data smoke test |
 | [ ] | ~~varnish~~ | varnishcache/varnish-cache | 🟢 BSD | C | 21M | 4k | **Deferred → see below.** varnishd compiles VCL with `cc` at runtime → needs gcc+binutils+headers in prod (breaks the shell-less/minimal thesis). |
 | [ ] | apisix | apache/apisix | 🟢 Apache-2.0 | C/Lua/OpenResty | 37M | 17k | API gateway (harder: OpenResty) |
-| [ ] | vaultwarden | dani-garcia/vaultwarden | 🟡 AGPL-3.0 | Rust | 304M | 64k | self-hosted Bitwarden |
+| [x] | vaultwarden | dani-garcia/vaultwarden | 🟡 AGPL-3.0 | Rust | 304M | 64k | self-hosted Bitwarden — shipped |
 | [ ] | kvrocks | apache/kvrocks | 🟢 Apache-2.0 | C++ | 3.5M | 4k | Redis-on-RocksDB |
 | [x] | patroni | patroni/patroni | 🟢 MIT | Python | — | 9k | Postgres HA — shipped; first Python-daemon pattern |
 | [ ] | woodpecker | woodpecker-ci/woodpecker | 🟢 Apache-2.0 | Go+frontend | 2.7M | 7k | CI server (has web UI) |
@@ -138,12 +138,12 @@ Fills thin **Infrastructure**.
 
 ### Batch H — JVM-jlink (kafka/zookeeper template)
 cassandra (🟢 wide-column DB, Java-17 + jamm agent) · solr (🟢 search, Java-21) ·
-pulsar (🟢 messaging, Java-21) — **DONE**. flink (🟢 stream processing, Java-21) remaining.
+pulsar (🟢 messaging, Java-21) · flink (🟢 stream processing, Java-21) — **all DONE**.
 All Apache. Fills thin DB/search/messaging.
 
 ### Batch I — Rust (qdrant/vector precedent, own effort each)
-vector (🟢 MPL-2.0, observability pipeline) — **DONE**. vaultwarden (🟡 AGPL-3.0, Bitwarden
-server; ~304M pulls) remaining.
+vector (🟢 MPL-2.0, observability pipeline) · vaultwarden (🟡 AGPL-3.0, Bitwarden
+server; ~304M pulls) — **both DONE**.
 
 ### Batch J — Erlang / Python
 patroni (🟢 MIT, Postgres HA — new Python-daemon pattern) — **DONE**.
@@ -157,6 +157,80 @@ whichever land first.
 
 **Beyond the 100-path (deliberate exceptions, not scheduled):** varnish (runtime cc), grafana/argocd/uptime-kuma
 (frontend-in-bwrap), clickhouse/kubescape (disk-cap). See the deferred table above.
+
+## Wave 2 — beyond 108 (demand-ranked, re-surveyed 2026-08-30)
+
+Candidate survey after the 100 target was met. Same lens as above (license ·
+container demand · use case), with one new input: **many of these already have a
+Wolfi package**, which moves them from "own effort" into the cheapest bucket we
+have (apko-only, `dnsmasq`/`vector` precedent — no melange recipe, no
+`versions.yaml` row, just an `autoupdate-coverage.yaml` classification).
+
+Pull counts are Docker Hub `pull_count` read on 2026-08-30; treat as
+order-of-magnitude (cumulative, CI/bot-inflated).
+
+### Tier W1 — apko-only from an existing Wolfi package (cheapest crank)
+
+Verified present in the Wolfi `x86_64` APKINDEX on 2026-08-30. `(v)` = versioned
+package ⇒ `wolfi-versioned`; `(r)` = unversioned/rolling ⇒ `wolfi-rolling`.
+
+| ✓ | Image | Wolfi package | License | 🐳 pulls | Category | Notes |
+|---|---|---|---|---:|---|---|
+| [ ] | gitlab-runner | `gitlab-runner-18.11` (v) | 🟢 MIT | 3.6B | K8s, CI & IaC | Highest-demand gap in the catalog. Upstream is gitlab.com, so a *source* build would need a bespoke version-check — the Wolfi package sidesteps that entirely. |
+| [ ] | buildkit | `buildkitd` (r) | 🟢 Apache-2.0 | 1.8B | K8s, CI & IaC | `buildkitd` + `buildctl`. Decide rootless-vs-privileged posture and document it; daemon wants a writable state dir. |
+| [ ] | wordpress | `wordpress` (r) + `wordpress-oci-entrypoint` | 🟡 GPL-2.0-or-later | 1.5B | Apps | Largest single demand number in the survey. Pairs with our `php`/`httpd`; Wolfi ships the OCI entrypoint too. Fills the thinnest category (Apps, 6). |
+| [ ] | sonarqube | `sonarqube` (r) | 🟡 LGPL-3.0 | 1.2B | K8s, CI & IaC | Community Build. Heavier than it looks — bundles Elasticsearch and needs an external Postgres; smoke test = boot + `/api/system/status`. |
+| [ ] | nextcloud | `nextcloud-server-33` (v) | 🟡 AGPL-3.0 | 1.0B | Apps | AGPL precedent already set (loki/tempo/mimir/minio/vaultwarden). PHP-FPM. |
+| [ ] | maven | `maven-3.9` (v) | 🟢 Apache-2.0 | 767M | Languages & Runtimes | Build-tool image on top of our `java`. Near-zero effort, very high demand. |
+| [ ] | kong | `kong` (r) + `kong-entrypoint` | 🟢 Apache-2.0 | 359M | Web Servers & Proxies | The Wolfi package removes the OpenResty/Lua build problem that keeps `apisix` deferred. Fills a thin category (8). |
+| [ ] | neo4j | `neo4j-2025.12` (v) | 🟡 GPL-3.0 | 322M | Databases | Graph DB — a category we have zero coverage of. GPL precedent: dnsmasq, keepalived. |
+| [ ] | gradle | `gradle-9` (v) | 🟢 Apache-2.0 | 300M | Languages & Runtimes | Same shape as maven. |
+| [ ] | perl | `perl` (r) | 🟡 Artistic-1.0 / GPL-1.0+ | 255M | Languages & Runtimes | Trivial; the last mainstream scripting runtime we're missing. |
+| [ ] | couchdb | `couchdb-3.3` (v) | 🟢 Apache-2.0 | 205M | Databases | Already named in Batch J as an Erlang source build — the Wolfi package makes it a W1, not an own-effort. |
+| [ ] | argo-cd | `argo-cd-3.2` + `-repo-server` (v) | 🟢 Apache-2.0 | 148M | K8s, CI & IaC | **Re-opens a deferred item.** Wolfi packaging removes the yarn-frontend build; the repo-server's runtime git/helm/kustomize needs still apply, so this is multi-image, not one. |
+| [ ] | rust | `rust-1.92` (v) | 🟢 MIT OR Apache-2.0 | 143M | Languages & Runtimes | Toolchain image (builder-shaped, like our `go`). |
+| [ ] | erlang | `erlang-28` (v) | 🟢 Apache-2.0 | 65M | Languages & Runtimes | Natural companion to `rabbitmq`. |
+| [ ] | meilisearch | `meilisearch` (r) | 🟢 MIT | 51M | Databases | Rust search engine; complements `opensearch`/`solr` at a much smaller size. |
+| [ ] | temporal | `temporal` (r) | 🟢 MIT | 47M | Apps | Durable-execution server. Wolfi also has `temporal-ui-server-oci-entrypoint` if we want the UI later. |
+
+**Also packaged in Wolfi, parked deliberately:** `argo-workflows` (🟢 Apache — take
+with argo-cd or not at all), `harbor-2.14-*` (🟢 Apache, but 5+ images — own
+effort like cert-manager), `mattermost-11.4` (⚠️ mixed AGPL + Mattermost Source
+Available License in the same tree — needs a license read before onboarding),
+`apisix-ingress-controller` (🟢 Apache — note Wolfi packages the *controller*,
+not apisix itself, so the Tier-3 apisix entry above is unchanged).
+
+### Tier W2 — source-built Go (the proven crank; no Wolfi package)
+
+| ✓ | Image | Upstream | License | 🐳 pulls | Category | Notes |
+|---|---|---|---|---:|---|---|
+| [ ] | alloy | grafana/alloy | 🟢 Apache-2.0 | 388M | Observability | Successor to promtail (2.8B) and grafana-agent (470M), both now EOL — so the real demand it inherits is far above its own count. **Risk:** ships an embedded web UI built with yarn; check whether `go build` succeeds against a stubbed/pre-generated `ui/dist` before committing, or it becomes a frontend-in-bwrap item. |
+| [ ] | authelia | authelia/authelia | 🟢 Apache-2.0 | 81M | Web Servers & Proxies | Auth gateway; pairs with `oauth2-proxy`. Same embedded-frontend caveat as alloy (pnpm). |
+| [x] | syncthing | syncthing/syncthing | 🟢 MPL-2.0 | 346M (two repos) | Infrastructure | **Shipped** — confirmed the easiest build in this table. `CGO_ENABLED=0` picks the pure-Go `modernc.org/sqlite` driver v2.x needs; the web GUI is `.gitignore`'d upstream and regenerated by `script/genassets.go`, which is plain Go — no npm step. Built `-tags noupgrade` like upstream's own container. |
+| [x] | nsq | nsqio/nsq | 🟢 MIT | 63M | Caches, Queues & Messaging | **Shipped** — was indeed about an hour. Ships all nine upstream binaries for drop-in parity with `nsqio/nsq`; nsqadmin's web assets are committed pre-built and pulled in via `go:embed`. Note upstream is quiet (v1.3.0, Dec 2023), so its auto-update loop will be idle by design. |
+
+### Tier W3 — heavier / needs a decision
+
+| Image | Why it's not W1/W2 |
+|---|---|
+| influxdb | 1.1B pulls on `library/influxdb`, but that number is v1/v2 (Go, MIT); current upstream is **InfluxDB 3 Core in Rust** (🟢 Apache-2.0), no Wolfi package, and our time-series slot is already served by prometheus/mimir/victoria-metrics/thanos. Worth it only if we want line-protocol coverage. |
+| emqx | 47M pulls, but the repo is `NOASSERTION` (Apache core + BSL-ish enterprise pieces) and it's a large Erlang build. License read required first. |
+| timescaledb | 123M pulls, but the tree is split Apache-2.0 / TSL (source-available) — an Apache-only build is possible and is the only version we could ship. Own effort. |
+| pgadmin4 | 444M pulls (🟢 PostgreSQL license), Python + prebuilt frontend. Plausible via pip wheels; needs its own investigation. |
+
+### Confirmed avoid (🔴 non-OSS) — checked in this survey
+
+`terraform` (492M) · `vault` (554M) · `nomad` · `boundary` · `waypoint` — all
+BUSL-1.1; already covered by our `opentofu` and `openbao`. `elasticsearch` /
+`kibana` / `logstash` — Elastic License; covered by `opensearch`. `redpanda`
+(35M) — BSL. `n8n` — Sustainable Use License. No change to the policy.
+
+### Suggested first PR out of this survey
+
+Six images, all W1, no new build template, spanning four categories:
+**gitlab-runner · wordpress · maven · gradle · kong · perl** — the two largest
+demand numbers we're missing, the two cheapest Languages entries, and the first
+addition to Web Servers & Proxies since oauth2-proxy.
 
 ## Execution model
 

--- a/images/nsq/apko/nsq-dev.yaml
+++ b/images/nsq/apko/nsq-dev.yaml
@@ -1,0 +1,79 @@
+# Development variant of minimal-nsq.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - nsq
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# NSQ is a set of separate daemons, not one multi-command binary. nsqd is the
+# message daemon and the one you run by default; override the entrypoint to get
+# nsqlookupd, nsqadmin or any of the nsq_to_* / to_nsq / nsq_tail / nsq_stat
+# helpers, all of which ship in this image.
+#
+# Default ports (nsqd 4150/4151, nsqlookupd 4160/4161, nsqadmin 4171) are above
+# 1024, so every daemon binds fine as nonroot.
+entrypoint:
+  command: /usr/bin/nsqd
+
+# nsqd persists its topic/channel metadata and any overflowed messages to disk.
+# Without --data-path it writes them to the working directory, which is
+# read-only here — point it at the writable volume instead.
+cmd: --data-path=/data
+
+work-dir: /data
+
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+
+# Writable data directory. A nonroot process cannot create it at runtime, so
+# apko must author it owned by the run-as user.
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-nsq-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-nsq: same nsq daemons + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/nsq"
+  org.opencontainers.image.licenses: "MIT"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/nsq/apko/nsq.yaml
+++ b/images/nsq/apko/nsq.yaml
@@ -1,0 +1,69 @@
+# Minimal NSQ image - realtime distributed messaging, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - nsq
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# NSQ is a set of separate daemons, not one multi-command binary. nsqd is the
+# message daemon and the one you run by default; override the entrypoint to get
+# nsqlookupd, nsqadmin or any of the nsq_to_* / to_nsq / nsq_tail / nsq_stat
+# helpers, all of which ship in this image.
+#
+# Default ports (nsqd 4150/4151, nsqlookupd 4160/4161, nsqadmin 4171) are above
+# 1024, so every daemon binds fine as nonroot.
+entrypoint:
+  command: /usr/bin/nsqd
+
+# nsqd persists its topic/channel metadata and any overflowed messages to disk.
+# Without --data-path it writes them to the working directory, which is
+# read-only here — point it at the writable volume instead.
+cmd: --data-path=/data
+
+work-dir: /data
+
+environment:
+  PATH: /usr/bin:/bin
+
+# Writable data directory. A nonroot process cannot create it at runtime, so
+# apko must author it owned by the run-as user.
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-nsq"
+  org.opencontainers.image.description: "Hardened shell-less NSQ realtime distributed messaging platform (nsqd, nsqlookupd, nsqadmin) built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/nsq"
+  org.opencontainers.image.licenses: "MIT"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/nsq/melange.yaml
+++ b/images/nsq/melange.yaml
@@ -1,0 +1,82 @@
+# Melange build configuration for minimal NSQ
+# Pure Go from source. NSQ is a set of small daemons and utilities built from
+# one module: nsqd (the message daemon), nsqlookupd (topology discovery),
+# nsqadmin (web UI) plus the nsq_to_* / to_nsq / nsq_tail / nsq_stat helpers.
+# The upstream `nsqio/nsq` image ships all nine, so this one does too — dropping
+# the helpers would break it as a drop-in replacement.
+# License: MIT (Bitly / the NSQ authors).
+#
+# Wolfi ships no `nsq` package, so this is a source build by necessity rather
+# than by preference.
+
+package:
+  # Named `nsq` (not `nsq-minimal`) so vulnerability scanners can identify it.
+  # Syft derives a package's CPE from its apk name, and a suffix produces
+  # cpe:2.3:a:nsq-minimal:nsq-minimal:*, which matches nothing in NVD.
+  name: nsq
+  version: 1.3.0
+  epoch: 0
+  description: "Minimal NSQ realtime distributed messaging platform built from source"
+  copyright:
+    - license: MIT
+
+vars:
+  # SHA256 of nsq source tarball - updated by update-versions.yml workflow
+  sha256: c6289e295aaa40c8d9651de76e66bc9f23e7f5c40b1cc051ea5901965093e1f0
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go-1.27
+      - git
+
+pipeline:
+  # Download and verify nsq source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 8 --retry-all-errors \
+        "https://github.com/nsqio/nsq/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/nsq.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/nsq.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf nsq.tar.gz
+      rm nsq.tar.gz
+
+  # No -X version ldflag: nsq carries its version as a Go constant
+  # (internal/version.Binary), set by upstream at release time, so there is
+  # nothing to inject — the binaries self-report ${{package.version}} already.
+  # nsqadmin's web assets are committed pre-built under nsqadmin/static/build
+  # and pulled in with //go:embed, so no npm step is needed.
+  - runs: |
+      cd /home/build/nsq-${{package.version}}
+      for app in nsqd nsqlookupd nsqadmin nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat to_nsq; do
+        echo "Building $app..."
+        GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+          -trimpath \
+          -ldflags="-s -w -buildid=" \
+          -o "/home/build/nsq-bin/$app" \
+          "./apps/$app"
+      done
+
+  # Install binaries
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/nsq-bin/* "${{targets.destdir}}/usr/bin/"
+      chmod 0755 "${{targets.destdir}}"/usr/bin/*
+
+  # Verify the build
+  - runs: |
+      echo "Verifying nsq binaries..."
+      "${{targets.destdir}}/usr/bin/nsqd" --version
+      "${{targets.destdir}}/usr/bin/nsqlookupd" --version
+      "${{targets.destdir}}/usr/bin/nsqadmin" --version

--- a/images/nsq/test-dev.sh
+++ b/images/nsq/test-dev.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Smoke test for minimal-nsq-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing nsqd version (parity with prod)..."
+nv=$(docker run --rm --entrypoint /usr/bin/nsqd "$IMAGE" --version 2>&1)
+echo "$nv" | grep -qE 'nsqd v1\.[0-9]+' || { echo "unexpected version: $nv"; exit 1; }
+
+echo "Testing nsqlookupd and nsqadmin are present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "nsqlookupd --version && nsqadmin --version" 2>&1 | grep -q 'nsqadmin v1'
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "All nsq-dev tests passed!"

--- a/images/nsq/test.sh
+++ b/images/nsq/test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing nsqd version..."
+nv=$(docker run --rm --entrypoint /usr/bin/nsqd "$IMAGE" --version 2>&1)
+echo "$nv" | grep -qE 'nsqd v1\.[0-9]+' || { echo "unexpected version: $nv"; exit 1; }
+
+echo "Testing every shipped binary is present and reports its version..."
+# The upstream nsqio/nsq image ships all nine; a partial build here would make
+# this image a silent non-replacement, and only nsqd would ever be exercised.
+for app in nsqd nsqlookupd nsqadmin nsq_to_nsq nsq_to_file nsq_to_http nsq_tail nsq_stat; do
+  out=$(docker run --rm --entrypoint "/usr/bin/$app" "$IMAGE" --version 2>&1)
+  echo "$out" | grep -qE "$app v1\.[0-9]+" || { echo "FAIL: $app missing or wrong version: $out"; exit 1; }
+done
+
+# to_nsq is the ninth and the one exception: it is a stdin-to-nsqd pipe with no
+# --version flag at all (`flag provided but not defined: -version`), so assert
+# it is present and its flag set is wired instead.
+out=$(docker run --rm --entrypoint /usr/bin/to_nsq "$IMAGE" --help 2>&1 || true)
+echo "$out" | grep -q 'nsqd-tcp-address' || { echo "FAIL: to_nsq missing or not wired: $out"; exit 1; }
+echo "All nine binaries OK"
+
+echo "Testing nsqd help lists its flags..."
+docker run --rm --entrypoint /usr/bin/nsqd "$IMAGE" --help 2>&1 | grep -qE 'data-path|lookupd-tcp-address'
+
+echo "Testing a full publish/consume round-trip through nsqd..."
+# Boot nsqd against the image's own /data, publish over the HTTP API and read
+# the message back. Exercises the writable data dir, the TCP and HTTP
+# listeners, and the diskqueue metadata write — not just flag parsing.
+CID=$(docker run -d --rm -p 14150:4150 -p 14151:4151 "$IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+ok=""
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time 3 http://127.0.0.1:14151/ping 2>/dev/null | grep -q 'OK'; then
+    ok=1; break
+  fi
+  sleep 1
+done
+[ -n "$ok" ] || { echo "FAIL: nsqd did not answer /ping"; docker logs "$CID" 2>&1 | tail -30; exit 1; }
+
+curl -fsS --max-time 5 -d 'minimal-smoke-test' \
+  'http://127.0.0.1:14151/pub?topic=smoke' >/dev/null \
+  || { echo "FAIL: publish rejected"; docker logs "$CID" 2>&1 | tail -20; exit 1; }
+
+stats=$(curl -fsS --max-time 5 'http://127.0.0.1:14151/stats?format=json' 2>/dev/null || true)
+echo "$stats" | grep -q '"topic_name":"smoke"' \
+  || { echo "FAIL: published topic not in stats: $stats"; exit 1; }
+echo "nsqd publish round-trip OK"
+
+echo "Verifying /data is writable by nonroot..."
+docker logs "$CID" 2>&1 | grep -qiE 'permission denied' \
+  && { echo "FAIL: permission denied writing /data"; exit 1; } || echo "/data writable OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All nsq tests passed!"

--- a/images/syncthing/apko/syncthing-dev.yaml
+++ b/images/syncthing/apko/syncthing-dev.yaml
@@ -1,0 +1,87 @@
+# Development variant of minimal-syncthing.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - syncthing
+    - ca-certificates-bundle
+    - busybox
+    - bash
+    - apk-tools
+    - wget
+    - curl
+    - openssl
+    - bind-tools
+    - jq
+    - git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# `serve` is the daemon subcommand; bare `syncthing` runs the monitor process,
+# which forks a child and restarts it on exit. A container supervisor already
+# does that job, and the monitor's restart path is what `--no-restart` disables
+# upstream, so run the server directly instead.
+entrypoint:
+  command: /usr/bin/syncthing
+
+cmd: serve --no-browser
+
+# Ports: 8384 GUI/REST, 22000 tcp+udp sync, 21027/udp local discovery — all
+# above 1024, so they bind fine as nonroot.
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+  # Syncthing writes its config, index database and certificates under $HOME.
+  # nonroot has no home directory, so anchor it at the data volume — the same
+  # layout upstream's own container uses (HOME=/var/syncthing,
+  # STHOMEDIR=/var/syncthing/config).
+  HOME: /var/syncthing
+  STHOMEDIR: /var/syncthing/config
+  # Bind the GUI to all interfaces; the default 127.0.0.1:8384 is unreachable
+  # from outside the container.
+  STGUIADDRESS: 0.0.0.0:8384
+
+# Writable state. A nonroot process cannot create these at runtime, so apko
+# must author them owned by the run-as user.
+paths:
+  - path: /var/syncthing
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/syncthing/config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-syncthing-dev"
+  org.opencontainers.image.description: "Dev variant of minimal-syncthing: same syncthing + shell + curl/openssl/dig/jq/git. Not for production."
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/syncthing"
+  org.opencontainers.image.licenses: "MPL-2.0"
+
+  dev.minimal.variant: "dev"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/syncthing/apko/syncthing.yaml
+++ b/images/syncthing/apko/syncthing.yaml
@@ -1,0 +1,77 @@
+# Minimal Syncthing image - continuous P2P file synchronisation, built from source via melange
+# Shell-less, distroless. CVE patching via daily rebuilds from upstream source.
+
+contents:
+  repositories:
+    - https://packages.wolfi.dev/os
+    # Local melange-built packages (passed via --repository-append CLI flag)
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    # Local signing key passed via --keyring-append CLI flag
+  packages:
+    - wolfi-baselayout
+    - syncthing
+    - ca-certificates-bundle
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532
+      gid: 65532
+  run-as: 65532
+
+# `serve` is the daemon subcommand; bare `syncthing` runs the monitor process,
+# which forks a child and restarts it on exit. A container supervisor already
+# does that job, and the monitor's restart path is what `--no-restart` disables
+# upstream, so run the server directly instead.
+entrypoint:
+  command: /usr/bin/syncthing
+
+cmd: serve --no-browser
+
+# Ports: 8384 GUI/REST, 22000 tcp+udp sync, 21027/udp local discovery — all
+# above 1024, so they bind fine as nonroot.
+environment:
+  PATH: /usr/bin:/bin
+  # Syncthing writes its config, index database and certificates under $HOME.
+  # nonroot has no home directory, so anchor it at the data volume — the same
+  # layout upstream's own container uses (HOME=/var/syncthing,
+  # STHOMEDIR=/var/syncthing/config).
+  HOME: /var/syncthing
+  STHOMEDIR: /var/syncthing/config
+  # Bind the GUI to all interfaces; the default 127.0.0.1:8384 is unreachable
+  # from outside the container.
+  STGUIADDRESS: 0.0.0.0:8384
+
+# Writable state. A nonroot process cannot create these at runtime, so apko
+# must author them owned by the run-as user.
+paths:
+  - path: /var/syncthing
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+  - path: /var/syncthing/config
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o700
+  - path: /tmp
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o1777
+
+annotations:
+  org.opencontainers.image.title: "minimal-syncthing"
+  org.opencontainers.image.description: "Hardened shell-less Syncthing continuous file synchronisation daemon built from source via melange with daily CVE patches"
+  org.opencontainers.image.url: "https://github.com/rtvkiz/minimal"
+  org.opencontainers.image.source: "https://github.com/rtvkiz/minimal/tree/main/images/syncthing"
+  org.opencontainers.image.licenses: "MPL-2.0"
+
+archs:
+  - x86_64
+  - aarch64

--- a/images/syncthing/melange.yaml
+++ b/images/syncthing/melange.yaml
@@ -1,0 +1,93 @@
+# Melange build configuration for minimal Syncthing
+# Pure Go from source. Single static `syncthing` binary (continuous P2P file
+# synchronisation). License: MPL-2.0 (The Syncthing Authors).
+#
+# Wolfi ships no `syncthing` package, so this is a source build by necessity
+# rather than by preference.
+
+package:
+  # Named `syncthing` (not `syncthing-minimal`) so vulnerability scanners can
+  # identify it. Syft derives a package's CPE from its apk name, and a suffix
+  # produces cpe:2.3:a:syncthing-minimal:syncthing-minimal:*, which matches
+  # nothing in NVD. NVD indexes this product bare, as
+  # cpe:2.3:a:syncthing:syncthing:*.
+  name: syncthing
+  version: 2.1.3
+  epoch: 0
+  description: "Minimal Syncthing continuous file synchronisation daemon built from source"
+  copyright:
+    - license: MPL-2.0
+
+vars:
+  # SHA256 of syncthing source tarball - updated by update-versions.yml workflow
+  sha256: 177792c697f61fc25f02d8fc8923dfc57ebb35753bd92c8d32a73d553446d117
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+      - ca-certificates-bundle
+      - curl
+      - build-base
+      - go-1.27
+      - git
+
+pipeline:
+  # Download and verify syncthing source
+  - runs: |
+      mkdir -p /home/build
+      curl -fsSL --retry 8 --retry-all-errors \
+        "https://github.com/syncthing/syncthing/archive/refs/tags/v${{package.version}}.tar.gz" \
+        -o /home/build/syncthing.tar.gz
+
+      echo "${{vars.sha256}}  /home/build/syncthing.tar.gz" | sha256sum -c -
+
+      cd /home/build
+      tar xzf syncthing.tar.gz
+      rm syncthing.tar.gz
+
+  # The web GUI is served from lib/api/auto/gui.files.go, which upstream
+  # .gitignore's and regenerates at build time. The generator (script/genassets.go)
+  # is plain Go reading the committed gui/ tree — there is no npm/yarn step — so
+  # this stays a hermetic Go-only build. Without it the binary compiles but
+  # serves an empty GUI (lib/api/auto/noassets.go is the fallback).
+  - runs: |
+      cd /home/build/syncthing-${{package.version}}
+      export GOFLAGS=-mod=mod
+      go run script/genassets.go -o lib/api/auto/gui.files.go gui
+
+  # CGO_ENABLED=0 selects the pure-Go SQLite driver: internal/db/sqlite has
+  # db_open_cgo.go (//go:build cgo -> mattn/go-sqlite3) and db_open_nocgo.go
+  # (//go:build !cgo -> modernc.org/sqlite). Syncthing 2.x needs SQLite for its
+  # index database, so getting this wrong is a runtime failure, not a link error.
+  #
+  # The `noupgrade` tag matches upstream's own container build
+  # (`go run build.go -no-upgrade build syncthing`): it compiles out the
+  # self-updater, which has no business writing to a read-only image anyway.
+  - runs: |
+      cd /home/build/syncthing-${{package.version}}
+      GOTOOLCHAIN=local CGO_ENABLED=0 go build \
+        -trimpath \
+        -tags noupgrade \
+        -ldflags="-s -w -buildid= \
+          -X github.com/syncthing/syncthing/lib/build.Version=v${{package.version}} \
+          -X github.com/syncthing/syncthing/lib/build.User=melange \
+          -X github.com/syncthing/syncthing/lib/build.Host=wolfi \
+          -X github.com/syncthing/syncthing/lib/build.Tags=noupgrade" \
+        -o /home/build/syncthing-bin \
+        ./cmd/syncthing
+
+  # Install binary
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/bin"
+      cp /home/build/syncthing-bin "${{targets.destdir}}/usr/bin/syncthing"
+      chmod 0755 "${{targets.destdir}}/usr/bin/syncthing"
+
+  # Verify the build
+  - runs: |
+      echo "Verifying syncthing binary..."
+      "${{targets.destdir}}/usr/bin/syncthing" --version

--- a/images/syncthing/test-dev.sh
+++ b/images/syncthing/test-dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Smoke test for minimal-syncthing-dev.
+set -eu  # NB: no pipefail — `docker run | grep -q` is SIGPIPE-prone in CI
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing syncthing version (parity with prod)..."
+sv=$(docker run --rm --entrypoint /usr/bin/syncthing "$IMAGE" --version 2>&1)
+echo "$sv" | grep -qE 'syncthing v2\.[0-9]+' || { echo "unexpected version: $sv"; exit 1; }
+
+echo "Testing /bin/sh (busybox)..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo sh-ok" | grep -q sh-ok
+
+echo "Testing /bin/bash..."
+docker run --rm --entrypoint /bin/bash "$IMAGE" -c "echo bash-ok" | grep -q bash-ok
+
+echo "Testing apk-tools present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "apk --version" | grep -q apk-tools
+
+echo "Testing curl/openssl/jq present..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "curl --version >/dev/null && openssl version >/dev/null && jq --version >/dev/null"
+
+echo "All syncthing-dev tests passed!"

--- a/images/syncthing/test.sh
+++ b/images/syncthing/test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -eu  # NB: no pipefail — `docker run | grep` is SIGPIPE-prone
+
+: "${IMAGE:?IMAGE env var required}"
+
+echo "Testing syncthing version..."
+sv=$(docker run --rm --entrypoint /usr/bin/syncthing "$IMAGE" --version 2>&1)
+echo "$sv" | grep -qE 'syncthing v2\.[0-9]+' || { echo "unexpected version: $sv"; exit 1; }
+
+echo "Verifying the self-updater is compiled out..."
+# Built with -tags noupgrade, matching upstream's container build. A hardened
+# read-only image must never be able to replace its own binary.
+echo "$sv" | grep -q 'noupgrade' || { echo "FAIL: noupgrade tag missing: $sv"; exit 1; }
+
+echo "Testing syncthing subcommands are wired..."
+docker run --rm --entrypoint /usr/bin/syncthing "$IMAGE" --help 2>&1 | grep -qE 'serve|generate|cli'
+
+echo "Testing syncthing serves its REST API..."
+# Full round-trip: boot the daemon, let it generate its device certificate and
+# open the SQLite index database under /var/syncthing, then answer on the GUI
+# port. Exercises the writable state dirs, the pure-Go SQLite driver and the
+# generated web assets — not just that the binary parses a flag.
+CID=$(docker run -d --rm -p 18384:8384 "$IMAGE")
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+
+ok=""
+for _ in $(seq 1 45); do
+  if curl -fsS --max-time 3 http://127.0.0.1:18384/rest/noauth/health 2>/dev/null | grep -q 'OK'; then
+    ok=1; break
+  fi
+  sleep 1
+done
+[ -n "$ok" ] || { echo "FAIL: syncthing did not serve /rest/noauth/health"; docker logs "$CID" 2>&1 | tail -30; exit 1; }
+echo "syncthing REST health OK"
+
+echo "Verifying the web GUI assets were generated into the binary..."
+# lib/api/auto/gui.files.go is .gitignore'd upstream and regenerated at build
+# time; skip that step and the daemon still boots but serves nothing. The
+# noassets.go fallback returns 404 here, so this asserts the generator ran.
+gui=$(curl -fsS --max-time 5 http://127.0.0.1:18384/ 2>/dev/null || true)
+echo "$gui" | grep -qi '<html' || { echo "FAIL: GUI assets missing (noassets fallback?)"; exit 1; }
+echo "GUI assets OK"
+
+echo "Verifying /var/syncthing is writable by nonroot..."
+docker logs "$CID" 2>&1 | grep -qiE 'permission denied' \
+  && { echo "FAIL: permission denied writing /var/syncthing"; exit 1; } || echo "/var/syncthing writable OK"
+
+echo "Verifying no shell..."
+docker run --rm --entrypoint /bin/sh "$IMAGE" -c "echo fail" 2>/dev/null \
+  && echo "FAIL: shell found!" && exit 1 || echo "No shell (as expected)"
+
+echo "All syncthing tests passed!"

--- a/vex/nsq.openvex.json
+++ b/vex/nsq.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/nsq",
+  "author": "rtvkiz",
+  "timestamp": "2026-09-06T00:15:24Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}

--- a/vex/syncthing.openvex.json
+++ b/vex/syncthing.openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/rtvkiz/minimal/vex/syncthing",
+  "author": "rtvkiz",
+  "timestamp": "2026-09-06T00:15:24Z",
+  "version": 1,
+  "tooling": "tools/vex/validate.sh",
+  "statements": []
+}


### PR DESCRIPTION
Two new source-built Go images, 108 → 110. Both are absent from Wolfi (checked against the x86_64 APKINDEX), so apko-only was never an option — these are genuine melange builds, which is what the demand + not-free-on-Chainguard + built-from-source lens asked for.

Neither has a free Chainguard equivalent (`docker manifest inspect cgr.dev/chainguard/{syncthing,nsq}` — both gated; the probe was validated against known-free nginx/python/go/static first).

## syncthing — 346M pulls, MPL-2.0, Infrastructure

Two things about the 2.x line that a naive `go build ./cmd/syncthing` gets wrong:

- **`CGO_ENABLED=0` is load-bearing, not a linking preference.** `internal/db/sqlite` splits on the cgo build tag: `db_open_cgo.go` pulls `mattn/go-sqlite3`, `db_open_nocgo.go` pulls `modernc.org/sqlite`. Syncthing 2.x needs SQLite for its index database, so the wrong branch is a runtime failure, not a link error. The build banner confirms the choice: `[modernc-sqlite, noupgrade]`.
- **The web GUI is generated at build time.** `lib/api/auto/gui.files.go` is `.gitignore`'d upstream and produced by `script/genassets.go` from the committed `gui/` tree. That generator is plain Go — no npm, no yarn — so the build stays hermetic. Skip it and the daemon still boots but serves nothing (the `noassets.go` fallback), which is why the smoke test fetches `/` and asserts real HTML rather than only checking REST health.

Built `-tags noupgrade`, matching upstream's own container: a read-only hardened image has no business replacing its own binary. `test.sh` asserts the tag is in the version banner.

Prod image: 29.3 MB.

## nsq — 63M pulls, MIT, Caches, Queues & Messaging

Ships **all nine** upstream binaries (`nsqd`, `nsqlookupd`, `nsqadmin` and the `nsq_to_*` / `to_nsq` / `nsq_tail` / `nsq_stat` helpers) so the image is a drop-in replacement for `nsqio/nsq`; shipping only the three daemons would have made it a silent non-replacement. nsqadmin's web assets are committed pre-built and embedded with `go:embed`, so no frontend build is needed. No `-X` version ldflag — nsq carries its version as a Go constant in `internal/version`.

`to_nsq` is the one binary with no `--version` flag at all (it is a stdin pipe), so `test.sh` checks its flag set instead. Found by the test failing, not by reading the source.

Prod image: 73.1 MB (nine static binaries).

## Registration

Per `docs/onboarding.md`, all ten points: melange + apko prod/dev, executable smoke tests, VEX stubs, Makefile targets (incl. `DEV_IMAGE_RULE`/`DEV_TEST_RULE`), `build.yml` matrix, catalog entries with 140-160 char descriptions, `cron-enabled` `versions.yaml` rows, README count, and both images added to the three `patch-go-deps` assoc-arrays.

## Validation

All four variants built and tested locally on x86_64 (CI covers aarch64):

```
make syncthing-melange && make syncthing && make test-syncthing
make syncthing-dev     && make test-syncthing-dev
make nsq-melange       && make nsq       && make test-nsq
make nsq-dev           && make test-nsq-dev
```

Both prod tests do a real round-trip, not a version grep — syncthing generates its device certificate, opens the SQLite index under `/var/syncthing` and answers `/rest/noauth/health`; nsq publishes over the HTTP API and reads the message back out of `/stats`.

Gates clean: `check-catalog-descriptions`, `check-autoupdate`, `check-packages`, `check-docs`, `lint-workflows`, VEX validation.

Auto-update rows validated per §9 safe rollout before enabling — dispatched `update-versions.yml` against this branch for each:

| row | result |
|---|---|
| syncthing | `current=2.1.3 latest=2.1.3` — clean no-update ([run](https://github.com/rtvkiz/minimal/actions/runs/34001073220)) |
| nsq | `current=1.3.0 latest=1.3.0` — clean no-update ([run](https://github.com/rtvkiz/minimal/actions/runs/34001084241)) |

## Note on nsq's update cadence

Upstream is quiet — v1.3.0 shipped Dec 2023, so nsq's `versions.yaml` loop will be idle by design. It still gets the 6-hourly base rebuild and `patch-go-deps` coverage, which is where its CVE currency actually comes from. Recorded in `docs/roadmap.md` so it does not later read as a frozen row.