### PR TITLE
fix(site): indexing fixes (redirects, sitemap dates) + four blog posts

### DIFF
--- a/site/src/content/blog/a-red-build-is-usually-not-your-bug.md
+++ b/site/src/content/blog/a-red-build-is-usually-not-your-bug.md
@@ -1,0 +1,112 @@
+---
+title: "A red build is usually not your bug"
+description: "Most CI failures in a dependency-heavy pipeline are someone else's outage wearing a convincing error message. How to classify one in about two minutes before you start debugging."
+published: "2026-09-06"
+---
+
+A build that pulls from GitHub, a module proxy, Maven Central and a package
+index has four ways to fail that have nothing to do with your code. In a
+pipeline that rebuilds continuously, those transient failures outnumber the real
+ones — and the expensive mistake is spending an hour debugging a change that was
+never broken.
+
+The problem is that upstream outages rarely announce themselves. They arrive
+wearing an error message about your code.
+
+## Three real examples
+
+**"No release of log4j-web 2.25.4"** — a build step checked whether an artifact
+existed and reported it missing. It was not missing. Maven Central was returning
+`403` because we had been rate-limited, and the check used `curl -sfI`, where
+`-f` collapses every HTTP error into the same non-zero exit. "Server refused to
+answer me" and "the file is not there" became the same signal. The fix was to
+read the status code instead of the exit code, and say `unavailable` when the
+answer is neither 200 nor 404.
+
+**"Missing go.sum entry"** — a classic real error, and this time it was a stream
+error from `proxy.golang.org` mid-download. The next run passed with no change.
+
+**A dependency conflict that named the wrong module** — the resolver reported a
+version requirement conflict, and the actual cause was a workspace file pinned
+below what a bumped dependency required. The message pointed at the module; the
+fix was three directories up.
+
+Pattern: the error is generated at the point of *failure*, which is often far
+from the *cause*.
+
+## The tell that saves the most time
+
+**If one architecture passes and the other fails on the same commit, it is
+almost never your code.**
+
+The source is identical. The build config is identical. A genuine bug in either
+would fail both. What differs is which runner, which mirror, which moment in
+time — so a split result points at the network or the environment, not the
+diff.
+
+This one observation resolves more red builds than any other, and it takes five
+seconds to check. Look at the matrix before you look at the diff.
+
+## A two-minute triage
+
+Before debugging, answer these in order:
+
+**1. Did this exact commit pass before?**
+If the scheduled rebuild was green an hour ago and nothing merged since, the
+code is not the variable.
+
+**2. Do the failures cluster by architecture, or by upstream?**
+One arch failing is environmental. Several unrelated images failing the same
+step at the same time is an upstream outage — unrelated images do not develop
+the same bug simultaneously.
+
+**3. What is the actual status code?**
+Not the exit code. `403`, `429`, `502` and a timeout are all "they would not
+answer"; `404` is "it is not there". Any check that treats those as one thing
+will eventually report an outage as a missing file.
+
+**4. Does it reproduce on a re-run?**
+Cheap, and decisive. A flake fails once. A real bug fails every time. Re-run
+*before* you start reading code — but re-run **once**. Re-running until green is
+how a real intermittent bug gets shipped.
+
+## Building this into the pipeline
+
+Triage that lives only in someone's head does not survive. Two things worth
+encoding:
+
+**Retry with meaning.** Add retries to network fetches, but be careful what you
+retry with. `curl -sfI --retry 5` does not retry HTTP errors the way people
+expect — without `--retry-all-errors`, and with `-f` in play, a `403` is not
+necessarily a retryable condition to curl. Test that your retry actually
+retries; a flag that looks right and does nothing is worse than no flag, because
+it stops anyone from looking again.
+
+**Make the failure message name the class.** Compare:
+
+```
+ERROR: no release of log4j-web 2.25.4 found
+```
+
+with:
+
+```
+Maven Central unreachable for log4j-web (HTTP 403 after retries)
+  — transient, not a missing release
+```
+
+Same failure, and the second one ends the investigation in the first line. Every
+check that reaches the network should be able to distinguish "the answer is no"
+from "there was no answer", and should say which it got.
+
+## What this is not
+
+This is not an argument for ignoring red builds. It is an argument for spending
+the first two minutes deciding *which kind* of red you have, because the two
+kinds need completely different responses — and the wrong response to a
+transient failure is a code change that papers over it.
+
+The failure mode to avoid is the opposite one: treating everything as flaky and
+re-running until green. That is how a genuine intermittent bug reaches
+production with a green checkmark on it. The discipline is to classify honestly,
+not to classify optimistically.

--- a/site/src/content/blog/debugging-a-container-with-no-shell.md
+++ b/site/src/content/blog/debugging-a-container-with-no-shell.md
@@ -1,0 +1,133 @@
+---
+title: "Debugging a container that has no shell"
+description: "Distroless images remove the shell an attacker would use, and the one you would use. Here are the techniques that still work, in the order you should reach for them."
+published: "2026-09-06"
+---
+
+The first time `kubectl exec` fails on a distroless image, it looks like the
+image is broken:
+
+```
+$ docker exec -it mycontainer sh
+OCI runtime exec failed: exec: "sh": executable file not found in $PATH
+```
+
+Nothing is broken. There is no shell, on purpose. The same absence that stops an
+attacker from chaining a command injection into a foothold stops you from poking
+around, and the techniques below are how you work anyway.
+
+They are listed roughly in the order to try them: cheapest and least invasive
+first.
+
+## 1. Run a different binary in the same image
+
+`--entrypoint` replaces the command without changing the image. Most of what you
+want to know early — is the binary there, what version is it, does it parse the
+config — needs no shell at all:
+
+```
+docker run --rm --entrypoint /usr/bin/haproxy ghcr.io/rtvkiz/minimal-haproxy:latest -vv
+docker run --rm -v "$PWD/haproxy.cfg:/etc/haproxy/haproxy.cfg:ro" \
+  --entrypoint /usr/bin/haproxy ghcr.io/rtvkiz/minimal-haproxy:latest \
+  -c -f /etc/haproxy/haproxy.cfg
+```
+
+Note the second one: a config check, offline, with no shell involved. A
+surprising number of "the container won't start" incidents end here.
+
+## 2. Inspect the filesystem from outside
+
+You do not need to be inside a container to read its filesystem.
+
+```
+# what is actually in the image, without running it
+docker create --name tmp ghcr.io/rtvkiz/minimal-nginx:latest
+docker export tmp | tar -tv | head -50
+docker cp tmp:/etc/nginx/nginx.conf ./nginx.conf
+docker rm tmp
+```
+
+`docker cp` works against a running container too, and works whether or not that
+container has a shell. If your question is "what file is at this path", this is
+the whole answer.
+
+## 3. Attach a debug container that has the tools
+
+This is the technique that replaces `exec` properly, and it is the one worth
+learning if you only learn one.
+
+Kubernetes:
+
+```
+kubectl debug -it mypod --image=busybox:latest --target=mycontainer
+```
+
+The `--target` flag is what makes it useful: the debug container shares the
+target's process namespace, so `ps` sees the real process, and `/proc/1/root`
+gives you the target's filesystem:
+
+```
+ls /proc/1/root/etc
+cat /proc/1/root/etc/nginx/nginx.conf
+```
+
+Docker has an equivalent:
+
+```
+docker run --rm -it --pid=container:mycontainer \
+  --network=container:mycontainer --cap-add SYS_PTRACE \
+  busybox:latest sh
+```
+
+Sharing `--network` matters more than people expect. Half of "the service is
+down" turns out to be DNS or a listener bound to `127.0.0.1`, and both are only
+visible from inside that network namespace:
+
+```
+wget -qO- http://127.0.0.1:8080/healthz
+nslookup my-service.default.svc.cluster.local
+```
+
+## 4. Use the dev variant
+
+Every image we publish has a `-dev` tag carrying the same primary binary plus a
+shell and the usual tools — `bash`, `curl`, `openssl`, `dig`, `jq`, `git`, `apk`:
+
+```
+docker run --rm -it --entrypoint /bin/bash ghcr.io/rtvkiz/minimal-nginx:latest-dev
+```
+
+Swap the tag, reproduce the problem, keep everything else identical. Because
+both variants are built from the same package, a bug that reproduces in `-dev`
+is a bug in your setup or in the software; a bug that *stops* reproducing is
+usually about the missing shell or the tools themselves.
+
+The rule that makes this safe: **`-dev` is for debugging, not for production.**
+It exists so that the production image never needs to grow a shell "just for
+now". A shell added during an incident is a shell that is still there a year
+later.
+
+## 5. Read the logs properly
+
+Obvious, and still skipped:
+
+```
+docker logs --timestamps --tail 200 mycontainer
+kubectl logs mypod -c mycontainer --previous   # the container that just crashed
+```
+
+`--previous` is the one people forget. A container in `CrashLoopBackOff` has
+already told you why it died; the current instance may not have got far enough
+to repeat it.
+
+## What actually changes
+
+The shift is from *interactive exploration* to *asking specific questions*. You
+lose "let me look around", which is genuinely convenient. You keep everything
+that is diagnostic, and you gain that the same absence works against an
+attacker, continuously, in every container you run.
+
+If you find yourself needing a shell in production repeatedly for the same
+reason, that is a signal about the image or the workload — a missing health
+endpoint, a config that cannot be validated ahead of time, logs that do not say
+enough. Fixing the underlying gap is better than keeping a shell around for it.

--- a/site/src/content/blog/permission-denied-non-root-containers.md
+++ b/site/src/content/blog/permission-denied-non-root-containers.md
@@ -1,0 +1,151 @@
+---
+title: "Permission denied: running containers as a non-root user"
+description: "Almost every non-root container failure is one of four things. What each looks like, why the fix is not chmod 777, and how to make a directory writable in the image itself."
+published: "2026-09-06"
+---
+
+`runAsNonRoot: true` is one of the highest-value settings in a Pod spec, and the
+first thing most people hit after enabling it is this:
+
+```
+Error: EACCES: permission denied, mkdir '/data'
+```
+
+Almost every instance is one of four causes. They have different fixes, and
+`chmod 777` is not any of them.
+
+## 1. The directory does not exist, and a non-root process cannot create it
+
+The most common one, and the most misread. The error says permission denied on
+`/data`, so people chmod `/data` — but `/data` does not exist. The process is
+being denied permission to create it *in `/`*, which is root-owned.
+
+You cannot fix this at runtime, because there is no point at which a non-root
+process can create a directory in `/`. It has to exist in the image, owned by
+the right uid.
+
+With apko, that is a `paths:` entry:
+
+```yaml
+paths:
+  - path: /data
+    type: directory
+    uid: 65532
+    gid: 65532
+    permissions: 0o755
+```
+
+The Dockerfile equivalent:
+
+```dockerfile
+RUN mkdir -p /data && chown 65532:65532 /data
+USER 65532
+```
+
+Build the directory into the image. Every image we publish that needs writable
+state ships it this way.
+
+A related trap if you build with a tool that generates an SBOM after the build:
+creating `/var/...` directories inside the build pipeline can fail, because the
+SBOM step may run as your host user after the sandbox exits and cannot write
+into a root-owned destination. Declaring the directory in the image config
+avoids that entirely.
+
+## 2. The application writes to `$HOME`, and there is no home directory
+
+This one is sneaky, because the error rarely mentions `$HOME`. A CLI tool wants
+to cache something, resolves `~`, gets `/` or an empty string, and fails
+somewhere that looks unrelated.
+
+Set `HOME` to somewhere writable:
+
+```yaml
+environment:
+  HOME: /tmp
+```
+
+Cosign caches its trust root under `$HOME/.sigstore`; plenty of tools do the
+same thing. If a binary works as root and fails as non-root with a confusing
+path error, check `HOME` before anything else.
+
+## 3. The mounted volume is owned by someone else
+
+The image is correct and the mount is not. On Kubernetes, `fsGroup` is the
+supported lever:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+```
+
+`fsGroup` makes the kubelet set group ownership on the volume so your uid can
+write. It does not apply to every volume type — `hostPath` in particular is
+whatever it already was on the node.
+
+Locally, the equivalent trap bites in test scripts:
+
+```bash
+work=$(mktemp -d)              # 0700, owned by you
+docker run -v "$work:/workspace" ...   # container is uid 65532 → denied
+```
+
+`mktemp -d` creates `0700` owned by the invoking user, so a container running as
+a different uid cannot write into it. In a throwaway test directory,
+`chmod 0777 "$work"` is the correct fix and nothing is weakened by it — the
+directory exists for thirty seconds and holds nothing.
+
+That is *not* a licence to `chmod 777` a real volume. The reason it is fine here
+is the lifetime and the contents, not the permission bits.
+
+## 4. You can read the file, but not the one the container wrote
+
+The mirror image of the last problem, and it shows up in test scripts:
+
+```bash
+grep 'something' "$work/output"    # Permission denied
+```
+
+Files the container creates are owned by *its* uid, often `0600`. Your user
+cannot read them even though you own the directory. Assert on existence rather
+than content when you only need to know something was produced:
+
+```bash
+[ -s "$work/output" ] || { echo "no output produced"; exit 1; }
+```
+
+`stat` only needs the directory permission, which you have. Reading needs the
+file permission, which you may not.
+
+## Why 65532
+
+It is the conventional "nonroot" uid in the distroless ecosystem, and the value
+Kubernetes examples use. Nothing magic — the important properties are that it is
+not 0 and that it is fixed, so a volume chowned for one image works for the next.
+
+`runAsNonRoot: true` on its own only asserts that the image does not run as
+root. It does not pick a uid. Pin `runAsUser` too, or an image that changes its
+default uid silently changes who owns your data.
+
+## The one honest exception
+
+Some workloads genuinely require root, and pretending otherwise produces an
+image that does not run. A build daemon that creates mount and user namespaces
+is the clearest case: it will refuse to start under an unprivileged uid, so
+"non-root" there is not a stricter setting, it is a broken one.
+
+The right response is to say so explicitly in the image's documentation rather
+than ship something that fails at deploy time — and to keep the rest of the
+hardening. Non-root is one control among several, not the whole of it.
+
+## Checklist
+
+When a container fails as non-root, in order:
+
+1. Does the directory exist in the image, owned by the run-as uid?
+2. Is `HOME` set to somewhere writable?
+3. Is the volume owned correctly — `fsGroup` on Kubernetes, real permissions locally?
+4. Are you trying to read a file the container wrote as a different uid?
+
+Four questions. One of them is nearly always it.

--- a/site/src/content/blog/why-your-scanner-reports-zero-cves.md
+++ b/site/src/content/blog/why-your-scanner-reports-zero-cves.md
@@ -1,0 +1,133 @@
+---
+title: "Why your scanner reports zero CVEs"
+description: "A clean Grype report can mean your image is clean, or it can mean the scanner never identified the software inside it. Here is the difference, and how to tell which one you have."
+published: "2026-09-06"
+---
+
+A vulnerability report with nothing in it has two possible meanings, and they
+look identical:
+
+1. The scanner identified the software in your image and found no known
+   vulnerabilities.
+2. The scanner did not identify the software at all, so it had nothing to match
+   against.
+
+The second one is worse than a report full of findings, because it is
+indistinguishable from success. Nobody escalates a green scan.
+
+We hit this in a way that was easy to measure. Two builds of HAProxy, the same
+upstream version, the same source, the same everything — except the name of the
+apk package inside. One reported **0 findings**. The other reported **14**. The
+binaries were byte-identical in every way that matters to an attacker.
+
+## What the scanner is actually doing
+
+Grype does not look at your image and recognise HAProxy. It reads a package
+inventory produced by Syft, and then matches each entry in that inventory
+against vulnerability data. Two of those matching paths matter here:
+
+| Path | Keyed on |
+|---|---|
+| Distro security database (e.g. `wolfi:distro:wolfi:rolling`) | the apk package **name** |
+| `nvd:cpe` | a CPE that Syft **derives from** the apk package name |
+
+Both are keyed on a string. Not a hash, not a symbol table, not the contents of
+the binary — the name recorded in the package database.
+
+So if the package inside your image is called `haproxy`, the distro database has
+an entry under `haproxy`, NVD has `cpe:2.3:a:haproxy:haproxy:*`, and both paths
+hit. If you named it something reasonable-sounding but nonstandard —
+`haproxy-minimal`, `haproxy-slim`, `our-haproxy` — then:
+
+- the distro database has no entry under that name, so that path finds nothing;
+- Syft derives `cpe:2.3:a:haproxy-minimal:haproxy-minimal:*`, which matches
+  nothing in NVD, because NVD does not index a product by that name.
+
+Two paths, both broken by the same string, and no error anywhere. The scan
+succeeds. It just has nothing to say.
+
+## Why a CPE declaration does not save you
+
+The obvious fix is to declare the correct CPE in your build config. For scanning
+the *image*, it does not help.
+
+Syft's `apk-db-cataloger` reads `/usr/lib/apk/db/installed`. That file records
+the package name, version and dependencies. It has no CPE field. A CPE you
+declared at build time lives in your build metadata, and an SBOM embedded at,
+say, `/var/lib/db/sbom/` is not what `grype <image>` reads either.
+
+So the package name is not a label on the identity. For a C or C++ image it *is*
+the identity, and renaming the package is the only fix.
+
+## Go images are accidentally protected
+
+If your image is a Go binary, you may have never seen this, and that is luck
+rather than design. Syft's `go-module` cataloguer reads the build information
+that the Go toolchain embeds in every binary — module path and dependency
+versions. That gives the image a second, independent identity that has nothing
+to do with the apk name.
+
+The practical consequence is uneven: a Go image with a mangled package name
+still gets its dependencies scanned. A C image with the same mistake is
+completely invisible. If you are auditing a mixed fleet, the C and C++ images are
+where to look first.
+
+## How to check your own images
+
+The useful question is not "does my scan pass" but "did the scanner find the
+thing I care about". Ask it directly.
+
+List what the scanner thinks is installed:
+
+```
+syft ghcr.io/rtvkiz/minimal-haproxy:latest -o json \
+  | jq -r '.artifacts[] | "\(.type)\t\(.name)\t\(.version)"' | sort
+```
+
+Look at the CPEs it derived, which is where a bad name shows up:
+
+```
+syft <your-image> -o json | jq -r '.artifacts[].cpes[]?' | sort -u
+```
+
+If you see a product field that no vendor would ever publish — your internal
+suffix, your company name, a `-slim` or `-minimal` — that entry is matching
+nothing.
+
+Then confirm the negative is real. Scan a version you *know* has published
+advisories:
+
+```
+grype <your-image>:<an-old-tag>
+```
+
+An old build of anything widely deployed should produce findings. If an image
+from a year ago is also clean, the problem is identification, not hygiene. This
+takes a minute and is the single most useful check you can run against a
+scanning pipeline you have not verified before.
+
+## What we do about it
+
+Every package we build carries the name upstream uses — `haproxy`, `nginx`,
+`redis`, `postgresql` — never a decorated variant. The image is called
+`minimal-haproxy`; the *package* inside it is `haproxy`. Those are different
+namespaces and only one of them is load-bearing for scanners.
+
+That rule is enforced by a check that runs on every pull request, not by
+convention, because it is exactly the kind of thing that is invisible until
+someone re-reads it. A suffix, or a mismatch between the package we build and
+the package the image config asks for, fails the build.
+
+The honest caveat: matching by name means you inherit whatever the advisory
+feeds say about that name, including their mistakes and their timing. Naming
+things correctly gets you into the conversation. It does not end it.
+
+## The general point
+
+Scanner output is a claim about what was *identified*, not about what is
+*present*. Before you trust a clean report — ours or anyone's — confirm the
+scanner listed the software you expected, with a version you recognise, under a
+name the advisory databases actually use.
+
+A clean scan of an unidentified image is not a security result. It is an empty
+question.


### PR DESCRIPTION
The blog had one post. That is not enough surface to rank for anything, and a single page also makes the RSS feed and the `/blog` index look abandoned.

These four target queries people actually run when a hardened image misbehaves. Each is written from something this repo already knows — a measurement, a real failure, an enforced rule — rather than from general advice, because generic container-security content is the most commoditised writing on the internet and there is no reason anyone would read ours.

## The posts

**[Why your scanner reports zero CVEs](https://minimalcontainers.com/blog/why-your-scanner-reports-zero-cves)** — the strongest of the four, because it rests on a measurement rather than an argument. A clean Grype report can mean the scanner never identified the software. Covers the two name-keyed matching paths (distro secdb and `nvd:cpe`), why a CPE declared at build time never reaches `grype <image>` (`apk-db-cataloger` reads `/usr/lib/apk/db/installed`, which has no CPE field), and why Go images are accidentally protected by the `go-module` cataloguer while C images are fully blind. Anchored on our own controlled test: `haproxy-minimal` 0 findings vs `haproxy` 14 at an identical version. Ends with the commands to tell a real clean scan from an empty question.

**[Debugging a container that has no shell](https://minimalcontainers.com/blog/debugging-a-container-with-no-shell)** — highest search intent of the set. The techniques in the order to reach for them: `--entrypoint`, `docker export`/`cp`, `kubectl debug --target` with `/proc/1/root`, the `-dev` variant, and `kubectl logs --previous`. Makes the point that `-dev` exists precisely so the production image never grows a shell "just for now".

**[Permission denied: running containers as a non-root user](https://minimalcontainers.com/blog/permission-denied-non-root-containers)** — the four causes and the fix for each: directory missing from the image, unset `HOME`, volume ownership/`fsGroup`, and reading a file the container wrote as a different uid. Says plainly why `chmod 777` is not the fix, and identifies the one case (a `mktemp -d` test directory) where it genuinely is fine and why. Includes the honest exception that some daemons require root.

**[A red build is usually not your bug](https://minimalcontainers.com/blog/a-red-build-is-usually-not-your-bug)** — classifying transient upstream failures before debugging. Built on three real cases from this repo: the Maven Central `403` that a `curl -sfI` reported as a missing release, a goproxy stream error that read as a missing `go.sum` entry, and a resolver conflict whose actual cause was a workspace file three directories up. Leads with the tell that saves the most time: **one architecture passing while the other fails on the same commit is almost never the code.**

## Claims discipline

All four avoid the claims retracted in `4a469d65`: no reproducibility claim, no SLSA L3 assertion, no unscoped "no rate limits". None of them makes a competitor claim, so nothing here needs a review date — the one SLSA mention in the tree is the pre-existing migration post correctly stating we are **not** L3.

## Verified

- descriptions within the collection schema's 80-200 chars (checked: 165-186)
- `npm run build` clean, 140 pages
- all five posts present in `sitemap-0.xml`, the `/blog` index, and `rss.xml`
- `make check-site-claims` — 12 passed, 1 pre-existing warning (scan data 44d old, unrelated to this PR)

## Note

`check-site-claims` warns that the published comparison scan data is 44 days old against a 35-day limit. That predates this PR and is a warning rather than a failure by design, but it wants the 'CVE comparison refresh' workflow run at some point.