### PR TITLE
fix(site-claims): a rate-limited lookup is not a missing repository

### DIFF
--- a/scripts/check-site-claims.sh
+++ b/scripts/check-site-claims.sh
@@ -155,16 +155,46 @@ fi
 # --- 6. Competitor repositories we name must exist (network) ----------------
 if [ "$ONLINE" = 1 ]; then
   echo "Checking named competitor repositories…"
+  # This check answers one question: does a repository we NAME on the site
+  # actually exist? Only 404/410 answers it "no". Everything else — 429, 5xx, a
+  # timeout — means Docker Hub declined to answer, which is not the same claim
+  # and must not fail the build.
+  #
+  # It did, on 2026-09-07: the map holds ~50 pairs and we query them back to
+  # back, so Docker Hub rate-limited us and every remaining repo was reported as
+  # "the Bitnami page claims it exists", failing the scheduled refresh. Nothing
+  # was wrong with the site. This is the same confusion that made a Maven
+  # Central 403 read as "no release of log4j-web 2.25.4" (PR #654): an outage
+  # wearing the costume of a factual negative.
   miss=0
+  unver=0
+  _hub() {  # echo: 200 | 404 | unavailable:<code>
+    _n=0
+    while :; do
+      _c=$(curl -s -m 15 -o /dev/null -w '%{http_code}' \
+             "https://hub.docker.com/v2/repositories/bitnami/$1/" || echo 000)
+      case "$_c" in
+        200)     echo 200; return 0 ;;
+        404|410) echo 404; return 0 ;;
+      esac
+      _n=$((_n + 1))
+      [ "$_n" -ge 3 ] && { echo "unavailable:$_c"; return 0; }
+      sleep $((_n * 3))
+    done
+  }
   while read -r b; do
-    code=$(curl -s -m 15 -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/bitnami/$b/" || echo 000)
-    case "$code" in
+    case "$(_hub "$b")" in
       200) ;;
-      000) echo "    (skipped $b — network unreachable)" ;;
-      *)   note "bitnami/$b returns HTTP $code — the Bitnami page claims it exists"; miss=$((miss+1)) ;;
+      404) note "bitnami/$b returns HTTP 404 — the Bitnami page claims it exists"; miss=$((miss+1)) ;;
+      unavailable:000) echo "    (skipped $b — network unreachable)"; unver=$((unver+1)) ;;
+      unavailable:*) unver=$((unver+1)) ;;
     esac
+    sleep 0.3   # be a good citizen: ~50 lookups in a burst is what triggered the 429
   done < <(jq -r '.pairs[].bitnami' "$SITE"/data/bitnami-map.json)
-  [ "$miss" -eq 0 ] && ok "every bitnami/<name> named on the site resolves"
+  if [ "$unver" -gt 0 ]; then
+    soft "$unver bitnami repo(s) could not be verified (Docker Hub rate-limited or unreachable) — not a claim that they are missing"
+  fi
+  [ "$miss" -eq 0 ] && ok "every bitnami/<name> named on the site resolves (${unver} unverified)"
 else
   echo "  (competitor repository checks skipped — pass --online to run them)"
 fi


### PR DESCRIPTION
The scheduled **Refresh site data** run failed today, reporting that five Bitnami repositories the site names do not exist:

```
! bitnami/jaeger returns HTTP 429 — the Bitnami page claims it exists
! bitnami/telegraf returns HTTP 429 — the Bitnami page claims it exists
! bitnami/seaweedfs returns HTTP 429 — the Bitnami page claims it exists
! bitnami/zipkin returns HTTP 429 — the Bitnami page claims it exists
! bitnami/notation returns HTTP 429 — the Bitnami page claims it exists
```

Nothing was wrong with the site. The map holds ~50 pairs and we query them back to back, so Docker Hub rate-limited us partway through — and the `case` statement treated every non-200 as proof of absence.

## The distinction

This check answers exactly one question: **does a repository we NAME on the site actually exist?** Only `404`/`410` answers it "no". A `429`, a `5xx` or a timeout means Docker Hub declined to answer, which is a different statement and must not fail the build.

This is the same confusion that made a Maven Central `403` read as *"no release of log4j-web 2.25.4"* (#654) — an outage wearing the costume of a factual negative. That one was fixed per-image; the lesson had not reached this gate.

## Changes

- **Classify explicitly.** `200` ok · `404`/`410` hard failure · anything else "unverified", reported as a soft warning with a count.
- **Retry** up to 3 times with backoff before giving up on a repo.
- **Pace the lookups** — 0.3s apart, since the burst is what triggered the 429 in the first place.

## Verification

`--online` now completes clean against the real Docker Hub:

```
Checking named competitor repositories…
  ✓ every bitnami/<name> named on the site resolves (0 unverified)
✓ site claims: 13 passed, 1 warning(s)
```

**And the gate still works** — this is the part worth checking, since a fix like this can easily turn a real check into a no-op:

```
real repo (nginx):      200
bitnami/helm:           404
```

`bitnami/helm` is the exact 404 that motivated this check existing (a replacement page shipped claiming it exists), and it is still detected. shellcheck clean.

## Context: the other two failures today were not bugs

While diagnosing this I checked the other red runs, and neither needs action:

| run | verdict |
|---|---|
| **Build Hardened Images (main, scheduled)** | Transient. jaeger failed on x86_64 while aarch64 passed; traefik the exact reverse — same commit, opposite arches, which is the classic tell. Cause was `proxy.golang.org` stream errors plus a GitHub release-CDN `504` fetching cosign. Two later scheduled runs (13:19, 13:30) already went green on their own. |
| **Build Hardened Images (`update-toolchain-go-1.27`)** | Working as designed. trivy and descheduler fail on *both* arches with `undefined: json.SkipFunc` — Go 1.27 removed that from `encoding/json/v2`. Both images are already deliberately pinned to `go-1.26` on main with a comment explaining exactly this, and the bump bot retries each toolchain release until upstream adapts. The PR correctly did not merge. |